### PR TITLE
Compile the shipped image with the otlp feature

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,13 @@ COPY . .
 
 FROM build-base AS builder
 
-RUN cargo build --locked --release --features server-runtime,indexer-runtime \
+# `otlp` is off by default in Cargo.toml, and every OTLP path — the trace
+# bridge, the log appender, the observable-counter registration — compiles to an
+# inert stub without it. Omitting it here produced an image whose OTLP export
+# was absent rather than misconfigured: no error, no endpoint, nothing on the
+# wire. It must stay on this line for OTEL_EXPORTER_OTLP_ENDPOINT to mean
+# anything at runtime.
+RUN cargo build --locked --release --features server-runtime,indexer-runtime,otlp \
       --bin graph-node --bin graph-indexer && \
     strip target/release/graph-node target/release/graph-indexer
 


### PR DESCRIPTION
One line, but it is the difference between the OTLP work being exported and being dead code.

## What was wrong

`otlp` is off by default in `Cargo.toml:112` and nothing enables it implicitly. The Dockerfile built `--features server-runtime,indexer-runtime`, so in the image that actually runs:

- `install_trace_context_bridge` is the empty stub (`src/bin/graph-node.rs:74-75`)
- `MetricCollection::start` takes the inert arm (`otel_metrics.rs:1435-1443`)
- the observable instruments registered by `2a5a8d1` are never registered at all

The failure mode is the bad one: telemetry **absent** rather than misconfigured. No error, no endpoint, nothing on the wire, and nothing inside the pod that distinguishes it from a collector being down. That is the same shape as the M1 problem the observable-counter work exists to prevent — an instrument whose callback is never invoked is silent, and silence is indistinguishable from a genuine zero.

## Scope

Only the `builder` stage. The benchmark builder at `:27` builds an example rather than a shipped binary and has no telemetry to export, so it is left alone.

## Verification

`just check-all-features` (`cargo check --locked --all-targets --all-features`) passes. That is the only recipe that compiles `otlp` together with `indexer-runtime` — `test-node-otlp` covers `server-runtime,otlp` on `graph-node` alone, and the GitHub Actions workflow builds neither: `rg 'otlp|--all-features|turbolay-telemetry' .github/workflows/` returns nothing. Worth a follow-up so this combination cannot rot between local `just ci` runs.

## Deployment side

Inert on its own. The Kubernetes half is usecortex/hydradb-argocd#428, which sets `OTEL_EXPORTER_OTLP_ENDPOINT` (the OTel-standard name — the Rust config does not read the `OTLP_ENDPOINT` the Go services use, and an empty value disables export silently) to the gateway's **4318** HTTP port, since this crate is built `http-proto` only and silently downgrades a `grpc` setting. It also opens the NetworkPolicy egress the exporter needs.

Neither PR gives logs↔traces correlation: `TurbolayJson::format_event` (`crates/telemetry/src/layers.rs:319-415`) emits no `trace_id` or `span_id`, so the log pipeline has nothing to lift into `logRecord.traceId`. Separate change.