### PR TITLE
feat(telemetry): attribute exported logs to tenant and sub-tenant

### DIFF
--- a/crates/telemetry/src/bridge.rs
+++ b/crates/telemetry/src/bridge.rs
@@ -53,6 +53,71 @@ pub fn current_traceparent() -> Option<String> {
     Some(traceparent.to_string())
 }
 
+/// The active trace and span ids, lower-case hex, for the stdout log line.
+///
+/// `None` when no OTel context is active — no tracer installed, or an event
+/// emitted outside any span — so the two keys are simply absent from the line
+/// rather than present and zero.
+///
+/// # Why the stdout formatter needs this at all
+///
+/// It is the same stamping [`OpenTelemetryTracingBridge`] does for free on the
+/// OTLP log record, reproduced on the path that is *not* the OTLP log record.
+/// With [`TelemetryConfig::otlp_logs`] off — the Kubernetes configuration —
+/// stdout is the only route logs take out of the pod, and Vector's `prep_otlp`
+/// remap reads exactly these two keys to populate the OTLP `logRecord`'s
+/// `traceId`/`spanId`. Those dedicated fields, not log attributes, are what the
+/// backend's log-to-trace deep link resolves against; without them the jump
+/// from a log line to its trace stops working.
+///
+/// Sampling is deliberately not consulted. An unsampled span still has a valid
+/// trace id, and two log lines carrying the same one are correlatable with each
+/// other whether or not the trace itself was kept — which is the same trade
+/// [`current_traceparent`] makes one function up, and the same one the OTLP
+/// appender was already making.
+///
+/// # Why this reads the OTel context and not `Span::current()`
+///
+/// The obvious implementation is [`current_traceparent`]'s — take
+/// `tracing::Span::current()` and ask it for its context — and it returns
+/// `None` every single time from the only caller that matters.
+///
+/// `Span::current()` resolves through `tracing`'s *dispatcher*, and the
+/// dispatcher refuses to re-enter: while a subscriber is already handling a
+/// callback, `get_default` hands back the no-op dispatch instead of the real
+/// one, so that a subscriber which itself logs cannot recurse forever. The
+/// caller here is an event formatter, which runs inside exactly that callback.
+/// The span it wants is on the stack a few frames down, and the dispatcher will
+/// not name it — the result is `Span::none()`, an empty context and an invalid
+/// span context, with no error anywhere.
+///
+/// `opentelemetry::Context::current()` is a different thread-local entirely,
+/// owned by the OTel SDK and unaware of `tracing`'s re-entrancy rules.
+/// `tracing-opentelemetry` attaches to it on `on_enter` (its `context_activation`
+/// setting, on by default), which is also how `opentelemetry-appender-tracing`
+/// stamps its own log records — so this reads the same source the OTLP appender
+/// did, and agrees with it by construction rather than by coincidence.
+///
+/// The consequence worth knowing: this reports the *entered* span. An event
+/// aimed at a span that was never entered — `info!(parent: &span, …)` — has no
+/// active OTel context and gets no ids. That matches what the OTLP appender did
+/// before it was switched off, so it is not a change in behaviour.
+///
+/// [`OpenTelemetryTracingBridge`]: opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge
+/// [`TelemetryConfig::otlp_logs`]: crate::TelemetryConfig::otlp_logs
+pub fn current_trace_ids() -> Option<(String, String)> {
+    let context = Context::current();
+    let span = context.span();
+    let span_context = span.span_context();
+    if !span_context.is_valid() {
+        return None;
+    }
+    Some((
+        span_context.trace_id().to_string(),
+        span_context.span_id().to_string(),
+    ))
+}
+
 /// Make `span` a child of the remote trace named by `traceparent`.
 ///
 /// A malformed value is ignored. This is the boundary where a peer's bytes

--- a/crates/telemetry/src/config.rs
+++ b/crates/telemetry/src/config.rs
@@ -94,6 +94,16 @@ pub struct TelemetryConfig {
     pub otlp_headers: Vec<(String, String)>,
     /// OTLP wire encoding.
     pub otlp_protocol: OtlpProtocol,
+    /// Whether the OTLP *log* pipeline is installed.
+    ///
+    /// Separate from [`Self::otlp_endpoint`] because logs are the one signal
+    /// that has a second, independent route out of the pod. In Kubernetes the
+    /// stdout JSON lines are collected by the Vector DaemonSet, which parses
+    /// them and dual-writes to ClickHouse and the OTLP collectors — so with
+    /// this on, every line reaches the backend *twice*, once from here and once
+    /// from Vector. Traces and metrics have no such second path and are not
+    /// affected by this flag.
+    pub otlp_logs: bool,
     /// Head sampling ratio for traces with no forced-keep reason.
     pub sample_ratio: f64,
     /// Export batch timeout.
@@ -141,6 +151,7 @@ impl TelemetryConfig {
             otlp_endpoint: None,
             otlp_headers: Vec::new(),
             otlp_protocol: OtlpProtocol::default(),
+            otlp_logs: true,
             sample_ratio: Self::DEFAULT_SAMPLE_RATIO,
             export_timeout: Duration::from_secs(10),
             metric_export_interval: Self::DEFAULT_METRIC_EXPORT_INTERVAL,
@@ -195,6 +206,17 @@ impl TelemetryConfig {
             .and_then(OtlpProtocol::parse)
         {
             config.otlp_protocol = protocol;
+        }
+
+        // `OTEL_LOGS_EXPORTER` is the OTel-defined per-signal selector, and
+        // `none` is its defined value for "install no exporter for this
+        // signal". Only that exact value disables the pipeline: an unrecognised
+        // spelling (`console`, a typo) leaves logs exporting, because silently
+        // dropping a signal is a worse failure than exporting one the operator
+        // meant to route elsewhere. In Kubernetes this is set to `none` and
+        // Vector carries the stdout lines instead — see `otlp_logs`.
+        if let Some(value) = get("OTEL_LOGS_EXPORTER") {
+            config.otlp_logs = !value.trim().eq_ignore_ascii_case("none");
         }
 
         // An unparseable or out-of-range ratio falls back to the default rather
@@ -298,6 +320,50 @@ mod tests {
             env_from(&[("OTEL_EXPORTER_OTLP_ENDPOINT", "   ")]),
         );
         assert!(!config.otlp_enabled());
+    }
+
+    /// The Kubernetes setting. Logs go out on stdout for Vector to collect, so
+    /// the OTLP log pipeline is off — but the endpoint is still set, and traces
+    /// and metrics must keep using it.
+    #[test]
+    fn logs_exporter_none_disables_logs_alone() {
+        let config = TelemetryConfig::from_env_with(
+            ServiceIdentity::GraphNode,
+            env_from(&[
+                (
+                    "OTEL_EXPORTER_OTLP_ENDPOINT",
+                    "http://otel-gateway.observability.svc.cluster.local:4318",
+                ),
+                ("OTEL_LOGS_EXPORTER", "none"),
+            ]),
+        );
+        assert!(!config.otlp_logs);
+        assert!(config.otlp_enabled(), "traces and metrics still export");
+    }
+
+    /// Logs export by default: an operator who sets an endpoint and nothing
+    /// else gets all three signals, which is what a bare `docker run` against a
+    /// local collector should do.
+    #[test]
+    fn logs_export_unless_turned_off() {
+        let unset = TelemetryConfig::from_env_with(ServiceIdentity::GraphNode, env_from(&[]));
+        assert!(unset.otlp_logs);
+
+        // Only the exact OTel-defined `none` disables the signal. An
+        // unrecognised value leaves logs exporting rather than silently
+        // dropping them, because a typo that removes a signal is far harder to
+        // notice than one that leaves it on.
+        for value in ["otlp", "console", "NONE ", " none"] {
+            let config = TelemetryConfig::from_env_with(
+                ServiceIdentity::GraphNode,
+                env_from(&[("OTEL_LOGS_EXPORTER", value)]),
+            );
+            assert_eq!(
+                config.otlp_logs,
+                !value.trim().eq_ignore_ascii_case("none"),
+                "OTEL_LOGS_EXPORTER={value:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/telemetry/src/layers.rs
+++ b/crates/telemetry/src/layers.rs
@@ -275,6 +275,32 @@ impl tracing::field::Visit for JsonFieldVisitor {
     }
 }
 
+/// Span fields lifted to the top level of the line, and the key each takes
+/// there.
+///
+/// The log collector maps a line's **root** keys onto warehouse columns by
+/// name, and `cortex.cortex_logs_v2` has a `tenant_id` and a `sub_tenant_id`
+/// column waiting for exactly these. Nothing in that pipeline lifts a nested
+/// key: a value under `fields`, or inside the `spans` array below, is bucketed
+/// whole into an opaque attributes blob and the column stays null. So the two
+/// identities are hoisted out of the enclosing request span onto every line
+/// emitted while it is open.
+///
+/// Which is the point, and not merely a plumbing convenience. Tenancy is a
+/// property of the *request*, not of the one line that happened to mention it,
+/// so it is recorded once where the request is understood — see
+/// `client_root_span` in the kernel — and every planner warning, admission
+/// refusal and error logged underneath inherits it without knowing it exists.
+///
+/// The base64 spellings (`turbolay.tenant.scope_id`) are deliberately not
+/// promoted. They have no column, they are what `turbolay.scope` already spells
+/// out on the span, and a root key with no column is copied into the attributes
+/// map on every single line.
+const PROMOTED_SPAN_FIELDS: &[(&str, &str)] = &[
+    ("turbolay.tenant_id", "tenant_id"),
+    ("turbolay.sub_tenant_id", "sub_tenant_id"),
+];
+
 /// The JSON event format.
 ///
 /// Every line carries `binary` and `service`, which is what makes a shared log
@@ -364,12 +390,35 @@ where
             serde_json::Value::String(meta.target().to_string()),
         );
 
+        // Trace correlation, top-level rather than under `fields`, because the
+        // log collector reads these two keys by name to fill the OTLP
+        // `logRecord`'s dedicated `traceId`/`spanId` — the fields a backend's
+        // log-to-trace deep link resolves against. Absent, not zero, when no
+        // trace is active: a zero id is a *valid-looking* id that resolves to
+        // nothing, which is worse to debug than a missing key.
+        #[cfg(feature = "otlp")]
+        if let Some((trace_id, span_id)) = crate::bridge::current_trace_ids() {
+            line.insert("trace_id".to_string(), serde_json::Value::String(trace_id));
+            line.insert("span_id".to_string(), serde_json::Value::String(span_id));
+        }
+
         // Event fields, redacted. This is the path the built-in JSON formatter
         // bypasses.
         let mut visitor = JsonFieldVisitor::default();
         let mut redacting = RedactingVisitor::new(&mut visitor);
         event.record(&mut redacting);
         let mut fields = visitor.into_map();
+
+        // An event that names one of the promoted fields itself outranks the
+        // span stack: it is the more specific statement, and the only reason to
+        // write it on an event is to correct what the span says.
+        let mut event_promoted = serde_json::Map::new();
+        for (field, column) in PROMOTED_SPAN_FIELDS {
+            if let Some(value) = fields.get(*field) {
+                event_promoted.insert((*column).to_string(), value.clone());
+            }
+        }
+        let mut promoted = serde_json::Map::new();
 
         // `message` is just another field to `tracing`; promoting it to the top
         // level is what makes the line readable in a log viewer.
@@ -397,6 +446,15 @@ where
                             serde_json::from_str::<serde_json::Value>(formatted.fields.as_str())
                         {
                             for (key, value) in parsed {
+                                // Walking root-first means the innermost span
+                                // writes last and wins, which is what a nested
+                                // scope should do.
+                                if let Some((_, column)) = PROMOTED_SPAN_FIELDS
+                                    .iter()
+                                    .find(|(field, _)| *field == key.as_str())
+                                {
+                                    promoted.insert((*column).to_string(), value.clone());
+                                }
                                 entry.insert(key, value);
                             }
                         }
@@ -408,6 +466,8 @@ where
                 line.insert("spans".to_string(), serde_json::Value::Array(spans));
             }
         }
+        promoted.extend(event_promoted);
+        line.extend(promoted);
 
         let rendered =
             serde_json::to_string(&serde_json::Value::Object(line)).map_err(|_| fmt::Error)?;
@@ -480,6 +540,18 @@ mod tests {
         assert_eq!(lines[0]["fields"]["cell_id"], "cell-7");
     }
 
+    /// With no tracer installed there is no trace to name, and the two keys
+    /// must be *absent* rather than present and zero. A zero id looks valid to
+    /// the log collector, which would lift it into the OTLP `logRecord` and
+    /// produce a deep link to a trace that cannot exist. `tests/log_trace_ids.rs`
+    /// covers the other half — that a real tracer does populate them.
+    #[test]
+    fn no_active_trace_emits_no_trace_ids() {
+        let lines = capture_json(ServiceIdentity::GraphNode, || tracing::info!("up"));
+        assert!(lines[0].get("trace_id").is_none());
+        assert!(lines[0].get("span_id").is_none());
+    }
+
     /// The two binaries must be separable by field, not by message text.
     #[test]
     fn the_two_binaries_are_distinguishable() {
@@ -521,6 +593,59 @@ mod tests {
         assert_eq!(lines[0]["spans"][0]["token"], crate::redact::REDACTED);
         assert_eq!(lines[0]["spans"][0]["cell_id"], "c9");
         assert_eq!(lines[0]["spans"][0]["name"], "client.query");
+    }
+
+    /// The whole reason the promotion exists: a line logged deep inside a
+    /// request, by code that has never heard of a tenant, still names one at
+    /// the top level where the warehouse's column mapping can see it.
+    #[test]
+    fn tenancy_is_promoted_from_the_enclosing_span_to_the_line_root() {
+        let lines = capture_json(ServiceIdentity::GraphNode, || {
+            let request = tracing::info_span!(
+                "client.query",
+                turbolay.tenant_id = "l3c4v6lu2w",
+                turbolay.sub_tenant_id = "[Gmail]/All Mail",
+                turbolay.tenant.scope_id = "bDNjNHY2bHUydw",
+            );
+            let _request = request.enter();
+            let plan = tracing::info_span!("query.plan");
+            let _plan = plan.enter();
+            tracing::warn!(turbolay.query.full_scan = true, "unindexed access path");
+        });
+        assert_eq!(lines[0]["tenant_id"], "l3c4v6lu2w");
+        assert_eq!(lines[0]["sub_tenant_id"], "[Gmail]/All Mail");
+        // The base64 spelling stays on the span. It has no column, and a root
+        // key with no column is copied into the attributes map on every line.
+        assert!(lines[0].get("tenant.scope_id").is_none());
+        assert_eq!(
+            lines[0]["spans"][0]["turbolay.tenant.scope_id"],
+            "bDNjNHY2bHUydw"
+        );
+    }
+
+    /// Outside a request there is no tenant, and the keys must be absent rather
+    /// than blank: `tenant_id = ""` is a value the warehouse stores and nobody
+    /// can then tell from a tenant that genuinely reported nothing.
+    #[test]
+    fn a_line_outside_any_request_carries_no_tenancy() {
+        let lines = capture_json(ServiceIdentity::GraphNode, || {
+            tracing::info!("cell writer fence refreshed");
+        });
+        assert!(lines[0].get("tenant_id").is_none());
+        assert!(lines[0].get("sub_tenant_id").is_none());
+    }
+
+    /// A sub-tenant is optional — a tenant-level database resolves to a scope
+    /// with no third namespace segment — and its absence must not suppress the
+    /// tenant that *is* known.
+    #[test]
+    fn a_tenant_without_a_sub_tenant_still_promotes() {
+        let lines = capture_json(ServiceIdentity::GraphNode, || {
+            let span = tracing::info_span!("client.query", turbolay.tenant_id = "l3c4v6lu2w");
+            span.in_scope(|| tracing::info!("executing"));
+        });
+        assert_eq!(lines[0]["tenant_id"], "l3c4v6lu2w");
+        assert!(lines[0].get("sub_tenant_id").is_none());
     }
 
     #[test]

--- a/crates/telemetry/src/otlp.rs
+++ b/crates/telemetry/src/otlp.rs
@@ -12,6 +12,14 @@
 //!   `trace_id` and `span_id`, so clicking from a log line to its trace works
 //!   on day one.
 //!
+//!   This one is **conditional** on [`TelemetryConfig::otlp_logs`], and is off
+//!   in Kubernetes. Logs are the only signal with a second route out of the
+//!   pod: the Vector DaemonSet reads the stdout JSON lines and dual-writes them
+//!   to ClickHouse and the OTLP collectors, so leaving this on delivers every
+//!   line to the backend twice. The `trace_id`/`span_id` stamping that made the
+//!   deep link work is reproduced on the stdout side by [`crate::layers`], and
+//!   Vector lifts those two fields into the OTLP `logRecord`.
+//!
 //! The third is not:
 //!
 //! - **Metrics**, via an [`SdkMeterProvider`] with a `PeriodicReader`. Nothing
@@ -60,7 +68,9 @@ use crate::TelemetryError;
 /// a caller does — hence [`Providers::meter`].
 pub struct Providers {
     tracer: SdkTracerProvider,
-    logger: SdkLoggerProvider,
+    /// `None` when [`TelemetryConfig::otlp_logs`] is off — the Kubernetes
+    /// configuration, where Vector carries the stdout lines instead.
+    logger: Option<SdkLoggerProvider>,
     meter: SdkMeterProvider,
 }
 
@@ -83,8 +93,10 @@ impl Providers {
         if let Err(error) = self.tracer.shutdown() {
             eprintln!("turbolay-telemetry: tracer shutdown failed: {error}");
         }
-        if let Err(error) = self.logger.shutdown() {
-            eprintln!("turbolay-telemetry: logger shutdown failed: {error}");
+        if let Some(logger) = self.logger {
+            if let Err(error) = logger.shutdown() {
+                eprintln!("turbolay-telemetry: logger shutdown failed: {error}");
+            }
         }
         // The meter goes last for a reason: its shutdown runs one final
         // collection, and an observable callback that reads a snapshot the rest
@@ -143,18 +155,10 @@ where
         .build()
         .map_err(|error| TelemetryError::Exporter(error.to_string()))?;
 
-    let log_exporter = opentelemetry_otlp::LogExporter::builder()
-        .with_http()
-        .with_endpoint(format!("{}/v1/logs", endpoint.trim_end_matches('/')))
-        .with_headers(headers.clone())
-        .with_timeout(config.export_timeout)
-        .build()
-        .map_err(|error| TelemetryError::Exporter(error.to_string()))?;
-
     let metric_exporter = opentelemetry_otlp::MetricExporter::builder()
         .with_http()
         .with_endpoint(format!("{}/v1/metrics", endpoint.trim_end_matches('/')))
-        .with_headers(headers)
+        .with_headers(headers.clone())
         .with_timeout(config.export_timeout)
         .build()
         .map_err(|error| TelemetryError::Exporter(error.to_string()))?;
@@ -170,10 +174,28 @@ where
         ))
         .build();
 
-    let logger_provider = SdkLoggerProvider::builder()
-        .with_resource(resource.clone())
-        .with_batch_exporter(log_exporter)
-        .build();
+    // The one conditional pipeline. Building the exporter inside the branch
+    // matters as much as skipping the provider: `LogExporter::build` is what
+    // constructs the HTTP client and resolves the endpoint, so with logs off
+    // nothing here touches `/v1/logs` at all.
+    let logger_provider = if config.otlp_logs {
+        let log_exporter = opentelemetry_otlp::LogExporter::builder()
+            .with_http()
+            .with_endpoint(format!("{}/v1/logs", endpoint.trim_end_matches('/')))
+            .with_headers(headers)
+            .with_timeout(config.export_timeout)
+            .build()
+            .map_err(|error| TelemetryError::Exporter(error.to_string()))?;
+
+        Some(
+            SdkLoggerProvider::builder()
+                .with_resource(resource.clone())
+                .with_batch_exporter(log_exporter)
+                .build(),
+        )
+    } else {
+        None
+    };
 
     // `PeriodicReader` — not the `rt-tokio` variant — because it runs the
     // collection on its own OS thread, which is what every observable callback
@@ -193,9 +215,11 @@ where
 
     let tracer = tracer_provider.tracer("turbolay");
     let trace_layer = tracing_opentelemetry::layer().with_tracer(tracer);
-    let log_layer = OpenTelemetryTracingBridge::new(&logger_provider);
 
-    let layers: OtlpLayers<S> = vec![Box::new(trace_layer), Box::new(log_layer)];
+    let mut layers: OtlpLayers<S> = vec![Box::new(trace_layer)];
+    if let Some(provider) = logger_provider.as_ref() {
+        layers.push(Box::new(OpenTelemetryTracingBridge::new(provider)));
+    }
 
     Ok((
         layers,
@@ -396,6 +420,29 @@ mod tests {
         // The meter is reachable, which is the whole point of holding it: unlike
         // traces and logs, nothing reaches the metrics pipeline through the
         // subscriber.
+        let _meter = providers.meter("turbolay.test");
+        providers.shutdown();
+    }
+
+    /// The Kubernetes configuration: traces and metrics export, logs do not,
+    /// because Vector already carries the stdout lines. The assertion that
+    /// matters is the *layer count* — a logger provider that exists but is
+    /// never bridged into the subscriber would still pass a check on
+    /// `providers`, while silently costing nothing and doing nothing.
+    #[test]
+    fn logs_off_drops_the_appender_but_keeps_traces_and_metrics() {
+        let mut config = TelemetryConfig::new(ServiceIdentity::GraphNode);
+        config.otlp_endpoint = Some("http://127.0.0.1:1".to_string());
+        config.otlp_logs = false;
+        config.export_timeout = Duration::from_millis(50);
+        config.metric_export_interval = Duration::from_secs(3_600);
+
+        let (layers, providers) =
+            build::<tracing_subscriber::Registry>(&config).expect("exporters must build");
+        assert_eq!(layers.len(), 1, "the trace bridge alone");
+
+        let providers = providers.expect("an endpoint means providers");
+        assert!(providers.logger.is_none(), "no log pipeline was built");
         let _meter = providers.meter("turbolay.test");
         providers.shutdown();
     }

--- a/crates/telemetry/tests/log_trace_ids.rs
+++ b/crates/telemetry/tests/log_trace_ids.rs
@@ -1,0 +1,153 @@
+//! The stdout log line carries the ids that link it to its trace.
+//!
+//! This is the half of the OTLP-log-exporter removal that can silently regress.
+//! Dropping the `OpenTelemetryTracingBridge` also drops the `trace_id`/`span_id`
+//! stamping it did for free on the OTLP log record, and in Kubernetes stdout is
+//! then the *only* route logs take out of the pod. Vector's `prep_otlp` remap
+//! reads these two keys by name and decodes them into the OTLP `logRecord`'s
+//! dedicated `traceId`/`spanId` fields — which is what a backend's log-to-trace
+//! deep link resolves against. Log attributes do not work for that, so a line
+//! missing these keys breaks the jump from a log to its trace with no error
+//! anywhere.
+//!
+//! The unit test in `layers.rs` covers the no-tracer case (the keys are absent).
+//! Only this file can cover the case that matters, because populating them
+//! requires a real `tracing_opentelemetry` layer over a real tracer — exactly
+//! the machinery `capture_json` has no way to install.
+//!
+//! The sampler is pinned at ratio 0.0 on purpose: an unsampled span still has a
+//! valid trace id, and the ids must be emitted regardless of the sampling
+//! decision. Two log lines carrying the same trace id are correlatable with each
+//! other whether or not the trace itself was kept.
+
+#![cfg(feature = "otlp")]
+
+use std::sync::{Arc, Mutex};
+
+use opentelemetry::trace::TracerProvider as _;
+use opentelemetry_sdk::trace::SdkTracerProvider;
+use tracing_subscriber::layer::SubscriberExt;
+use turbolay_telemetry::layers::{RedactingFields, TurbolayJson};
+use turbolay_telemetry::sampling::TurbolaySampler;
+use turbolay_telemetry::{ServiceIdentity, TelemetryConfig};
+
+/// Collects the rendered stdout lines.
+#[derive(Clone, Default)]
+struct Capture(Arc<Mutex<Vec<u8>>>);
+
+impl std::io::Write for Capture {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0.lock().expect("capture mutex").extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for Capture {
+    type Writer = Self;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        self.clone()
+    }
+}
+
+/// Run `body` under a subscriber carrying both the JSON fmt layer and a real
+/// OTel trace layer — the production pairing — and return the captured lines.
+fn capture_with_tracer(body: impl FnOnce()) -> Vec<serde_json::Value> {
+    let capture = Capture::default();
+    let config = TelemetryConfig::new(ServiceIdentity::GraphNode);
+
+    let provider = SdkTracerProvider::builder()
+        .with_sampler(TurbolaySampler::new(0.0))
+        .build();
+    let otel_layer = tracing_opentelemetry::layer().with_tracer(provider.tracer("test"));
+
+    let fmt_layer = tracing_subscriber::fmt::layer()
+        .fmt_fields(RedactingFields::json())
+        .event_format(TurbolayJson::new(&config))
+        .with_writer(capture.clone());
+
+    let subscriber = tracing_subscriber::registry()
+        .with(otel_layer)
+        .with(fmt_layer);
+    tracing::subscriber::with_default(subscriber, body);
+
+    let bytes = capture.0.lock().expect("capture mutex").clone();
+    String::from_utf8(bytes)
+        .expect("the formatter writes UTF-8")
+        .lines()
+        .map(|line| serde_json::from_str(line).expect("each line must be valid JSON"))
+        .collect()
+}
+
+/// The shape contract with Vector: lower-case hex, 32 and 16 characters, and
+/// non-zero. `prep_otlp` guards on exactly `^[0-9a-f]{32}$` / `^[0-9a-f]{16}$`
+/// and skips anything else, so an id in any other spelling is silently dropped
+/// on the way to the backend rather than rejected loudly.
+#[test]
+fn an_event_inside_a_span_carries_hex_trace_and_span_ids() {
+    let lines = capture_with_tracer(|| {
+        let span = tracing::info_span!("read");
+        let _entered = span.enter();
+        tracing::info!("query served");
+    });
+
+    assert_eq!(lines.len(), 1, "one event, one line");
+
+    let trace_id = lines[0]["trace_id"].as_str().expect("trace_id is a string");
+    let span_id = lines[0]["span_id"].as_str().expect("span_id is a string");
+
+    assert_eq!(trace_id.len(), 32, "a W3C trace id is 16 bytes of hex");
+    assert_eq!(span_id.len(), 16, "a W3C span id is 8 bytes of hex");
+    assert!(
+        trace_id
+            .chars()
+            .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()),
+        "lower-case hex only: {trace_id}"
+    );
+    assert!(
+        span_id
+            .chars()
+            .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()),
+        "lower-case hex only: {span_id}"
+    );
+    assert_ne!(trace_id, "0".repeat(32), "a zero id resolves to no trace");
+    assert_ne!(span_id, "0".repeat(16), "a zero id resolves to no span");
+}
+
+/// Two events in the same span share a trace id, and events in different spans
+/// do not. This is the property the whole change exists to preserve: grouping
+/// log lines by request survives the exporter removal.
+#[test]
+fn ids_group_events_by_span_not_by_line() {
+    let lines = capture_with_tracer(|| {
+        {
+            let span = tracing::info_span!("read");
+            let _entered = span.enter();
+            tracing::info!("started");
+            tracing::info!("finished");
+        }
+        {
+            let span = tracing::info_span!("write");
+            let _entered = span.enter();
+            tracing::info!("started");
+        }
+    });
+
+    assert_eq!(lines.len(), 3);
+    assert_eq!(
+        lines[0]["trace_id"], lines[1]["trace_id"],
+        "one span, one trace"
+    );
+    assert_eq!(
+        lines[0]["span_id"], lines[1]["span_id"],
+        "one span, one span id"
+    );
+    assert_ne!(
+        lines[0]["trace_id"], lines[2]["trace_id"],
+        "a separate root span is a separate trace"
+    );
+}

--- a/src/client/bolt.rs
+++ b/src/client/bolt.rs
@@ -852,22 +852,39 @@ async fn run_bolt_protocol(
                 // with the right error; there is nothing useful to say about it
                 // twice.
                 let inbound_traceparent = bolt_traceparent(&extra).ok().flatten();
-                let (authenticated, database, request) =
-                    match prepare_bolt_run(&mut session, &context, query, parameters, extra) {
-                        Ok(prepared) => prepared,
-                        Err(error) => {
-                            send_bolt_failure(&mut writer, &error).await?;
-                            state = BoltState::Failed;
-                            continue;
-                        }
-                    };
+                // Opened before anything can reject the request, and from the
+                // `db` name alone, so that a RUN which never becomes a
+                // statement is still attributed to the tenant that sent it.
+                let run_span = bolt_run_span(&session, &context, &extra);
+                crate::core::trace_context::adopt_remote_parent(
+                    &run_span,
+                    inbound_traceparent.as_deref(),
+                );
+                let (authenticated, database, request) = match run_span
+                    .in_scope(|| prepare_bolt_run(&mut session, &context, query, parameters, extra))
+                {
+                    Ok(prepared) => prepared,
+                    Err(error) => {
+                        run_span.in_scope(|| {
+                            tracing::warn!(target: "slatedb_graph_kernel", error = %error, "Bolt RUN rejected");
+                        });
+                        send_bolt_failure(&mut writer, &error).await?;
+                        state = BoltState::Failed;
+                        continue;
+                    }
+                };
                 let prepared = match context
                     .service
                     .prepare_page_request(&authenticated, request, config.prefetch_rows)
+                    .instrument(run_span.clone())
                     .await
                 {
                     Ok(prepared) => prepared,
                     Err(error) => {
+                        run_span.record("error.class", error.class());
+                        run_span.in_scope(|| {
+                            tracing::warn!(target: "slatedb_graph_kernel", error = %error, "Bolt RUN preparation failed");
+                        });
                         send_bolt_failure(&mut writer, &graph_error_to_bolt(error)).await?;
                         state = BoltState::Failed;
                         continue;
@@ -1074,19 +1091,28 @@ async fn run_bolt_protocol(
                 ClientMessage::Route {
                     bookmarks, extra, ..
                 },
-            ) => match prepare_bolt_route(&session, &context, bookmarks, &extra).await {
-                Ok(routing_table) => {
-                    send_bolt_success(
-                        &mut writer,
-                        BoltDict::from([("rt".to_string(), BoltValue::Dict(routing_table))]),
-                    )
-                    .await?;
+            ) => {
+                let route_span = bolt_route_span(&session, &context, &extra);
+                match prepare_bolt_route(&session, &context, bookmarks, &extra)
+                    .instrument(route_span.clone())
+                    .await
+                {
+                    Ok(routing_table) => {
+                        send_bolt_success(
+                            &mut writer,
+                            BoltDict::from([("rt".to_string(), BoltValue::Dict(routing_table))]),
+                        )
+                        .await?;
+                    }
+                    Err(error) => {
+                        route_span.in_scope(|| {
+                            tracing::warn!(target: "slatedb_graph_kernel", error = %error, "Bolt ROUTE rejected");
+                        });
+                        send_bolt_failure(&mut writer, &error).await?;
+                        state = BoltState::Failed;
+                    }
                 }
-                Err(error) => {
-                    send_bolt_failure(&mut writer, &error).await?;
-                    state = BoltState::Failed;
-                }
-            },
+            }
             (BoltState::Ready, ClientMessage::Telemetry { .. }) => {
                 send_bolt_success(&mut writer, BoltDict::new()).await?;
             }
@@ -1177,6 +1203,90 @@ fn selected_bolt_database(
             .clone()
             .unwrap_or_else(|| context.default_database.clone())),
     }
+}
+
+/// The fields every Bolt ingress span carries before its request is understood.
+///
+/// A macro rather than a function because `tracing` builds each span's metadata
+/// into a `static`, so the name has to be a literal at the call site — the same
+/// constraint `client_root_span` works around with `root_span!`.
+macro_rules! bolt_ingress_span {
+    ($name:literal) => {
+        tracing::info_span!(
+            target: "slatedb_graph_kernel",
+            $name,
+            turbolay.scope = tracing::field::Empty,
+            turbolay.cell_id = tracing::field::Empty,
+            turbolay.tenant_id = tracing::field::Empty,
+            turbolay.tenant.scope_id = tracing::field::Empty,
+            turbolay.sub_tenant_id = tracing::field::Empty,
+            turbolay.sub_tenant.scope_id = tracing::field::Empty,
+            error.class = tracing::field::Empty,
+        )
+    };
+}
+
+/// Fill an ingress span from the database the message names.
+///
+/// The database is resolved here a second time — the preparation that follows
+/// resolves the same one — and every failure is swallowed. This span exists to
+/// attribute a rejection to a tenant; it must never *be* the rejection, and the
+/// real error arrives a line later with its own message. A malformed `db`
+/// simply leaves the fields absent, which is the honest answer: there is no
+/// tenant to name.
+fn record_bolt_ingress_scope(
+    span: &tracing::Span,
+    session: &BoltProtocolSession,
+    context: &BoltConnectionContext,
+    extra: &BoltDict,
+) {
+    let Ok(database) = selected_bolt_database(session, context, extra) else {
+        return;
+    };
+    let Ok(target) = context.database_resolver.resolve_database(Some(&database)) else {
+        return;
+    };
+    span.record("turbolay.scope", tracing::field::display(&target.scope));
+    span.record("turbolay.cell_id", target.cell_id.as_str());
+    crate::client::service::record_scope_tenancy(span, &target.scope);
+}
+
+/// The span a RUN is prepared under.
+///
+/// `client.query` cannot cover this: it needs a parsed request, and the two
+/// steps that produce one — [`prepare_bolt_run`] and
+/// `ClientQueryService::prepare_page_request` — are also the two that reject a
+/// query for an unknown database, a denied scope or a syntax error. Those
+/// rejections are exactly the lines an operator wants attributed to a customer,
+/// and before this span they carried no tenancy and, for every error class Bolt
+/// translates by hand, were not logged at all.
+///
+/// It is deliberately short: it closes as soon as the statement is prepared,
+/// and `client.query` takes over as the root of the statement's own trace.
+fn bolt_run_span(
+    session: &BoltProtocolSession,
+    context: &BoltConnectionContext,
+    extra: &BoltDict,
+) -> tracing::Span {
+    let span = bolt_ingress_span!("bolt.run");
+    record_bolt_ingress_scope(&span, session, context, extra);
+    span
+}
+
+/// The span a ROUTE is served under.
+///
+/// ROUTE never runs a query, so it opens no `client.query` and would otherwise
+/// have no tenancy anywhere. It is also the message a driver sends *first* and
+/// the one that fails when a tenant's grant is wrong, so a forbidden ROUTE with
+/// no tenant on it is a support ticket with nothing to grep for.
+fn bolt_route_span(
+    session: &BoltProtocolSession,
+    context: &BoltConnectionContext,
+    extra: &BoltDict,
+) -> tracing::Span {
+    let span = bolt_ingress_span!("bolt.route");
+    record_bolt_ingress_scope(&span, session, context, extra);
+    span
 }
 
 fn prepare_bolt_run(
@@ -1531,6 +1641,10 @@ where
             parent: &pending.statement_span,
             "query.page",
             turbolay.scope = %scope,
+            turbolay.tenant_id = tracing::field::Empty,
+            turbolay.tenant.scope_id = tracing::field::Empty,
+            turbolay.sub_tenant_id = tracing::field::Empty,
+            turbolay.sub_tenant.scope_id = tracing::field::Empty,
             turbolay.correlation_id = tracing::field::Empty,
             turbolay.caller.step = tracing::field::Empty,
             turbolay.read_epoch = tracing::field::Empty,
@@ -1540,6 +1654,11 @@ where
             fetch_size,
             remaining_runtime_ms = tracing::field::Empty,
         );
+        // Repeated from the statement span rather than inherited from it: a
+        // PULL that arrives long after its RUN is read on its own in a trace
+        // backend, and `turbolay.scope` two lines up is repeated for the same
+        // reason.
+        crate::client::service::record_scope_tenancy(&page_span, &scope);
         if let Some(correlation_id) = pending.prepared.request.correlation_id.as_deref() {
             page_span.record("turbolay.correlation_id", correlation_id);
         }

--- a/src/client/service.rs
+++ b/src/client/service.rs
@@ -165,6 +165,121 @@ fn unknown_graph_database(database: &str) -> GraphError {
     }
 }
 
+/// One tenancy segment of a [`GraphScope`], in both the form the scope stores
+/// and the form everything outside Turbolay uses.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct ScopeTenant {
+    /// The segment verbatim — URL-safe unpadded base64, as
+    /// [`encode_database_scope_id`] wrote it. This is the spelling that also
+    /// appears in the `scope` metric label and in the object-store prefix, so
+    /// it is what joins a log line to a metric series or to an S3 path.
+    pub scope_id: String,
+    /// The decoded identity: the tenant id the rest of the platform knows, or
+    /// the sub-tenant's own name. Falls back to [`Self::scope_id`] unchanged
+    /// when the segment is not base64 this crate produced — a hand-built scope
+    /// or a [`StaticClientDatabaseResolver`] target carries a literal name, and
+    /// the literal name *is* the identity there.
+    pub id: String,
+}
+
+/// The tenant and sub-tenant a [`GraphScope`] names.
+///
+/// [`HierarchicalClientDatabaseResolver`] writes exactly one layout — the
+/// process's root namespace, then the tenant, then an optional sub-tenant — so
+/// both identities are positional and can be read back from a bare scope
+/// without the resolver that produced it. That is what makes this usable from
+/// [`client_root_span`], which holds a [`ClientQueryRequest`] and nothing else,
+/// and from the Bolt page spans, which hold even less.
+///
+/// A root namespace deeper than one segment would shift both positions. None is
+/// configured: `GRAPH_NAMESPACE` is a single segment in `charts/turbolay`, in
+/// `scripts/deploy_single_node_k3s.sh` and in `scripts/runtime_smoke.sh`, and
+/// the HTTP `x-graph-namespace` header carries the same three-segment path Bolt
+/// encodes into its database name. A deeper root does not misreport a tenant as
+/// some *other* tenant — it reports a namespace segment that is not one — but
+/// it is the assumption to revisit first if these fields ever look wrong.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub(crate) struct ScopeTenancy {
+    pub tenant: Option<ScopeTenant>,
+    pub sub_tenant: Option<ScopeTenant>,
+}
+
+impl ScopeTenancy {
+    pub(crate) fn from_scope(scope: &GraphScope) -> Self {
+        let segments = scope.namespace.segments();
+        Self {
+            tenant: segments.get(1).map(ScopeTenant::from_segment),
+            sub_tenant: segments.get(2).map(ScopeTenant::from_segment),
+        }
+    }
+}
+
+impl ScopeTenant {
+    fn from_segment(segment: &NamespaceId) -> Self {
+        let scope_id = segment.as_str().to_string();
+        let id = decode_scope_id(&scope_id).unwrap_or_else(|| scope_id.clone());
+        Self { scope_id, id }
+    }
+}
+
+/// Decode a scope segment written by [`encode_database_scope_id`].
+///
+/// `None` — never a panic, never an error — for anything else.
+///
+/// The round-trip check is the canonicality test
+/// [`canonical_database_component`] applies on the resolution path, and it is
+/// necessary but *not* sufficient here. That function is deciding whether a
+/// segment came from the encoder, having already been told by the database
+/// prefix that it should have; this one is deciding the same question with no
+/// such promise, and short literals answer it wrongly. `acme` is canonical
+/// base64 for two well-formed UTF-8 code points, so a round-trip check alone
+/// reports the namespace `acme` as a tenant named `iʮ` — a nonsense value in
+/// the warehouse's `tenant_id` column, which is strictly worse than leaving the
+/// segment as it was found.
+///
+/// So the decoded value must additionally be printable ASCII: the same rule
+/// [`sanitize_caller_metadata`] applies to every other caller-supplied string
+/// that becomes a log field. It rejects `acme` and accepts every id and
+/// sub-tenant name the platform issues. The cost is a genuinely non-ASCII
+/// sub-tenant name — a mailbox label in Japanese — reported by its base64
+/// spelling instead; nothing is lost, since that spelling is what
+/// `turbolay.sub_tenant.scope_id` carries in every case anyway.
+fn decode_scope_id(encoded: &str) -> Option<String> {
+    let bytes = URL_SAFE_NO_PAD.decode(encoded).ok()?;
+    let value = String::from_utf8(bytes).ok()?;
+    if value.is_empty()
+        || !value.chars().all(|ch| ch.is_ascii_graphic() || ch == ' ')
+        || URL_SAFE_NO_PAD.encode(value.as_bytes()) != encoded
+    {
+        return None;
+    }
+    Some(value)
+}
+
+/// Record the tenancy of `scope` on `span`.
+///
+/// The four fields are declared `tracing::field::Empty` at each span's creation
+/// and filled here, because a scope with no tenancy must leave them *absent*
+/// rather than blank: `tenant_id = ""` is a value the log warehouse will
+/// happily store in a column nobody can then distinguish from a tenant that
+/// genuinely reported nothing.
+///
+/// Both spellings go on the span. The decoded id is the one that joins to every
+/// other system's `tenant_id`; the base64 one is the one that joins to the
+/// `scope` metric label and to the object-store prefix, and it is not derivable
+/// from the decoded value in the fallback case above.
+pub(crate) fn record_scope_tenancy(span: &tracing::Span, scope: &GraphScope) {
+    let tenancy = ScopeTenancy::from_scope(scope);
+    if let Some(tenant) = &tenancy.tenant {
+        span.record("turbolay.tenant_id", tenant.id.as_str());
+        span.record("turbolay.tenant.scope_id", tenant.scope_id.as_str());
+    }
+    if let Some(sub_tenant) = &tenancy.sub_tenant {
+        span.record("turbolay.sub_tenant_id", sub_tenant.id.as_str());
+        span.record("turbolay.sub_tenant.scope_id", sub_tenant.scope_id.as_str());
+    }
+}
+
 #[derive(Clone, Default)]
 pub struct StaticClientDatabaseResolver {
     targets: BTreeMap<String, ClientQueryTarget>,
@@ -2054,6 +2169,10 @@ pub(crate) fn client_root_span(
                 db.system.name = "neo4j",
                 turbolay.scope = %request.target.scope,
                 turbolay.cell_id = %request.target.cell_id,
+                turbolay.tenant_id = tracing::field::Empty,
+                turbolay.tenant.scope_id = tracing::field::Empty,
+                turbolay.sub_tenant_id = tracing::field::Empty,
+                turbolay.sub_tenant.scope_id = tracing::field::Empty,
                 turbolay.query.fingerprint = %fingerprint,
                 turbolay.consistency = ?request.consistency,
                 turbolay.correlation_id = tracing::field::Empty,
@@ -2071,6 +2190,12 @@ pub(crate) fn client_root_span(
     } else {
         root_span!("client.query")
     };
+    // The tenancy goes on the root and nowhere else, so that every line logged
+    // under this request — planner warnings, admission refusals, the error the
+    // query dies of — is attributable to a customer without any call site
+    // knowing there is a customer. `turbolay.scope` above already contains both
+    // segments, but only as one opaque path a warehouse cannot split.
+    record_scope_tenancy(&span, &request.target.scope);
     // Absent rather than empty: a blank correlation id is indistinguishable
     // from one that failed validation, and both would join to nothing.
     if let Some(correlation_id) = &request.correlation_id {

--- a/src/client/service/tests.rs
+++ b/src/client/service/tests.rs
@@ -84,6 +84,93 @@ fn hierarchical_database_resolver_rejects_malformed_or_unsafe_scopes() {
         .is_err());
 }
 
+/// The tenancy read back from a scope must be the tenancy that went in, for the
+/// exact scope shape the resolver writes — including the sub-tenant that
+/// decodes to something a human wrote, which is the case the log warehouse
+/// exists to make searchable.
+#[test]
+fn scope_tenancy_reads_back_what_the_resolver_encoded() {
+    let resolver = HierarchicalClientDatabaseResolver::new(
+        "hydradb",
+        ClientQueryTarget::new(
+            GraphScope::new(
+                NamespacePath::root(NamespaceId::new("staging").unwrap()),
+                GraphId::new("hydradb").unwrap(),
+            ),
+            "cell-0",
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    let database = resolver
+        .scoped_database_name("l3c4v6lu2w", Some("[Gmail]/All Mail"))
+        .unwrap();
+    let scope = resolver.resolve_database(Some(&database)).unwrap().scope;
+    assert_eq!(
+        scope.to_string(),
+        "staging/bDNjNHY2bHUydw/W0dtYWlsXS9BbGwgTWFpbA/graphs/hydradb"
+    );
+
+    let tenancy = ScopeTenancy::from_scope(&scope);
+    let tenant = tenancy.tenant.expect("the tenant segment is present");
+    assert_eq!(tenant.id, "l3c4v6lu2w");
+    assert_eq!(tenant.scope_id, "bDNjNHY2bHUydw");
+    let sub_tenant = tenancy
+        .sub_tenant
+        .expect("the sub-tenant segment is present");
+    assert_eq!(sub_tenant.id, "[Gmail]/All Mail");
+    assert_eq!(sub_tenant.scope_id, "W0dtYWlsXS9BbGwgTWFpbA");
+}
+
+/// A tenant-level database has no third segment, and the default scope has
+/// neither. Both must report absence rather than a blank identity, which is
+/// what keeps an empty `tenant_id` out of the warehouse column.
+#[test]
+fn scope_tenancy_reports_absence_rather_than_a_blank_identity() {
+    let resolver = HierarchicalClientDatabaseResolver::new(
+        "default",
+        ClientQueryTarget::new(GraphScope::default(), "cell-0").unwrap(),
+    )
+    .unwrap();
+    let database = resolver.scoped_database_name("l3c4v6lu2w", None).unwrap();
+    let scope = resolver.resolve_database(Some(&database)).unwrap().scope;
+    let tenancy = ScopeTenancy::from_scope(&scope);
+    assert_eq!(
+        tenancy.tenant.map(|tenant| tenant.id),
+        Some("l3c4v6lu2w".to_string())
+    );
+    assert!(tenancy.sub_tenant.is_none());
+
+    let root = ScopeTenancy::from_scope(&GraphScope::default());
+    assert_eq!(root, ScopeTenancy::default());
+}
+
+/// A scope built by hand — a static resolver's target, a test, the HTTP
+/// `x-graph-namespace` header used literally — carries plain names, not base64.
+/// Those are already the identity and must pass through unchanged.
+///
+/// `acme` is the case that makes this more than a formality: it is canonical
+/// URL-safe base64 for two well-formed UTF-8 code points, so a round-trip check
+/// alone would report the tenant as `iʮ`. See `decode_scope_id`.
+#[test]
+fn a_literal_namespace_segment_is_its_own_identity() {
+    for segment in ["acme", "search", "tenant-with-a-longer-name"] {
+        let scope = GraphScope::new(
+            NamespacePath::new([
+                NamespaceId::new("staging").unwrap(),
+                NamespaceId::new(segment).unwrap(),
+            ])
+            .unwrap(),
+            GraphId::new("social").unwrap(),
+        );
+        let tenant = ScopeTenancy::from_scope(&scope)
+            .tenant
+            .expect("the tenant segment is present");
+        assert_eq!(tenant.id, segment, "{segment} was decoded rather than kept");
+        assert_eq!(tenant.scope_id, segment);
+    }
+}
+
 struct SnapshotEpochClient;
 
 struct ConsistencyTestClient {


### PR DESCRIPTION
## Why

Incoming queries carry a scope of the form `<environment>/<b64 tenant>/<b64 sub_tenant>/graphs/<graph>`, but nothing on the query path emitted it. The `tenant_id` and `sub_tenant_id` columns in `cortex.cortex_logs_v2` were empty for **every** turbolay row — measured 0 populated out of 19,884 rows over 6 hours — so no log line could be attributed to a customer.

## What

Resolve tenancy at ingress and record it on the **per-query span**, so every line emitted while handling a query inherits it, not just the entry line.

- `client_root_span` covers Bolt RUN and HTTP alike.
- New `bolt.run` and `bolt.route` spans cover the preparation and routing steps that reject a query *before* `client.query` exists. Those rejection paths previously logged nothing at all; they now `warn` inside the span.
- `query.page` (PULL / DISCARD) gains the same fields.

### Field names

| Location | Fields |
| --- | --- |
| Span | `turbolay.tenant_id`, `turbolay.tenant.scope_id`, `turbolay.sub_tenant_id`, `turbolay.sub_tenant.scope_id` |
| Log root | `tenant_id`, `sub_tenant_id` (decoded only) |

Both spellings are kept. The **decoded** id is what the rest of the platform calls a tenant, so it is what makes a turbolay row joinable to a cortex-ingestion row in the same table — base64 in that column would populate it with something that joins to nothing. The **base64** `scope_id` stays on the span because it is the spelling that joins to the `scope` Prometheus label and the S3 prefix, and it is not derivable in the fallback case.

Decoding is total and cannot panic or drop a line: decode → UTF-8 → printable-ASCII → re-encode must equal the input, else fall back to the raw segment. The printable-ASCII rule is not cosmetic — `acme` is canonical URL-safe base64 for two well-formed code points, so a round-trip check alone reports the namespace `acme` as a tenant named `iʮ`.

### The load-bearing bit

`PROMOTED_SPAN_FIELDS` in `crates/telemetry/src/layers.rs` lifts the two ids from the span stack to **top-level** keys. The `vector-agent` `parse_and_remap` transform maps root keys to columns by identical name and has **no generic flatten**, so a value left nested under `fields` is JSON-encoded whole into `attributes` and the column stays null. This is the same mechanism by which `environment` already works.

**No pipeline change is required.** `tenant_id` and `sub_tenant_id` are already in the `known` allow-list and the `prep_otlp` promote list in `hydradb-argocd/infra/environments/common/vector-agent/values.yaml` (verified against the live ConfigMap). The columns exist at `cortex-infra-scripts/prod/clickhouse/sql/cortex-logs-v2-table.sql:20-22`. Everything was pre-wired and waiting on the emitter.

## Not covered, deliberately

HELLO, LOGON, LOGOFF, RESET, GOODBYE, TELEMETRY, BEGIN/COMMIT/ROLLBACK — none names a database, so there is no tenant to attribute.

Worth knowing: **a LOGON auth failure cannot carry a tenant.** Authentication is by bearer token/principal; the tenant is only stated later on the RUN or ROUTE `db` field. Attributing auth failures would need a token→tenant mapping that does not exist today.

## Cardinality

Nothing tenant-related was added to any Prometheus label. The pre-existing `scope` label on `graph_cache_*` (`src/bin/graph_node/admin.rs:732,808`) already renders the full scope including the base64 sub-tenant; §1.4 of the metrics plan grandfathered those families and forbade new ones joining, and that is honoured here.

## Reviewer attention, please

1. **Privacy.** `crates/telemetry/src/redact.rs` exists to keep tenant data out of a third-party backend and redacts bookmarks because they "encode positions and, transitively, tenancy". Decoded sub-tenant values are user-authored strings — mailbox and channel names like `[Gmail]/All Mail`. These now go to ClickHouse *and*, as span attributes, to SigNoz/ClickStack. The warehouse has columns for it, but it is a step past the line that file was drawing, and deserves an explicit decision rather than landing by default.
2. **`NamespacePath::tenant_id()` (`src/core/namespace.rs:151`) returns `segments[0]`** — the environment root (`staging`), not the tenant. Misleadingly named, unused on the query path, unchanged here, but it is a trap.
3. **Positional read.** Tenancy is read as `namespace[1]` / `namespace[2]`, the layout `HierarchicalClientDatabaseResolver` writes. A `GRAPH_NAMESPACE` deeper than one segment would shift both; none is configured anywhere in the repo. Documented at the type.

## Known gap

`Span::record` on an undeclared field is a silent no-op, so a typo between an `info_span!` declaration and `record_scope_tenancy` would fail invisibly. All four names were verified across all three span sites by inspection, but there is no test guarding it — that would need `tracing-subscriber` as a dev-dependency of the root crate, which the manifest deliberately avoids.

## Verification

- `just fmt-check`, `just check`, `just check-all-features`, `just check-bolt-server` — pass
- `just clippy-client-protocols` (`-D warnings`) — clean
- `just test-client-protocols` — 363 passed, 0 failed
- `just test-telemetry` — pass

6 new tests: encode/decode round-trip against a real production scope, absence vs blank, the literal-namespace fallback, and the promotion.

## Scope note

This branch also carries the in-progress log-export work in `crates/telemetry/` (`bridge.rs`, `config.rs`, `otlp.rs`, `tests/log_trace_ids.rs`). It is interleaved with the promotion change in `layers.rs` and the promotion depends on the JSON formatter changes, so it is not cleanly separable into its own PR.
