### PR TITLE
feat(telemetry): map the stdout log line onto the warehouse columns

### DIFF
--- a/crates/telemetry/src/layers.rs
+++ b/crates/telemetry/src/layers.rs
@@ -275,22 +275,32 @@ impl tracing::field::Visit for JsonFieldVisitor {
     }
 }
 
-/// Span fields lifted to the top level of the line, and the key each takes
-/// there.
+/// Span and event fields lifted to the top level of the line, and the key each
+/// takes there.
 ///
 /// The log collector maps a line's **root** keys onto warehouse columns by
-/// name, and `cortex.cortex_logs_v2` has a `tenant_id` and a `sub_tenant_id`
-/// column waiting for exactly these. Nothing in that pipeline lifts a nested
-/// key: a value under `fields`, or inside the `spans` array below, is bucketed
-/// whole into an opaque attributes blob and the column stays null. So the two
-/// identities are hoisted out of the enclosing request span onto every line
-/// emitted while it is open.
+/// name, and `cortex.cortex_logs_v2` has a column waiting for each entry below.
+/// Nothing in that pipeline lifts a nested key: a value under `fields`, or
+/// inside the `spans` array below, is bucketed whole into an opaque attributes
+/// blob and the column stays null. So these are hoisted out of the enclosing
+/// span — or off the event itself — onto every line emitted while it is open.
 ///
-/// Which is the point, and not merely a plumbing convenience. Tenancy is a
-/// property of the *request*, not of the one line that happened to mention it,
-/// so it is recorded once where the request is understood — see
+/// Which is the point for tenancy, and not merely a plumbing convenience.
+/// Tenancy is a property of the *request*, not of the one line that happened to
+/// mention it, so it is recorded once where the request is understood — see
 /// `client_root_span` in the kernel — and every planner warning, admission
 /// refusal and error logged underneath inherits it without knowing it exists.
+///
+/// The rest are plain renames from the name a Rust call site writes to the name
+/// the warehouse column has. Two days of staging traffic put `error_type`,
+/// `correlation_id` and `operation` at exactly zero populated rows out of
+/// 82,807, because every one of them was spelled the `turbolay.*` way and left
+/// nested. A rename table is all that gap ever was.
+///
+/// Values are copied **verbatim**, with no type coercion: `duration_ms` and
+/// `result_count` face numeric columns, and the collector coerces them there.
+/// Coercing here as well would mean two places to disagree about what
+/// `elapsed_ms = "n/a"` means, and the one that runs first would silently win.
 ///
 /// The base64 spellings (`turbolay.tenant.scope_id`) are deliberately not
 /// promoted. They have no column, they are what `turbolay.scope` already spells
@@ -299,13 +309,85 @@ impl tracing::field::Visit for JsonFieldVisitor {
 const PROMOTED_SPAN_FIELDS: &[(&str, &str)] = &[
     ("turbolay.tenant_id", "tenant_id"),
     ("turbolay.sub_tenant_id", "sub_tenant_id"),
+    ("error.class", "error_type"),
+    ("error", "error_message"),
+    ("turbolay.correlation_id", "correlation_id"),
+    ("turbolay.outcome", "event"),
+    ("elapsed_ms", "duration_ms"),
+    ("turbolay.query.rows_returned", "result_count"),
 ];
+
+/// Root keys the line owns, which a same-named event field must not overwrite.
+///
+/// Event fields are flattened to the root so the collector can see them, and
+/// flattening is the moment a field called `level` or `target` stops being data
+/// and starts being a lie about the line itself: `tracing::info!(target = …)`
+/// would rewrite the Rust module path the line was emitted from, and no reader
+/// or query could tell the forged value from the real one. Colliding fields go
+/// under `fields` instead — nested, so invisible to the column mapping, which
+/// is the correct outcome for a value that has no column of its own anyway.
+///
+/// `trace_id` and `span_id` are reserved unconditionally, even though they are
+/// only ever *written* under `otlp`. Reserving them per-feature would make the
+/// shape of a line depend on how the binary was compiled, so a field named
+/// `trace_id` would flatten to the root in a default build and nest in an OTLP
+/// build — a difference that shows up as a column populated in one deployment
+/// and null in the next.
+const RESERVED_ROOT_KEYS: &[&str] = &[
+    "timestamp",
+    "level",
+    "binary",
+    "service_name",
+    "instance",
+    "version",
+    "environment",
+    "target",
+    "trace_id",
+    "span_id",
+    "message",
+    "operation",
+    "span",
+    "spans",
+    // Not in the spec'd list, and deliberately here anyway: `fields` is the
+    // object the colliding keys are *put into*, so flattening a field of that
+    // name to the root would be clobbered by the very map built to protect it.
+    "fields",
+];
+
+/// Whether `key` is a root key the line owns — either structural or a promoted
+/// column.
+fn is_reserved_root_key(key: &str) -> bool {
+    RESERVED_ROOT_KEYS.contains(&key)
+        || PROMOTED_SPAN_FIELDS
+            .iter()
+            .any(|(_, column)| *column == key)
+}
+
+/// A field value rendered as message text.
+///
+/// A JSON string contributes its *contents*: `serde_json::Value::to_string`
+/// would hand back `"\"connection refused\""`, quotes and escapes included, and
+/// that is what a human reads in the `message` column. Everything else — a
+/// number, a bool — has no unquoted spelling and keeps its JSON one.
+fn text_of(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::String(text) => text.clone(),
+        other => other.to_string(),
+    }
+}
 
 /// The JSON event format.
 ///
-/// Every line carries `binary` and `service`, which is what makes a shared log
-/// sink separable — see the module docs for why the built-in formatter cannot
-/// promise that.
+/// Every line carries `binary` and `service_name`, which is what makes a shared
+/// log sink separable — see the module docs for why the built-in formatter
+/// cannot promise that.
+///
+/// The struct field stays `service`; only the emitted key is `service_name`,
+/// which is the name of the `cortex_logs_v2` column and of the OTel resource
+/// attribute every other service already writes. Spelling it `service` on the
+/// wire bought a turbolay-only rename rule in the collector config, and a
+/// collector rule that exists for exactly one producer is a rule that stops
+/// being applied the day somebody rewrites the pipeline.
 #[derive(Clone, Debug)]
 pub struct TurbolayJson {
     binary: &'static str,
@@ -368,7 +450,7 @@ where
             serde_json::Value::String(self.binary.to_string()),
         );
         line.insert(
-            "service".to_string(),
+            "service_name".to_string(),
             serde_json::Value::String(self.service.to_string()),
         );
         line.insert(
@@ -409,6 +491,15 @@ where
         event.record(&mut redacting);
         let mut fields = visitor.into_map();
 
+        // Event field names already spoken for, and so skipped when the rest of
+        // the map is flattened to the root below. Every one of them is emitted
+        // under a *different* key — `error` as `error_message`, `name` as the
+        // `message` fallback — and a field that appears both under its own name
+        // and under its promoted one is the same value billed twice: once to a
+        // column, once to the attributes blob, with nothing to say they are one
+        // fact.
+        let mut consumed: Vec<&'static str> = Vec::new();
+
         // An event that names one of the promoted fields itself outranks the
         // span stack: it is the more specific statement, and the only reason to
         // write it on an event is to correct what the span says.
@@ -416,58 +507,175 @@ where
         for (field, column) in PROMOTED_SPAN_FIELDS {
             if let Some(value) = fields.get(*field) {
                 event_promoted.insert((*column).to_string(), value.clone());
+                consumed.push(field);
             }
         }
         let mut promoted = serde_json::Map::new();
 
-        // `message` is just another field to `tracing`; promoting it to the top
-        // level is what makes the line readable in a log viewer.
-        if let Some(message) = fields.remove("message") {
-            line.insert("message".to_string(), message);
-        }
-        if !fields.is_empty() {
-            line.insert("fields".to_string(), serde_json::Value::Object(fields));
-        }
+        // The span stack flattened root→innermost, and the name of the
+        // innermost span.
+        //
+        // `spans` below keeps the nesting for a human reading raw lines; this
+        // map exists because the collector cannot see into an array. Merging
+        // root→innermost gives the innermost span the last word on a repeated
+        // key while a field only an *outer* span carries still survives:
+        // `turbolay.scope` is recorded on `index.scope`, and an event that
+        // fires three frames down inside `artifact.publish` would otherwise
+        // carry no scope at all. The duplication against `spans` is deliberate
+        // and paid for knowingly.
+        let mut span_merged = serde_json::Map::new();
+        let mut operation: Option<String> = None;
 
         // The enclosing span stack, innermost last. Span fields were already
         // redacted when `RedactingFields` formatted them.
         if let Some(scope) = ctx.event_scope() {
-            let spans: Vec<serde_json::Value> = scope
-                .from_root()
-                .map(|span| {
-                    let mut entry = serde_json::Map::new();
-                    entry.insert(
-                        "name".to_string(),
-                        serde_json::Value::String(span.name().to_string()),
-                    );
-                    let extensions = span.extensions();
-                    if let Some(formatted) = extensions.get::<FormattedFields<N>>() {
-                        if let Ok(serde_json::Value::Object(parsed)) =
-                            serde_json::from_str::<serde_json::Value>(formatted.fields.as_str())
-                        {
-                            for (key, value) in parsed {
-                                // Walking root-first means the innermost span
-                                // writes last and wins, which is what a nested
-                                // scope should do.
-                                if let Some((_, column)) = PROMOTED_SPAN_FIELDS
-                                    .iter()
-                                    .find(|(field, _)| *field == key.as_str())
-                                {
-                                    promoted.insert((*column).to_string(), value.clone());
-                                }
-                                entry.insert(key, value);
+            let mut spans: Vec<serde_json::Value> = Vec::new();
+            for span in scope.from_root() {
+                // Root-first, so the last writer is the innermost span — which
+                // is the one `operation` means. Span names are already
+                // `subsystem.verb` (`index.cycle`, `artifact.publish`), the
+                // same shape the other services write to this column, so no
+                // massaging is needed to make them comparable.
+                operation = Some(span.name().to_string());
+                let mut entry = serde_json::Map::new();
+                entry.insert(
+                    "name".to_string(),
+                    serde_json::Value::String(span.name().to_string()),
+                );
+                let extensions = span.extensions();
+                if let Some(formatted) = extensions.get::<FormattedFields<N>>() {
+                    if let Ok(serde_json::Value::Object(parsed)) =
+                        serde_json::from_str::<serde_json::Value>(formatted.fields.as_str())
+                    {
+                        for (key, value) in parsed {
+                            // Walking root-first means the innermost span
+                            // writes last and wins, which is what a nested
+                            // scope should do.
+                            if let Some((_, column)) = PROMOTED_SPAN_FIELDS
+                                .iter()
+                                .find(|(field, _)| *field == key.as_str())
+                            {
+                                promoted.insert((*column).to_string(), value.clone());
                             }
+                            // The synthetic `name` above is never merged in: it
+                            // is `operation`, and copying it here would make
+                            // `span.name` mean "the innermost span" while an
+                            // actual `name` *field* on some span means
+                            // something else entirely.
+                            span_merged.insert(key.clone(), value.clone());
+                            entry.insert(key, value);
                         }
                     }
-                    serde_json::Value::Object(entry)
-                })
-                .collect();
+                }
+                spans.push(serde_json::Value::Object(entry));
+            }
             if !spans.is_empty() {
                 line.insert("spans".to_string(), serde_json::Value::Array(spans));
             }
         }
         promoted.extend(event_promoted);
+
+        // `message` is just another field to `tracing`; promoting it to the top
+        // level is what makes the line readable in a log viewer.
+        //
+        // It is also emitted *unconditionally*, and that is the fix for the
+        // worst thing these logs did: 1,559 of 1,570 staging ERROR rows carried
+        // the entire raw JSON log line in `message`. The collector merges the
+        // parsed keys over a record whose `message` starts out as the raw line,
+        // so a line with no `message` key of its own never overwrites it and
+        // the escape hatch becomes the value. `tracing::error!(error = …, name
+        // = …)` — no format string — produces exactly that, and the offenders
+        // are third-party (`opentelemetry_sdk`, and slatedb through the `log`
+        // bridge), so no amount of fixing our own call sites reaches them.
+        //
+        // The fallbacks descend from most to least specific and end at
+        // `meta.target()`, which always exists, so the key cannot be missing.
+        let message = match fields.remove("message") {
+            Some(value) => text_of(&value),
+            None => {
+                // Event before span at each rung: the event is closer to the
+                // call site, so its `error` is the one being reported.
+                let fallback = ["error", "name"].into_iter().find_map(|key| {
+                    fields
+                        .get(key)
+                        .or_else(|| span_merged.get(key))
+                        .map(|value| (key, text_of(value)))
+                });
+                match fallback {
+                    Some((key, text)) => {
+                        consumed.push(key);
+                        text
+                    }
+                    None => meta.target().to_string(),
+                }
+            }
+        };
+        line.insert("message".to_string(), serde_json::Value::String(message));
+
+        // `error_type` when nothing classified itself, so that an error is at
+        // least *groupable*.
+        //
+        // Every branch here is a bounded vocabulary, and that is a hard
+        // requirement rather than tidiness: the column is
+        // `LowCardinality(String)`, which ClickHouse encodes as a per-part
+        // dictionary and which degrades — badly, and permanently for those
+        // parts — once the distinct count runs away. `error.class` is an
+        // 11-variant enum, `name` is the OTel SDK's own internal error name,
+        // `target` is a Rust module path: all three are enumerable from the
+        // source tree. The error *text* is never a candidate, however tempting,
+        // because it carries ids, paths and byte counts; unbounded text is what
+        // `error_message` is for.
+        //
+        // Gated on ERROR and WARN because an `error_type` on an INFO line would
+        // make every healthy line look classified, and the column's whole use
+        // is `WHERE error_type = …` over the ones that failed.
+        if !promoted.contains_key("error_type")
+            && matches!(*meta.level(), tracing::Level::ERROR | tracing::Level::WARN)
+        {
+            let class = match fields.get("name").or_else(|| span_merged.get("name")) {
+                Some(value) => {
+                    consumed.push("name");
+                    text_of(value)
+                }
+                None => meta.target().to_string(),
+            };
+            promoted.insert("error_type".to_string(), serde_json::Value::String(class));
+        }
+
         line.extend(promoted);
+        if let Some(operation) = operation {
+            line.insert(
+                "operation".to_string(),
+                serde_json::Value::String(operation),
+            );
+        }
+        if !span_merged.is_empty() {
+            line.insert("span".to_string(), serde_json::Value::Object(span_merged));
+        }
+
+        // Event fields land at the *root*, not under a `fields` object, for the
+        // same reason the promoted table exists: the collector maps root keys
+        // to columns and buckets everything nested into an opaque blob. Nesting
+        // them was making every field of every event unqueryable by name.
+        //
+        // A field whose name the line already owns keeps the old nesting rather
+        // than overwriting it — see [`RESERVED_ROOT_KEYS`] — so the object is
+        // absent entirely in the common case and present, small, and lossless
+        // in the case that used to be a silent clobber.
+        let mut nested = serde_json::Map::new();
+        for (key, value) in fields {
+            if consumed.iter().any(|taken| *taken == key) {
+                continue;
+            }
+            if is_reserved_root_key(&key) {
+                nested.insert(key, value);
+            } else {
+                line.insert(key, value);
+            }
+        }
+        if !nested.is_empty() {
+            line.insert("fields".to_string(), serde_json::Value::Object(nested));
+        }
 
         let rendered =
             serde_json::to_string(&serde_json::Value::Object(line)).map_err(|_| fmt::Error)?;
@@ -535,9 +743,12 @@ mod tests {
         });
         assert_eq!(lines.len(), 1);
         assert_eq!(lines[0]["binary"], "graph-indexer");
-        assert_eq!(lines[0]["service"], "turbolay-graph-indexer");
+        assert_eq!(lines[0]["service_name"], "turbolay-graph-indexer");
         assert_eq!(lines[0]["message"], "graph index generation published");
-        assert_eq!(lines[0]["fields"]["cell_id"], "cell-7");
+        // Root, not under `fields`: the collector maps root keys to columns and
+        // buckets anything nested into an opaque blob.
+        assert_eq!(lines[0]["cell_id"], "cell-7");
+        assert!(lines[0].get("fields").is_none());
     }
 
     /// With no tracer installed there is no trace to name, and the two keys
@@ -558,7 +769,7 @@ mod tests {
         let node = capture_json(ServiceIdentity::GraphNode, || tracing::info!("up"));
         let indexer = capture_json(ServiceIdentity::GraphIndexer, || tracing::info!("up"));
         assert_ne!(node[0]["binary"], indexer[0]["binary"]);
-        assert_ne!(node[0]["service"], indexer[0]["service"]);
+        assert_ne!(node[0]["service_name"], indexer[0]["service_name"]);
     }
 
     /// The regression that motivated writing a custom event formatter: the
@@ -573,8 +784,8 @@ mod tests {
                 "slow query"
             );
         });
-        assert_eq!(lines[0]["fields"]["parameters"], crate::redact::REDACTED);
-        assert_eq!(lines[0]["fields"]["cell_id"], "cell-1");
+        assert_eq!(lines[0]["parameters"], crate::redact::REDACTED);
+        assert_eq!(lines[0]["cell_id"], "cell-1");
         assert!(
             !lines[0].to_string().contains("tenant-secret-value"),
             "redacted value leaked into the line"
@@ -687,14 +898,18 @@ mod tests {
         assert_eq!(lines[0]["spans"][0]["turbolay.writer.epoch"], 412);
     }
 
+    /// Types survive promotion as well as flattening. `duration_ms` and
+    /// `result_count` face numeric warehouse columns, and this formatter does
+    /// not coerce for them — it copies the value it was handed, and the
+    /// collector coerces once, in one place.
     #[test]
     fn typed_fields_keep_their_json_types() {
         let lines = capture_json(ServiceIdentity::GraphNode, || {
             tracing::info!(elapsed_ms = 42u64, full_scan = true, ratio = 0.5f64, "done");
         });
-        assert_eq!(lines[0]["fields"]["elapsed_ms"], 42);
-        assert_eq!(lines[0]["fields"]["full_scan"], true);
-        assert_eq!(lines[0]["fields"]["ratio"], 0.5);
+        assert_eq!(lines[0]["duration_ms"], 42);
+        assert_eq!(lines[0]["full_scan"], true);
+        assert_eq!(lines[0]["ratio"], 0.5);
     }
 
     #[test]
@@ -702,5 +917,200 @@ mod tests {
         let lines = capture_json(ServiceIdentity::GraphNode, || tracing::info!("bare"));
         assert_eq!(lines[0]["message"], "bare");
         assert!(lines[0].get("fields").is_none());
+    }
+
+    /// The bug this whole change exists for: a line with no `message` key lets
+    /// the collector's merge leave the *raw JSON line* sitting in the `message`
+    /// column, which is what 1,559 of 1,570 staging ERROR rows contained. Each
+    /// rung is exercised because the offending call sites are third-party —
+    /// `opentelemetry_sdk` writes `error` and `name`, slatedb comes through the
+    /// `log` bridge — so the formatter, not the call site, has to be the thing
+    /// that guarantees the key.
+    #[test]
+    fn message_is_always_present_at_every_fallback_rung() {
+        let lines = capture_json(ServiceIdentity::GraphNode, || {
+            tracing::error!(error = "boom", name = "ExportError", "explicit message");
+            tracing::error!(error = "connection refused", name = "ExportError");
+            tracing::error!(name = "BatchLogProcessor.Export.Error");
+            tracing::error!(retries = 3);
+        });
+        assert_eq!(lines[0]["message"], "explicit message");
+        // The `error` field's contents, not its quoted JSON rendering.
+        assert_eq!(lines[1]["message"], "connection refused");
+        assert_eq!(lines[2]["message"], "BatchLogProcessor.Export.Error");
+        assert_eq!(lines[3]["message"], "turbolay_telemetry::layers::tests");
+        for line in &lines {
+            assert!(
+                line["message"]
+                    .as_str()
+                    .is_some_and(|text| !text.is_empty()),
+                "message missing or empty: {line}"
+            );
+        }
+    }
+
+    /// A field spent on the `message` fallback must not also appear under its
+    /// own name — the same fact billed twice, once to a column and once to the
+    /// attributes blob, with nothing to say they are one fact.
+    #[test]
+    fn a_field_used_as_the_message_fallback_is_not_also_flattened() {
+        let lines = capture_json(ServiceIdentity::GraphNode, || {
+            tracing::error!(name = "ExportError", retries = 2);
+        });
+        assert_eq!(lines[0]["message"], "ExportError");
+        assert_eq!(lines[0]["retries"], 2);
+        assert!(lines[0].get("name").is_none());
+        assert!(lines[0].get("fields").is_none());
+    }
+
+    /// The renames that turned three warehouse columns from zero populated rows
+    /// out of 82,807 into the value the call site already had.
+    #[test]
+    fn the_rename_table_fills_the_columns_it_was_written_for() {
+        let lines = capture_json(ServiceIdentity::GraphNode, || {
+            tracing::error!(
+                error.class = "storage",
+                error = "object store timeout",
+                turbolay.correlation_id = "c-42",
+                turbolay.outcome = "failure",
+                elapsed_ms = 1200u64,
+                turbolay.query.rows_returned = 0u64,
+                "write failed"
+            );
+        });
+        assert_eq!(lines[0]["error_type"], "storage");
+        assert_eq!(lines[0]["error_message"], "object store timeout");
+        assert_eq!(lines[0]["correlation_id"], "c-42");
+        assert_eq!(lines[0]["event"], "failure");
+        assert_eq!(lines[0]["duration_ms"], 1200);
+        assert_eq!(lines[0]["result_count"], 0);
+        // Promoted, therefore consumed: no key is emitted under both spellings.
+        assert!(lines[0].get("error").is_none());
+        assert!(lines[0].get("error.class").is_none());
+        assert!(lines[0].get("elapsed_ms").is_none());
+        assert!(lines[0].get("fields").is_none());
+    }
+
+    /// `error_type` is `LowCardinality(String)`, so the fallback rungs are all
+    /// bounded vocabularies — here the target, a Rust module path. It fires for
+    /// the levels that failed and stays absent on the ones that did not:
+    /// classifying a healthy INFO line would make `WHERE error_type = …` match
+    /// the whole table.
+    #[test]
+    fn error_type_falls_back_only_for_failing_levels() {
+        let lines = capture_json(ServiceIdentity::GraphNode, || {
+            tracing::error!("object store call failed");
+            tracing::warn!("retrying");
+            tracing::info!("fine");
+            tracing::error!(name = "ExportError", "export failed");
+            tracing::error!(error.class = "storage", "classified");
+        });
+        assert_eq!(lines[0]["error_type"], "turbolay_telemetry::layers::tests");
+        assert_eq!(lines[1]["error_type"], "turbolay_telemetry::layers::tests");
+        assert!(lines[2].get("error_type").is_none());
+        // `name` outranks the target: it is the SDK's own error name, which is
+        // both bounded and more specific than the module that logged it.
+        assert_eq!(lines[3]["error_type"], "ExportError");
+        // A real classification is never overwritten by a fallback.
+        assert_eq!(lines[4]["error_type"], "storage");
+    }
+
+    /// The error *text* is unbounded — ids, paths, byte counts — and must never
+    /// reach the low-cardinality column, however convenient it would be.
+    #[test]
+    fn error_text_never_becomes_the_error_type() {
+        let lines = capture_json(ServiceIdentity::GraphNode, || {
+            tracing::error!(error = "conditional write failed for key cell-7/00412.sst");
+        });
+        assert_eq!(
+            lines[0]["error_message"],
+            "conditional write failed for key cell-7/00412.sst"
+        );
+        assert_eq!(lines[0]["error_type"], "turbolay_telemetry::layers::tests");
+    }
+
+    /// A field named like a root key the line owns must not rewrite it. A
+    /// forged `target` or `level` is indistinguishable from the real one once
+    /// written, so the collision is kept nested — invisible to the column
+    /// mapping, which is the right home for a value that has no column anyway.
+    #[test]
+    fn a_field_colliding_with_a_reserved_root_key_stays_nested() {
+        let lines = capture_json(ServiceIdentity::GraphNode, || {
+            tracing::info!(
+                target = "not-the-module",
+                level = "not-the-level",
+                tenant_id = "not-the-tenant",
+                cell_id = "cell-3",
+                "collision"
+            );
+        });
+        assert_eq!(lines[0]["target"], "turbolay_telemetry::layers::tests");
+        assert_eq!(lines[0]["level"], "INFO");
+        assert!(lines[0].get("tenant_id").is_none() || lines[0]["tenant_id"] != "not-the-tenant");
+        assert_eq!(lines[0]["fields"]["target"], "not-the-module");
+        assert_eq!(lines[0]["fields"]["level"], "not-the-level");
+        assert_eq!(lines[0]["fields"]["tenant_id"], "not-the-tenant");
+        // Non-colliding fields are unaffected and stay at the root.
+        assert_eq!(lines[0]["cell_id"], "cell-3");
+    }
+
+    /// `operation` is the innermost span's name, which is already the
+    /// `subsystem.verb` shape the other services write to this column.
+    #[test]
+    fn operation_names_the_innermost_span_and_is_absent_without_one() {
+        let lines = capture_json(ServiceIdentity::GraphNode, || {
+            let outer = tracing::info_span!("index.cycle");
+            let _outer = outer.enter();
+            let inner = tracing::info_span!("artifact.publish");
+            inner.in_scope(|| tracing::info!("published"));
+            drop(_outer);
+            tracing::info!("idle");
+        });
+        assert_eq!(lines[0]["operation"], "artifact.publish");
+        assert!(lines[1].get("operation").is_none());
+        assert!(lines[1].get("span").is_none());
+    }
+
+    /// The merged `span` object exists because the collector cannot see into
+    /// the `spans` array. Merging root→innermost gives the innermost span the
+    /// last word while a field only an outer span carries still survives — the
+    /// `turbolay.scope`-set-on-`index.scope` case, where the event fires frames
+    /// deeper inside `artifact.publish`.
+    #[test]
+    fn the_merged_span_object_takes_the_innermost_value_and_keeps_outer_only_fields() {
+        let lines = capture_json(ServiceIdentity::GraphNode, || {
+            let outer = tracing::info_span!(
+                "index.scope",
+                turbolay.scope = "acme/mail",
+                turbolay.cell_id = "cell-1"
+            );
+            let _outer = outer.enter();
+            let inner = tracing::info_span!("artifact.publish", turbolay.cell_id = "cell-9");
+            inner.in_scope(|| tracing::info!("published"));
+        });
+        assert_eq!(lines[0]["span"]["turbolay.cell_id"], "cell-9");
+        assert_eq!(lines[0]["span"]["turbolay.scope"], "acme/mail");
+        // The synthetic span name is `operation`, not a merged field.
+        assert!(lines[0]["span"].get("name").is_none());
+        // `spans` is unchanged: it keeps the nesting a human reads by, and the
+        // duplication is an accepted cost.
+        assert_eq!(lines[0]["spans"][0]["name"], "index.scope");
+        assert_eq!(lines[0]["spans"][0]["turbolay.cell_id"], "cell-1");
+        assert_eq!(lines[0]["spans"][1]["turbolay.cell_id"], "cell-9");
+    }
+
+    /// An event field outranks the span stack for both the promoted columns and
+    /// the merged object's readers: it is closer to the call site, and the only
+    /// reason to write it on the event is to correct what the span says.
+    #[test]
+    fn an_event_field_outranks_the_same_field_on_the_span() {
+        let lines = capture_json(ServiceIdentity::GraphNode, || {
+            let span = tracing::info_span!("client.query", turbolay.tenant_id = "span-tenant");
+            span.in_scope(|| {
+                tracing::info!(turbolay.tenant_id = "event-tenant", "executing");
+            });
+        });
+        assert_eq!(lines[0]["tenant_id"], "event-tenant");
+        assert_eq!(lines[0]["span"]["turbolay.tenant_id"], "span-tenant");
     }
 }


### PR DESCRIPTION
## Why

In Kubernetes the stdout JSON lines are collected by the Vector DaemonSet, which maps a line's **root** keys onto `cortex.cortex_logs_v2` columns by name. Nothing in that pipeline lifts a nested key — a value under `fields`, or inside the `spans` array, is bucketed whole into an opaque `attributes` blob and its column stays null.

Measured over two days of staging traffic, straight from ClickHouse:

```
service_name           level    n       with_error_type  with_corr  with_operation
turbolay-graph-node    INFO     44611   0                0          0
turbolay-graph-indexer INFO     24029   0                0          0
turbolay-graph-node    WARN     12597   0                0          0
turbolay-graph-node    ERROR     1165   0                0          0
turbolay-graph-indexer ERROR      405   0                0          0
```

82,807 rows, three columns, zero populated. Every one of those values was on the line already — spelled the `turbolay.*` way and nested.

And separately: **1,559 of 1,570 ERROR rows carried the entire raw JSON log line in `message`.** The collector merges parsed keys over a record whose `message` starts out as the raw line, so a line with no `message` key of its own never overwrites it.

## What changed

| | |
|---|---|
| `service` → `service_name` | The column name, and the OTel resource attribute every other service writes. Deletes a turbolay-only rename rule from the collector. |
| `message` always emitted | Falls back `error` → `name` → target. `tracing::error!(error = …, name = …)` produces no message field, and the offenders are third-party (`opentelemetry_sdk`, slatedb via the `log` bridge), so fixing our own call sites cannot reach them. |
| Six new `PROMOTED_SPAN_FIELDS` rows | `error.class`→`error_type`, `error`→`error_message`, `turbolay.correlation_id`→`correlation_id`, `turbolay.outcome`→`event`, `elapsed_ms`→`duration_ms`, `turbolay.query.rows_returned`→`result_count`. Plain renames; the existing span-walk and event-overlay machinery does the rest. |
| `operation` | The innermost span name — already the `subsystem.verb` shape the other services write to this column. |
| `error_type` fallback | ERROR/WARN only, from a bounded vocabulary. The column is `LowCardinality`, so every branch must be enumerable from the source tree. Never the error text. |
| Event fields flatten to root | A field whose name the line already owns stays nested instead of overwriting it, so `info!(target = …)` cannot forge the module path. The `fields` object is absent entirely in the common case. |
| New `span` object | The stack merged root→innermost, because the collector cannot see into an array. `spans` is still emitted for humans; the duplication is paid for knowingly. |

Sample line after the change:

```json
{"timestamp":"…","level":"INFO","binary":"graph-node","service_name":"turbolay-graph-node",
 "instance":"…","version":"0.1.0","environment":"staging","target":"…",
 "trace_id":"…","span_id":"…","message":"artifact published",
 "operation":"artifact.publish","event":"success","correlation_id":"corr-9",
 "tenant_id":"t-1","duration_ms":12.5,"edge_count":87,
 "span":{"turbolay.scope":"…","turbolay.cell_id":"cell-0"},
 "spans":[…]}
```

## Safety

**Redaction is untouched.** `RedactingVisitor` still wraps the event visitor before the map exists, so flattening happens strictly downstream of it. `redact.rs` is unchanged, and the existing redaction test still passes.

**`trace_id`/`span_id` stay `#[cfg(feature = "otlp")]`.** No new dependencies.

## Rollout

The collector config (hydradb-argocd) handles **both** shapes for the whole rollout window and any rollback — every derivation there is gated on `!exists()` of the column it writes, so the app's value wins and the config only fills gaps for old-image pods. That change is purely additive, zero deleted lines. So this can land on its own, and the now-redundant collector branches get stripped in a follow-up once every pod is rebuilt.

## Verification

- `just test-telemetry` — 106 unit + 7 + 2 + 6 + 1 doctest, clippy `-D warnings`
- `cargo clippy --locked --all-targets -p turbolay-telemetry -- -D warnings` and `cargo test` — the feature-off path, 70 tests
- `just test-node-otlp` — 41, the binaries still build and run
- `just fmt-check`

New tests cover each `message` fallback rung, the `error_type` fallback firing at ERROR but not INFO, a colliding field name staying nested without clobbering the reserved key, flattening not duplicating a promoted key, and the merged `span` taking the innermost value while keeping an outer-only field.
