### PR TITLE
Document the incremental index build in the book chapters

### DIFF
--- a/books/chapters/01-architecture.typ
+++ b/books/chapters/01-architecture.typ
@@ -691,9 +691,10 @@ Four steps move a generation through its life cycle. All the durable logic lives
   which patches the *previous* generation rather than re-folding the whole adjacency: it decodes
   the previous CSC, asks `topology_tail_since` for the final-state `(src, dst, exists)` delta
   written since that generation, applies it, and re-encodes — declining back to the full scan
-  whenever it cannot proceed (no previous generation, the WAL tail no longer available, or the
-  tail oversized). Both paths publish identically, and publication is atomic: a reader sees
-  either the old generation or the new one, never a torn write.
+  whenever it cannot proceed (no previous generation, the previous generation's CSC payload
+  missing from the store, the WAL tail no longer available, or the tail oversized). Both paths
+  publish identically, and publication is atomic: a reader sees either the old generation or
+  the new one, never a torn write.
 - *Hydrate & overlay* — `matrix_cache.rs` is read-through: on a miss it hydrates the current
   generation's CSC into the shard's matrix caches (taking the `matrix_compilation_gate` for the
   compiled form). Because a read pins a sequence that may be *ahead* of the generation's

--- a/books/chapters/01-architecture.typ
+++ b/books/chapters/01-architecture.typ
@@ -686,8 +686,14 @@ Four steps move a generation through its life cycle. All the durable logic lives
 - *Build & publish* — `build_graph_index(cell_id, edge_type)` takes an artifact-build permit,
   snapshots at the current `base_sequence`, folds the canonical adjacency into a GraphBLAS CSC
   matrix, checksums it, names the generation by its SHA-256, and publishes the manifest with a
-  compare-and-set retry loop (`INDEX_PUBLISH_ATTEMPTS = 8`). Publication is atomic: a reader
-  sees either the old generation or the new one, never a torn write.
+  compare-and-set retry loop (`INDEX_PUBLISH_ATTEMPTS = 8`). Under
+  `GRAPH_INDEXER_BUILD_MODE=incremental` the indexer calls `build_graph_index_auto` instead,
+  which patches the *previous* generation rather than re-folding the whole adjacency: it decodes
+  the previous CSC, asks `topology_tail_since` for the final-state `(src, dst, exists)` delta
+  written since that generation, applies it, and re-encodes — declining back to the full scan
+  whenever it cannot proceed (no previous generation, the WAL tail no longer available, or the
+  tail oversized). Both paths publish identically, and publication is atomic: a reader sees
+  either the old generation or the new one, never a torn write.
 - *Hydrate & overlay* — `matrix_cache.rs` is read-through: on a miss it hydrates the current
   generation's CSC into the shard's matrix caches (taking the `matrix_compilation_gate` for the
   compiled form). Because a read pins a sequence that may be *ahead* of the generation's
@@ -749,8 +755,10 @@ read/write path builds generations anymore; the data node only *consumes* them.
 
 `graph-indexer` is a small loop. It reads its configuration from the environment — the data
 path, the cells to index, a poll interval (`GRAPH_INDEXER_INTERVAL_MS`, default 5000), how many
-previous generations to retain (`GRAPH_INDEXER_RETAIN_PREVIOUS`, default 1), and an admin
-address (`GRAPH_INDEXER_ADMIN_ADDR`, default `0.0.0.0:9091`) — and exposes an admin HTTP server
+previous generations to retain (`GRAPH_INDEXER_RETAIN_PREVIOUS`, default 1), a build mode
+(`GRAPH_INDEXER_BUILD_MODE`, `full` or `incremental`, default `full`), the incremental size
+floor (`GRAPH_INDEXER_INCREMENTAL_MIN_EDGES`, default 250000), and an admin address
+(`GRAPH_INDEXER_ADMIN_ADDR`, default `0.0.0.0:9091`) — and exposes an admin HTTP server
 with `/livez`, `/readyz`, and a Prometheus `/metrics` endpoint.
 
 The environment names one root scope, but the indexer does not index only that scope. Data
@@ -787,8 +795,23 @@ Within each opened scope, for every cell:
 + `refresh_storage_sequence` to catch up the reader to the latest durable write;
 + `dirty_graph_index_edge_types` to find which edge types have drifted;
 + for each dirty edge type, compare the current generation's `base_sequence` against the dirty
-  sequence and, if the generation is stale, `build_graph_index` to publish a fresh one;
+  sequence and, if the generation is stale, publish a fresh one — the full scan by default, or,
+  in incremental mode and at or above the size floor, the WAL-tail patch
+  (`build_graph_index_auto`), which falls back to the full scan when it cannot proceed;
 + `gc_graph_index_generations` to prune superseded generations beyond the retained count.
+
+The build in step 3 has two shapes. The default is the full scan: every dirty edge type
+re-reads the whole canonical adjacency, however small the change that dirtied it. In
+incremental mode the indexer patches the previous generation with the WAL tail instead, so the
+work tracks the delta rather than the graph — at a million edges and a hundred changed per
+cycle, that is a ten-thousand-fold drop in edges touched per build. The size floor exists
+because small graphs invert the trade: a graph that fits the block cache full-scans at memory
+speed, while the incremental path still decodes and re-encodes the whole previous CSC payload,
+so below `GRAPH_INDEXER_INCREMENTAL_MIN_EDGES` the indexer deliberately keeps the full path.
+Three Prometheus counters keep the choice observable: `graph_indexer_full_build_edges` and
+`graph_indexer_incremental_delta_edges` count the work each path actually did, and
+`graph_indexer_incremental_fallbacks` counts every time the incremental path declined and the
+full scan ran in its place.
 
 #custom-box(title: [Why], icon: "tip")[
   Separating the builder from the data node is compute–compute separation: index building can

--- a/books/chapters/05-caching.typ
+++ b/books/chapters/05-caching.typ
@@ -511,7 +511,11 @@ cluster per scope. For each cell it refreshes its durable reader, reads the mark
 `base_sequence` at or beyond the marker. For the rest it calls `build_graph_index`, which pins a
 durable snapshot, takes `base_sequence` and `last_wal_id` from it, materializes the canonical
 adjacency, encodes one CSC matrix, hashes it, writes the generation object with `PutMode::Create`,
-and advances the `current` manifest with a compare-and-swap that refuses to move backwards. Older
+and advances the `current` manifest with a compare-and-swap that refuses to move backwards. (Under
+`GRAPH_INDEXER_BUILD_MODE=incremental`, large edge types take a cheaper route to the same
+publication: `build_graph_index_auto` decodes the previous generation, applies the WAL-tail delta
+written since it, and re-encodes — falling back to the full scan whenever the patch cannot
+proceed.) Older
 generations are then pruned by `gc_graph_index_generations` down to `GRAPH_INDEXER_RETAIN_PREVIOUS`
 (default 1).
 

--- a/interactive/inside/01-architecture.html
+++ b/interactive/inside/01-architecture.html
@@ -827,8 +827,15 @@ pub struct GraphIndexGeneration {
       artifact-build permit, snapshots at the current <code>base_sequence</code>, folds the
       canonical adjacency into a GraphBLAS CSC matrix, checksums it, names the generation by its
       SHA-256, and publishes the manifest with a compare-and-set retry loop
-      (<code>INDEX_PUBLISH_ATTEMPTS = 8</code>). Publication is atomic: a reader sees either the old
-      generation or the new one, never a torn write.</li>
+      (<code>INDEX_PUBLISH_ATTEMPTS = 8</code>). Under
+      <code>GRAPH_INDEXER_BUILD_MODE=incremental</code> the indexer calls
+      <code>build_graph_index_auto</code> instead, which patches the <em>previous</em> generation
+      rather than re-folding the whole adjacency: it decodes the previous CSC, asks
+      <code>topology_tail_since</code> for the final-state <code>(src, dst, exists)</code> delta
+      written since that generation, applies it, and re-encodes — declining back to the full scan
+      whenever it cannot proceed (no previous generation, the WAL tail no longer available, or the
+      tail oversized). Both paths publish identically, and publication is atomic: a reader sees
+      either the old generation or the new one, never a torn write.</li>
     <li><em>Hydrate &amp; overlay</em> — <code>matrix_cache.rs</code> is read-through: on a miss it
       hydrates the current generation's CSC into the shard's matrix caches (taking the
       <code>matrix_compilation_gate</code> for the compiled form). Because a read pins a sequence
@@ -893,7 +900,10 @@ pub struct GraphIndexGeneration {
   <p><code>graph-indexer</code> is a small loop. It reads its configuration from the environment —
   the data path, the cells to index, a poll interval (<code>GRAPH_INDEXER_INTERVAL_MS</code>,
   default 5000), how many previous generations to retain
-  (<code>GRAPH_INDEXER_RETAIN_PREVIOUS</code>, default 1), and an admin address
+  (<code>GRAPH_INDEXER_RETAIN_PREVIOUS</code>, default 1), a build mode
+  (<code>GRAPH_INDEXER_BUILD_MODE</code>, <code>full</code> or <code>incremental</code>, default
+  <code>full</code>), the incremental size floor
+  (<code>GRAPH_INDEXER_INCREMENTAL_MIN_EDGES</code>, default 250000), and an admin address
   (<code>GRAPH_INDEXER_ADMIN_ADDR</code>, default <code>0.0.0.0:9091</code>) — and exposes an admin
   HTTP server with <code>/livez</code>, <code>/readyz</code>, and a Prometheus <code>/metrics</code>
   endpoint.</p>
@@ -933,11 +943,27 @@ for scope in scopes {
       write;</li>
     <li><code>dirty_graph_index_edge_types</code> to find which edge types have drifted;</li>
     <li>for each dirty edge type, compare the current generation's <code>base_sequence</code>
-      against the dirty sequence and, if the generation is stale, <code>build_graph_index</code> to
-      publish a fresh one;</li>
+      against the dirty sequence and, if the generation is stale, publish a fresh one — the full
+      scan by default, or, in incremental mode and at or above the size floor, the WAL-tail patch
+      (<code>build_graph_index_auto</code>), which falls back to the full scan when it cannot
+      proceed;</li>
     <li><code>gc_graph_index_generations</code> to prune superseded generations beyond the retained
       count.</li>
   </ol>
+
+  <p>The build in step 3 has two shapes. The default is the full scan: every dirty edge type
+  re-reads the whole canonical adjacency, however small the change that dirtied it. In incremental
+  mode the indexer patches the previous generation with the WAL tail instead, so the work tracks
+  the delta rather than the graph — at a million edges and a hundred changed per cycle, that is a
+  ten-thousand-fold drop in edges touched per build. The size floor exists because small graphs
+  invert the trade: a graph that fits the block cache full-scans at memory speed, while the
+  incremental path still decodes and re-encodes the whole previous CSC payload, so below
+  <code>GRAPH_INDEXER_INCREMENTAL_MIN_EDGES</code> the indexer deliberately keeps the full path.
+  Three Prometheus counters keep the choice observable:
+  <code>graph_indexer_full_build_edges</code> and
+  <code>graph_indexer_incremental_delta_edges</code> count the work each path actually did, and
+  <code>graph_indexer_incremental_fallbacks</code> counts every time the incremental path declined
+  and the full scan ran in its place.</p>
 
   <div class="callout why">
     <span class="callout-title">Why</span>

--- a/interactive/inside/01-architecture.html
+++ b/interactive/inside/01-architecture.html
@@ -833,9 +833,10 @@ pub struct GraphIndexGeneration {
       rather than re-folding the whole adjacency: it decodes the previous CSC, asks
       <code>topology_tail_since</code> for the final-state <code>(src, dst, exists)</code> delta
       written since that generation, applies it, and re-encodes — declining back to the full scan
-      whenever it cannot proceed (no previous generation, the WAL tail no longer available, or the
-      tail oversized). Both paths publish identically, and publication is atomic: a reader sees
-      either the old generation or the new one, never a torn write.</li>
+      whenever it cannot proceed (no previous generation, the previous generation's CSC payload
+      missing from the store, the WAL tail no longer available, or the tail oversized). Both paths
+      publish identically, and publication is atomic: a reader sees either the old generation or
+      the new one, never a torn write.</li>
     <li><em>Hydrate &amp; overlay</em> — <code>matrix_cache.rs</code> is read-through: on a miss it
       hydrates the current generation's CSC into the shard's matrix caches (taking the
       <code>matrix_compilation_gate</code> for the compiled form). Because a read pins a sequence

--- a/interactive/inside/05-caching.html
+++ b/interactive/inside/05-caching.html
@@ -520,7 +520,11 @@ self.graphblas_cache.lock().await.retain(/* same predicate */);</code></pre>
   <code>base_sequence</code> at or beyond the marker. For the rest it calls <code>build_graph_index</code>, which pins a
   durable <span class="concept" data-concept="snapshot-isolation">snapshot</span>, takes <code>base_sequence</code> and <code>last_wal_id</code> from it, materializes the canonical
   adjacency, encodes one CSC matrix, hashes it, writes the generation object with <code>PutMode::Create</code>,
-  and advances the <code>current</code> manifest with a compare-and-swap that refuses to move backwards. Older
+  and advances the <code>current</code> manifest with a compare-and-swap that refuses to move backwards. (Under
+  <code>GRAPH_INDEXER_BUILD_MODE=incremental</code>, large edge types take a cheaper route to the same
+  publication: <code>build_graph_index_auto</code> decodes the previous generation, applies the WAL-tail delta
+  written since it, and re-encodes — falling back to the full scan whenever the patch cannot
+  proceed.) Older
   generations are then pruned by <code>gc_graph_index_generations</code> down to <code>GRAPH_INDEXER_RETAIN_PREVIOUS</code>
   (default 1).</p>
 
@@ -676,7 +680,7 @@ window.TB_GLOSSARY = Object.assign(window.TB_GLOSSARY || {}, {
   },
   "indexer-process": {
     title: "Out-of-process indexer",
-    html: "<p><code>graph-indexer</code>, a separate binary that never writes graph data and never serves queries. On its own clock (default every 5 s) it reads the dirty markers a write left behind, rebuilds each cell's <span class=\"concept\" data-concept=\"index-generation\">index generation</span> from a pinned <span class=\"concept\" data-concept=\"snapshot-isolation\">snapshot</span>, publishes it with a compare-and-swap, and prunes old generations. Its independent clock is exactly why the matrix caches key on a lagging <span class=\"concept\" data-concept=\"base-epoch\">base</span>.</p>"
+    html: "<p><code>graph-indexer</code>, a separate binary that never writes graph data and never serves queries. On its own clock (default every 5 s) it reads the dirty markers a write left behind, rebuilds each cell's <span class=\"concept\" data-concept=\"index-generation\">index generation</span> from a pinned <span class=\"concept\" data-concept=\"snapshot-isolation\">snapshot</span> — or, in incremental mode, patches the previous generation with the WAL-tail delta written since it — publishes it with a compare-and-swap, and prunes old generations. Its independent clock is exactly why the matrix caches key on a lagging <span class=\"concept\" data-concept=\"base-epoch\">base</span>.</p>"
   }
 });
 </script>


### PR DESCRIPTION
Stacked on #12. Updates the book chapters that describe index builds, since the indexer now has a second build shape.

## What changed

**`books/chapters/01-architecture.typ` (+ derived `interactive/inside/01-architecture.html`)**
- The *Build & publish* life-cycle step now covers `build_graph_index_auto`: decode the previous generation's CSC, apply the `topology_tail_since` final-state delta, re-encode — and the three conditions under which it declines back to the full scan (no previous generation, WAL tail unavailable, tail oversized).
- The indexer configuration paragraph lists `GRAPH_INDEXER_BUILD_MODE` (`full` | `incremental`, default `full`) and `GRAPH_INDEXER_INCREMENTAL_MIN_EDGES` (default 250000).
- A new paragraph after the per-cell cycle explains why the size floor exists (small graphs full-scan at block-cache speed while the patch still decodes and re-encodes the whole CSC payload) and names the three Prometheus counters that make the path choice observable.

**`books/chapters/05-caching.typ` (+ derived `interactive/inside/05-caching.html`)**
- The out-of-process rebuild paragraph and the indexer glossary entry mention the incremental route to the same atomic publication.

## Verification

`make inside` compiles the Typst book clean (the only warning is the pre-existing local "Source Code Pro" font fallback). The HTML edits mirror the `.typ` prose verbatim per `interactive/README.md`.