### PR TITLE
Name which check an idempotency conflict failed

### DIFF
--- a/src/client/bolt/tests.rs
+++ b/src/client/bolt/tests.rs
@@ -1543,6 +1543,7 @@ fn an_idempotency_conflict_is_visible_and_non_retryable_to_bolt_clients() {
     let error = graph_error_to_bolt(GraphError::IdempotencyConflict {
         operation: "relationship-import",
         idempotency_key: "caller-operation-42".to_string(),
+        reason: "this key already stored a result for a different payload",
     });
 
     match error {
@@ -1550,6 +1551,7 @@ fn an_idempotency_conflict_is_visible_and_non_retryable_to_bolt_clients() {
             assert_eq!(code, "Neo.ClientError.Transaction.Invalid");
             assert!(message.contains("relationship-import"));
             assert!(message.contains("caller-operation-42"));
+            assert!(message.contains("different payload"));
         }
         other => panic!("expected a non-retryable Neo client error, got {other:?}"),
     }

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -209,6 +209,7 @@ pub(crate) fn validate_edge_mutations_for_cell(
             return Err(GraphError::IdempotencyConflict {
                 operation: "create",
                 idempotency_key: mutation.idempotency_key.clone(),
+                reason: "the same key appears twice in one batch",
             });
         }
     }
@@ -680,6 +681,7 @@ pub(crate) fn decode_segment_compaction_idempotency(
         return Err(GraphError::IdempotencyConflict {
             operation: "segment-compact",
             idempotency_key: idempotency_key.to_string(),
+            reason: "the stored record names a different key",
         });
     }
     let recorded_epoch = parse_u64(key, parts[1], "compacted_through_epoch")?;
@@ -687,6 +689,7 @@ pub(crate) fn decode_segment_compaction_idempotency(
         return Err(GraphError::IdempotencyConflict {
             operation: "segment-compact",
             idempotency_key: idempotency_key.to_string(),
+            reason: "a stored result for this key compacted through a different epoch",
         });
     }
     Ok(SegmentCompactionResult {
@@ -907,10 +910,18 @@ pub(crate) fn decode_bulk_import_idempotency(
             reason: "expected bulk_import1 record with 7 fields".to_string(),
         });
     }
-    if parts[6] != idempotency_key || parse_u64(key, parts[5], "fingerprint")? != fingerprint {
+    if parts[6] != idempotency_key {
         return Err(GraphError::IdempotencyConflict {
             operation: "bulk-import",
             idempotency_key: idempotency_key.to_string(),
+            reason: "the stored record names a different key",
+        });
+    }
+    if parse_u64(key, parts[5], "fingerprint")? != fingerprint {
+        return Err(GraphError::IdempotencyConflict {
+            operation: "bulk-import",
+            idempotency_key: idempotency_key.to_string(),
+            reason: "this key already stored a result for a different payload",
         });
     }
     Ok(BulkImportResult {
@@ -938,10 +949,24 @@ pub(crate) fn decode_relationship_import_idempotency(
             reason: "expected relationship_import1 record with 9 fields".to_string(),
         });
     }
-    if parts[8] != idempotency_key || parse_u64(key, parts[7], "fingerprint")? != fingerprint {
+    // Split from one `||` into two arms so the reason can name which half
+    // failed. The second is the signature of a caller whose keys are not
+    // derived from what it is writing: the key replayed, a stored result came
+    // back, and it was produced by a different set of relationships. The first
+    // cannot happen through `keys::idempotency` — that path *is* the key — so
+    // it means the slot holds another request's record.
+    if parts[8] != idempotency_key {
         return Err(GraphError::IdempotencyConflict {
             operation: "relationship-import",
             idempotency_key: idempotency_key.to_string(),
+            reason: "the stored record names a different key",
+        });
+    }
+    if parse_u64(key, parts[7], "fingerprint")? != fingerprint {
+        return Err(GraphError::IdempotencyConflict {
+            operation: "relationship-import",
+            idempotency_key: idempotency_key.to_string(),
+            reason: "this key already stored a result for a different payload",
         });
     }
     Ok(RelationshipImportResult {
@@ -984,6 +1009,7 @@ pub(crate) fn decode_relationship_create_idempotency(
         return Err(GraphError::IdempotencyConflict {
             operation: "relationship-create",
             idempotency_key: mutation.idempotency_key.clone(),
+            reason: "this key already stored a result for a different edge or payload",
         });
     }
     Ok(RelationshipCreateResult {
@@ -1044,6 +1070,7 @@ pub(crate) fn decode_relationship_delete_idempotency(
         return Err(GraphError::IdempotencyConflict {
             operation: "relationship-delete",
             idempotency_key: mutation.idempotency_key.clone(),
+            reason: "this key already stored a result for a different relationship",
         });
     }
     Ok(DeleteResult {
@@ -1074,6 +1101,7 @@ pub(crate) fn decode_vertex_delete_idempotency(
         return Err(GraphError::IdempotencyConflict {
             operation: "vertex-delete",
             idempotency_key: idempotency_key.to_string(),
+            reason: "this key already stored a result for a different vertex",
         });
     }
     Ok(VertexDeleteResult {
@@ -1105,6 +1133,7 @@ pub(crate) fn decode_cell_drop_idempotency(
         return Err(GraphError::IdempotencyConflict {
             operation: "cell-drop",
             idempotency_key: idempotency_key.to_string(),
+            reason: "this key already stored a result for a different cell",
         });
     }
     Ok(GraphCellDropResult {
@@ -1159,6 +1188,7 @@ pub(crate) fn ensure_idempotent_edge(
         return Err(GraphError::IdempotencyConflict {
             operation,
             idempotency_key: mutation.idempotency_key.clone(),
+            reason: "this key already stored a result for a different edge",
         });
     }
     Ok(())

--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -28,10 +28,24 @@ pub enum GraphError {
     },
     #[error("corrupt value at {key}: {reason}")]
     CorruptValue { key: String, reason: String },
-    #[error("idempotency key conflict for {operation} request key {idempotency_key}")]
+    /// A request reused an idempotency key that the store already resolved to a
+    /// different outcome.
+    ///
+    /// `reason` names *which* check failed, and it is the whole point of the
+    /// variant carrying three fields instead of two. The operation and the key
+    /// together say only "these two requests disagreed"; they cannot say
+    /// whether a replayed key found a stored record for a different payload
+    /// (the caller is minting keys that collide) or whether an identity the
+    /// payload carries is already bound to something else (the caller is
+    /// minting *ids* that collide). Those are different bugs on the caller's
+    /// side with different fixes. Bolt exposes the complete message as a
+    /// non-retryable `Neo.ClientError.Transaction.Invalid`, so callers can stop
+    /// retrying and diagnose the failed check directly.
+    #[error("idempotency key conflict for {operation} request key {idempotency_key}: {reason}")]
     IdempotencyConflict {
         operation: &'static str,
         idempotency_key: String,
+        reason: &'static str,
     },
     #[error(
         "control metadata conflict at {key}: expected generation {expected_generation:?}, actual generation {actual_generation:?}"

--- a/src/shard/write.rs
+++ b/src/shard/write.rs
@@ -1678,9 +1678,33 @@ impl GraphShard {
                     || existing.dst != requested.dst
                     || existing.relationship_id != requested.relationship_id
                 {
+                    // This conflict is about the *payload's* identity, not the
+                    // request key: the relationship id the caller sent already
+                    // resolves to another edge. It reaches the log with the
+                    // same `IdempotencyConflict` display as a replayed request
+                    // key does, and the two have opposite fixes — so the pair
+                    // that disagreed is logged here, where both are in hand.
+                    // Every field is an id or a type name, never user data.
+                    tracing::warn!(
+                        target: "slatedb_graph_kernel",
+                        idempotency_key,
+                        existing.cell_id = %existing.cell_id,
+                        existing.edge_type = %existing.edge_type,
+                        existing.src = existing.src,
+                        existing.dst = existing.dst,
+                        existing.relationship_id = existing.relationship_id,
+                        requested.cell_id = %requested.cell_id,
+                        requested.edge_type = %requested.edge_type,
+                        requested.src = requested.src,
+                        requested.dst = requested.dst,
+                        requested.relationship_id = requested.relationship_id,
+                        "relationship import rejected: relationship id is bound to a different edge",
+                    );
                     return Err(GraphError::IdempotencyConflict {
                         operation: "relationship-import",
                         idempotency_key: idempotency_key.to_string(),
+                        reason: "the relationship id in the payload is already bound to a \
+                                 different edge",
                     });
                 }
                 if existing.metadata != requested.metadata {
@@ -1688,6 +1712,8 @@ impl GraphShard {
                         return Err(GraphError::IdempotencyConflict {
                             operation: "relationship-import",
                             idempotency_key: idempotency_key.to_string(),
+                            reason: "the relationship exists with different properties and this \
+                                     operation does not update them",
                         });
                     }
                     let next_metadata =
@@ -4068,6 +4094,7 @@ impl GraphShard {
                 return Err(GraphError::IdempotencyConflict {
                     operation: "create",
                     idempotency_key: mutation.idempotency_key.clone(),
+                    reason: "the same key appears twice in one batch",
                 });
             }
         }
@@ -4704,6 +4731,7 @@ fn validate_unique_delete_mutation_identities(mutations: &[EdgeMutation]) -> Res
             return Err(GraphError::IdempotencyConflict {
                 operation: "delete",
                 idempotency_key: format!("{first_key},{}", mutation.idempotency_key),
+                reason: "two keys in one batch delete the same edge",
             });
         }
     }
@@ -4846,7 +4874,13 @@ fn coalesce_relationship_imports(
             Some(existing) if existing != &relationship => {
                 return Err(GraphError::IdempotencyConflict {
                     operation: "relationship-import",
+                    // Not the request key — this check runs before the request
+                    // key is in scope, so the id that collided stands in for it.
+                    // The reason says so, because a key shaped like a padded
+                    // integer otherwise reads as a truncated request key.
                     idempotency_key: format!("{:020}", relationship.relationship_id),
+                    reason: "the batch carries this relationship id twice with different \
+                             endpoints or properties (key shown is the relationship id)",
                 });
             }
             Some(_) => {}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1776,7 +1776,8 @@ async fn bulk_import_edges_writes_normal_indexes_and_idempotency() {
         conflict,
         GraphError::IdempotencyConflict {
             operation: "bulk-import",
-            ref idempotency_key
+            ref idempotency_key,
+            reason: "this key already stored a result for a different payload"
         } if idempotency_key == "bulk-1"
     ));
 
@@ -2331,7 +2332,8 @@ async fn write_edge_mutations_batch_rejects_idempotency_reuse_for_different_edge
         conflict,
         GraphError::IdempotencyConflict {
             operation: "create",
-            ref idempotency_key
+            ref idempotency_key,
+            reason: "this key already stored a result for a different edge"
         } if idempotency_key == "edge-batch-conflict"
     ));
 
@@ -2349,7 +2351,8 @@ async fn write_edge_mutations_batch_rejects_idempotency_reuse_for_different_edge
         duplicate_in_batch,
         GraphError::IdempotencyConflict {
             operation: "create",
-            ref idempotency_key
+            ref idempotency_key,
+            reason: "the same key appears twice in one batch"
         } if idempotency_key == "edge-batch-duplicate"
     ));
 }
@@ -2461,7 +2464,8 @@ async fn idempotency_keys_are_bound_to_the_original_edge() {
         create_err,
         GraphError::IdempotencyConflict {
             operation: "create",
-            ref idempotency_key
+            ref idempotency_key,
+            reason: "this key already stored a result for a different edge"
         } if idempotency_key == "create-conflict"
     ));
 
@@ -2477,7 +2481,8 @@ async fn idempotency_keys_are_bound_to_the_original_edge() {
         delete_err,
         GraphError::IdempotencyConflict {
             operation: "delete",
-            ref idempotency_key
+            ref idempotency_key,
+            reason: "this key already stored a result for a different edge"
         } if idempotency_key == "delete-conflict"
     ));
 }
@@ -2663,7 +2668,8 @@ async fn delete_edge_mutations_batch_rejects_duplicate_edge_identities() {
         err,
         GraphError::IdempotencyConflict {
             operation: "delete",
-            idempotency_key
+            idempotency_key,
+            reason: "two keys in one batch delete the same edge"
         } if idempotency_key.contains("delete-batch-duplicate-a")
             && idempotency_key.contains("delete-batch-duplicate-b")
     ));


### PR DESCRIPTION
## Why

Staging has been failing every relationship write on the `unwind-relationship-merge` path for hours, retrying forever, with one string in the log:

```
idempotency key conflict for relationship-import request key bolt-2-query-459.unwind-relationship-merge
```

That string is emitted from three different checks, and the error carried only `operation` and `idempotency_key` — so the log cannot say which one fired. Two candidates are live, with opposite causes and opposite fixes:

- **`codec.rs` (key replay, different fingerprint)** — the caller's *keys* collide. The Bolt session id is a process-local atomic (`bolt.rs:66`) and the query counter starts at 1 per connection; that string becomes the idempotency key (`service.rs:2283` → `algebra.rs:185` → `coordination.rs:3340`) and persists under `cell/{cell}/idem/relationship-import/{key}` with no node id or boot id in the path. A restart re-mints keys a previous process already stored against different payloads.
- **`write.rs` (relationship id bound elsewhere)** — the caller's *ids* collide. The lookup resolves by `keys::relationship_id` first (`write.rs:1635`), and that id is client-supplied (`coordination.rs:3327-3336`). Nothing to do with the session counter.

Both fit the reported evidence — the restart window, the counter reset, the wide query-number span. The other two sites are excluded on inspection: the metadata check needs `update_existing_metadata: false` and merge sets it true (`write.rs:1226`), and the batch-coalesce check substitutes the relationship id as the key, so a log showing a request key didn't come from there.

## What

`GraphError::IdempotencyConflict` gains `reason: &'static str` next to the `operation: &'static str` it already had, and the `Display` ends with it. All fourteen construction sites name their own check; the two-way `||` conditions in the bulk-import and relationship-import decoders split so the reason says which half failed.

No new log sites for this — `graph_error_to_bolt`'s catch-all already writes `%error` at WARN, so the discriminator rides the line that exists, for every operation rather than just this one.

The one addition is a WARN at the relationship-id check, logging existing vs requested identity side by side: the reason says *that* the id is bound elsewhere, triage needs *which* edge. Ids and type names only, no user data.

The six exhaustive test patterns now pin the exact reason per site, so a site can't quietly drift onto another's string.

## Reading the result

- `this key already stored a result for a different payload` → key collision, process-local counter.
- `the relationship id in the payload is already bound to a different edge` → id collision; the new WARN gives the colliding pair.

## Not in scope

No behaviour changes. `IdempotencyConflict` still reaches Bolt as an opaque `Backend` error and still classes as `contention` (`error.rs:263`, documented as expected-and-retryable). Both look wrong for a non-retryable caller bug, and both change live retry semantics — worth doing once the logs say which check is firing.

## Checks

`just check`, `check-all-features`, `clippy`, `clippy-opencypher`, `test` (173), `test-opencypher` (270) — all green.
