### PR TITLE
Gate, parallelize, and cache the incremental index build's WAL tail walk

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,9 @@ jobs:
           grep -q 'GRAPH_INDEXER_RETAIN_PREVIOUS: "1"' /tmp/turbolay-custom-auth.yaml
           grep -q 'GRAPH_INDEXER_BUILD_MODE: "full"' /tmp/turbolay-custom-auth.yaml
           grep -q 'GRAPH_INDEXER_INCREMENTAL_MIN_EDGES: "250000"' /tmp/turbolay-custom-auth.yaml
+          grep -q 'GRAPH_INDEXER_SCOPE_CONCURRENCY: "8"' /tmp/turbolay-custom-auth.yaml
+          grep -q 'GRAPH_INDEXER_MAX_TAIL_FILES: "4096"' /tmp/turbolay-custom-auth.yaml
+          grep -q 'GRAPH_WAL_TAIL_FETCH_CONCURRENCY: "16"' /tmp/turbolay-custom-auth.yaml
           helm template turbolay charts/turbolay \
             --namespace turbolay \
             --values charts/turbolay/ci/ci-values.yaml \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,17 @@ jobs:
           grep -q 'GRAPH_INDEXER_MAX_OPEN_SCOPES: "128"' /tmp/turbolay-custom-auth.yaml
           grep -q 'GRAPH_INDEXER_MAX_TAIL_FILES: "4096"' /tmp/turbolay-custom-auth.yaml
           grep -q 'GRAPH_WAL_TAIL_FETCH_CONCURRENCY: "16"' /tmp/turbolay-custom-auth.yaml
+          if helm template turbolay charts/turbolay \
+            --namespace turbolay \
+            --values charts/turbolay/ci/ci-values.yaml \
+            --set indexer.scopeConcurrency=64 \
+            --set indexer.maxOpenScopes=1 \
+            > /tmp/turbolay-invalid-indexer-capacity.yaml 2>&1; then
+            echo "indexer reader capacity below scope concurrency was accepted"
+            exit 1
+          fi
+          grep -q 'indexer.maxOpenScopes must be greater than or equal to indexer.scopeConcurrency' \
+            /tmp/turbolay-invalid-indexer-capacity.yaml
           helm template turbolay charts/turbolay \
             --namespace turbolay \
             --values charts/turbolay/ci/ci-values.yaml \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
           grep -q 'GRAPH_INDEXER_BUILD_MODE: "full"' /tmp/turbolay-custom-auth.yaml
           grep -q 'GRAPH_INDEXER_INCREMENTAL_MIN_EDGES: "250000"' /tmp/turbolay-custom-auth.yaml
           grep -q 'GRAPH_INDEXER_SCOPE_CONCURRENCY: "8"' /tmp/turbolay-custom-auth.yaml
+          grep -q 'GRAPH_INDEXER_MAX_OPEN_SCOPES: "128"' /tmp/turbolay-custom-auth.yaml
           grep -q 'GRAPH_INDEXER_MAX_TAIL_FILES: "4096"' /tmp/turbolay-custom-auth.yaml
           grep -q 'GRAPH_WAL_TAIL_FETCH_CONCURRENCY: "16"' /tmp/turbolay-custom-auth.yaml
           helm template turbolay charts/turbolay \

--- a/charts/turbolay/README.md
+++ b/charts/turbolay/README.md
@@ -113,7 +113,11 @@ indexer.buildMode defaults to full. Set it to incremental to patch the previous
 CSC generation from the durable WAL tail instead of rescanning the entire
 canonical adjacency. indexer.incrementalMinEdges keeps smaller indexes on the
 full path, and any unavailable or oversized tail safely falls back to a full
-rebuild.
+rebuild. `indexer.maxWalTailFiles` bounds that tail, while
+`indexer.walTailFetchConcurrency` bounds parallel immutable WAL reads and edge
+resolution. Registered scopes run in batches of `indexer.scopeConcurrency`.
+The indexer advances a CAS-protected cursor after each completed batch, so a
+restart resumes fairly and can replay at most the unfinished batch.
 
 The development example references an existing MinIO Service only to exercise
 the S3-compatible path without AWS. The chart does not install MinIO, and the

--- a/charts/turbolay/README.md
+++ b/charts/turbolay/README.md
@@ -117,7 +117,10 @@ rebuild. `indexer.maxWalTailFiles` bounds that tail, while
 `indexer.walTailFetchConcurrency` bounds parallel immutable WAL reads and edge
 resolution. Registered scopes run in batches of `indexer.scopeConcurrency`.
 The indexer advances a CAS-protected cursor after each completed batch, so a
-restart resumes fairly and can replay at most the unfinished batch.
+restart resumes fairly and can replay at most the unfinished batch. Read-only
+scope handles remain open in a bounded LRU of `indexer.maxOpenScopes`; retained
+SlateDB readers refresh only the new durable WAL instead of replaying the whole
+tail on every cycle.
 
 The development example references an existing MinIO Service only to exercise
 the S3-compatible path without AWS. The chart does not install MinIO, and the

--- a/charts/turbolay/templates/configmap.yaml
+++ b/charts/turbolay/templates/configmap.yaml
@@ -39,6 +39,7 @@ data:
   GRAPH_INDEXER_BUILD_MODE: {{ .Values.indexer.buildMode | quote }}
   GRAPH_INDEXER_INCREMENTAL_MIN_EDGES: {{ include "turbolay.decimalInteger" .Values.indexer.incrementalMinEdges | quote }}
   GRAPH_INDEXER_SCOPE_CONCURRENCY: {{ include "turbolay.decimalInteger" .Values.indexer.scopeConcurrency | quote }}
+  GRAPH_INDEXER_MAX_OPEN_SCOPES: {{ include "turbolay.decimalInteger" .Values.indexer.maxOpenScopes | quote }}
   GRAPH_INDEXER_MAX_TAIL_FILES: {{ include "turbolay.decimalInteger" .Values.indexer.maxWalTailFiles | quote }}
   GRAPH_WAL_TAIL_FETCH_CONCURRENCY: {{ include "turbolay.decimalInteger" .Values.indexer.walTailFetchConcurrency | quote }}
   GRAPH_INDEXER_ADMIN_ADDR: "0.0.0.0:9091"

--- a/charts/turbolay/templates/configmap.yaml
+++ b/charts/turbolay/templates/configmap.yaml
@@ -38,6 +38,9 @@ data:
   GRAPH_INDEXER_RETAIN_PREVIOUS: {{ include "turbolay.decimalInteger" .Values.indexer.retainPreviousGenerations | quote }}
   GRAPH_INDEXER_BUILD_MODE: {{ .Values.indexer.buildMode | quote }}
   GRAPH_INDEXER_INCREMENTAL_MIN_EDGES: {{ include "turbolay.decimalInteger" .Values.indexer.incrementalMinEdges | quote }}
+  GRAPH_INDEXER_SCOPE_CONCURRENCY: {{ include "turbolay.decimalInteger" .Values.indexer.scopeConcurrency | quote }}
+  GRAPH_INDEXER_MAX_TAIL_FILES: {{ include "turbolay.decimalInteger" .Values.indexer.maxWalTailFiles | quote }}
+  GRAPH_WAL_TAIL_FETCH_CONCURRENCY: {{ include "turbolay.decimalInteger" .Values.indexer.walTailFetchConcurrency | quote }}
   GRAPH_INDEXER_ADMIN_ADDR: "0.0.0.0:9091"
   GRAPH_BOLT_ADDR: 0.0.0.0:7687
   GRAPH_HTTP_ADDR: 0.0.0.0:8443

--- a/charts/turbolay/templates/validate.yaml
+++ b/charts/turbolay/templates/validate.yaml
@@ -82,3 +82,6 @@
 {{- if and .Values.podDisruptionBudget.enabled .Values.indexer.enabled (gt (int .Values.podDisruptionBudget.indexer.minAvailable) (int .Values.indexer.replicaCount)) -}}
 {{- fail "podDisruptionBudget.indexer.minAvailable cannot exceed indexer.replicaCount" -}}
 {{- end -}}
+{{- if lt (int .Values.indexer.maxOpenScopes) (int .Values.indexer.scopeConcurrency) -}}
+{{- fail "indexer.maxOpenScopes must be greater than or equal to indexer.scopeConcurrency" -}}
+{{- end -}}

--- a/charts/turbolay/values.schema.json
+++ b/charts/turbolay/values.schema.json
@@ -196,7 +196,7 @@
     },
     "indexerWorkload": {
       "type": "object",
-      "required": ["enabled", "replicaCount", "intervalMs", "retainPreviousGenerations", "buildMode", "incrementalMinEdges", "scopeConcurrency", "maxWalTailFiles", "walTailFetchConcurrency", "resources", "serviceAccount"],
+      "required": ["enabled", "replicaCount", "intervalMs", "retainPreviousGenerations", "buildMode", "incrementalMinEdges", "scopeConcurrency", "maxOpenScopes", "maxWalTailFiles", "walTailFetchConcurrency", "resources", "serviceAccount"],
       "properties": {
         "enabled": { "type": "boolean" },
         "replicaCount": { "type": "integer", "minimum": 1, "maximum": 100 },
@@ -205,6 +205,7 @@
         "buildMode": { "enum": ["full", "incremental"] },
         "incrementalMinEdges": { "$ref": "#/definitions/unsignedDecimal" },
         "scopeConcurrency": { "type": "integer", "minimum": 1, "maximum": 64 },
+        "maxOpenScopes": { "type": "integer", "minimum": 1, "maximum": 4096 },
         "maxWalTailFiles": { "$ref": "#/definitions/unsignedDecimal" },
         "walTailFetchConcurrency": { "$ref": "#/definitions/positiveUnsignedDecimal" },
         "resources": { "type": "object" },

--- a/charts/turbolay/values.schema.json
+++ b/charts/turbolay/values.schema.json
@@ -196,6 +196,7 @@
     },
     "indexerWorkload": {
       "type": "object",
+      "$comment": "templates/validate.yaml enforces maxOpenScopes >= scopeConcurrency because JSON Schema draft-07 cannot compare sibling numeric values",
       "required": ["enabled", "replicaCount", "intervalMs", "retainPreviousGenerations", "buildMode", "incrementalMinEdges", "scopeConcurrency", "maxOpenScopes", "maxWalTailFiles", "walTailFetchConcurrency", "resources", "serviceAccount"],
       "properties": {
         "enabled": { "type": "boolean" },

--- a/charts/turbolay/values.schema.json
+++ b/charts/turbolay/values.schema.json
@@ -196,7 +196,7 @@
     },
     "indexerWorkload": {
       "type": "object",
-      "required": ["enabled", "replicaCount", "intervalMs", "retainPreviousGenerations", "buildMode", "incrementalMinEdges", "resources", "serviceAccount"],
+      "required": ["enabled", "replicaCount", "intervalMs", "retainPreviousGenerations", "buildMode", "incrementalMinEdges", "scopeConcurrency", "maxWalTailFiles", "walTailFetchConcurrency", "resources", "serviceAccount"],
       "properties": {
         "enabled": { "type": "boolean" },
         "replicaCount": { "type": "integer", "minimum": 1, "maximum": 100 },
@@ -204,6 +204,9 @@
         "retainPreviousGenerations": { "$ref": "#/definitions/unsignedDecimal" },
         "buildMode": { "enum": ["full", "incremental"] },
         "incrementalMinEdges": { "$ref": "#/definitions/unsignedDecimal" },
+        "scopeConcurrency": { "type": "integer", "minimum": 1, "maximum": 64 },
+        "maxWalTailFiles": { "$ref": "#/definitions/unsignedDecimal" },
+        "walTailFetchConcurrency": { "$ref": "#/definitions/positiveUnsignedDecimal" },
         "resources": { "type": "object" },
         "serviceAccount": { "type": "object" },
         "podAnnotations": { "type": "object" },

--- a/charts/turbolay/values.yaml
+++ b/charts/turbolay/values.yaml
@@ -113,6 +113,15 @@ indexer:
   # Small indexes can be cheaper to rebuild from the block cache. Incremental
   # mode uses the full path below this current-generation edge count.
   incrementalMinEdges: 250000
+  # Number of graph scopes opened and indexed concurrently. Work is committed
+  # to a durable progress cursor in batches of this size.
+  scopeConcurrency: 8
+  # Decline an incremental build when its immutable WAL span is larger than
+  # this and use the full snapshot build instead.
+  maxWalTailFiles: 4096
+  # Concurrent immutable WAL object reads and snapshot edge resolutions used
+  # by one incremental build.
+  walTailFetchConcurrency: 16
   serviceAccount:
     create: true
     name: ""

--- a/charts/turbolay/values.yaml
+++ b/charts/turbolay/values.yaml
@@ -116,6 +116,10 @@ indexer:
   # Number of graph scopes opened and indexed concurrently. Work is committed
   # to a durable progress cursor in batches of this size.
   scopeConcurrency: 8
+  # Maximum read-only scope handles retained between indexing cycles. Reusing
+  # a handle avoids replaying the same durable SlateDB WAL on every sweep.
+  # Must be at least scopeConcurrency.
+  maxOpenScopes: 128
   # Decline an incremental build when its immutable WAL span is larger than
   # this and use the full snapshot build instead.
   maxWalTailFiles: 4096

--- a/examples/bolt_benchmark.rs
+++ b/examples/bolt_benchmark.rs
@@ -553,6 +553,7 @@ fn graph_options(fanout: u64, max_hop: u8, cache_dir: std::path::PathBuf) -> Gra
                 .unwrap_or(usize::MAX),
             max_query_scan_edges: edges.saturating_mul(u64::from(max_hop)).max(1),
             max_query_runtime_ms: Some(120_000),
+            ..GraphLimits::default()
         };
         options.cache =
             GraphCacheConfig::disk_cache_without_preload(cache_dir, 2 * 1024 * 1024 * 1024);

--- a/examples/query_bench.rs
+++ b/examples/query_bench.rs
@@ -869,6 +869,7 @@ fn graph_options(
             max_query_index_candidates: usize::try_from(query_rows).unwrap_or(usize::MAX),
             max_query_scan_edges: edges.saturating_mul(u64::from(max_hop).max(1)).max(1),
             max_query_runtime_ms: Some(env_u64("GRAPH_QUERY_BENCH_QUERY_TIMEOUT_MS", 120_000)),
+            ..GraphLimits::default()
         };
         options.cache = cache_dir
             .filter(|_| cache_bytes > 0)

--- a/examples/query_correctness.rs
+++ b/examples/query_correctness.rs
@@ -493,6 +493,7 @@ fn graph_options(cache_dir: Option<&Path>, fanout: u64, max_hop: u8) -> GraphOpe
             max_query_index_candidates: usize::try_from(query_rows).unwrap_or(usize::MAX),
             max_query_scan_edges: edges.saturating_mul(u64::from(max_hop).max(1)).max(1),
             max_query_runtime_ms: Some(env_u64("GRAPH_QUERY_CORRECTNESS_TIMEOUT_MS", 120_000)),
+            ..GraphLimits::default()
         };
         options.cache = cache_dir
             .map(|path| GraphCacheConfig::disk_cache_without_preload(path, 512 * 1024 * 1024))

--- a/examples/s3_bolt_benchmark_server.rs
+++ b/examples/s3_bolt_benchmark_server.rs
@@ -238,6 +238,7 @@ fn graph_options(fanout: u64, max_hop: u8, cache_dir: std::path::PathBuf) -> Gra
                 .unwrap_or(usize::MAX),
             max_query_scan_edges: edges.saturating_mul(2).max(1),
             max_query_runtime_ms: Some(180_000),
+            ..GraphLimits::default()
         };
         options.cache =
             GraphCacheConfig::disk_cache_without_preload(cache_dir, 2 * 1024 * 1024 * 1024);

--- a/examples/tail_concurrency_probe.rs
+++ b/examples/tail_concurrency_probe.rs
@@ -1,0 +1,87 @@
+//! Probe: does the WAL tail walk actually fetch concurrently?
+//!
+//! Wraps an in-memory store in `object_store`'s `ThrottledStore` with a fixed
+//! per-GET delay, manufactures a trickled span, and times one incremental
+//! build. With N files at D delay: a serial walk costs ~N x D x
+//! round-trips-per-file; a C-way concurrent walk divides that by C. Run twice
+//! with `GRAPH_WAL_TAIL_FETCH_CONCURRENCY=1` and `=16` to compare.
+//!
+//! Usage: cargo run --release --example tail_concurrency_probe [TRICKLE [DELAY_MS]]
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use slatedb::object_store::memory::InMemory;
+use slatedb::object_store::throttle::{ThrottleConfig, ThrottledStore};
+use slatedb::object_store::ObjectStore;
+use slatedb_graph_kernel::{GraphIndexBuildPath, GraphLimits, GraphShard, Result};
+
+const CELL: &str = "bench-cell";
+const EDGE_TYPE: &str = "FOLLOWS";
+
+fn arg(index: usize, default: u64) -> u64 {
+    std::env::args()
+        .nth(index)
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(default)
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let trickle = arg(1, 100);
+    let delay_ms = arg(2, 25);
+
+    let config = ThrottleConfig {
+        wait_get_per_call: Duration::from_millis(delay_ms),
+        ..ThrottleConfig::default()
+    };
+    let store: Arc<dyn ObjectStore> =
+        Arc::new(ThrottledStore::new(InMemory::new(), config)) as Arc<dyn ObjectStore>;
+
+    let limits = GraphLimits {
+        max_wal_tail_files: 1_000_000,
+        ..GraphLimits::default()
+    };
+    let shard =
+        GraphShard::open_standalone_writer_with_limits("probe/tail-concurrency", store, limits)
+            .await?;
+
+    shard
+        .write_edges_batch(
+            CELL,
+            EDGE_TYPE,
+            (0..1_000).map(|i| (i / 8, 1_000 + i)),
+            "seed",
+        )
+        .await?;
+    shard.build_graph_index(CELL, EDGE_TYPE).await?;
+
+    for index in 0..trickle {
+        shard
+            .write_edges_batch(
+                CELL,
+                EDGE_TYPE,
+                [(10_000 + index, 20_000 + index)],
+                &format!("trickle-{index}"),
+            )
+            .await?;
+    }
+
+    let concurrency = std::env::var("GRAPH_WAL_TAIL_FETCH_CONCURRENCY")
+        .unwrap_or_else(|_| "16 (default)".to_string());
+    let started = Instant::now();
+    let (generation, path) = shard.build_graph_index_auto(CELL, EDGE_TYPE).await?;
+    let elapsed = started.elapsed().as_millis();
+    let described = match path {
+        GraphIndexBuildPath::Incremental { delta_edges } => {
+            format!("incremental, {delta_edges} delta edges")
+        }
+        other => format!("{other:?}"),
+    };
+    println!(
+        "concurrency {concurrency}: walk+build {elapsed} ms over ~{} files at {delay_ms} ms/GET [{described}]",
+        generation.last_wal_id,
+    );
+    shard.close().await?;
+    Ok(())
+}

--- a/examples/wal_tail_trickle_bench.rs
+++ b/examples/wal_tail_trickle_bench.rs
@@ -21,6 +21,11 @@
 //! Defaults: 100_000 seed edges per type, 500 trickle commits per type,
 //! in-memory store. The env file is the same `CLOUD_PROVIDER=aws` format the
 //! other benches take; pass one pointing at real S3 to measure real latency.
+//!
+//! Measure-only mode: `BENCH_PATH=<existing store path> BENCH_TYPE=<edge type>`
+//! skips seeding and trickling and times one build over whatever un-walked
+//! span the path already holds — for measuring the same trickled span from
+//! multiple processes (each process resolves its fetch concurrency once).
 
 use std::sync::Arc;
 use std::time::Instant;
@@ -65,6 +70,49 @@ async fn main() -> Result<()> {
         max_artifact_build_edges: 50_000_000,
         ..GraphLimits::default()
     };
+
+    if let Ok(path) = std::env::var("BENCH_PATH") {
+        let edge_type = std::env::var("BENCH_TYPE").unwrap_or_else(|_| EDGE_TYPES[0].to_string());
+        let started = Instant::now();
+        let shard =
+            GraphShard::open_standalone_writer_with_limits(path.as_str(), store, limits).await?;
+        // The open replays every WAL file past the last checkpoint — over a
+        // freshly trickled span that is itself a serial walk, so it is timed
+        // and reported apart from the build being measured.
+        println!("opened in {} ms", started.elapsed().as_millis());
+        flush();
+        let previous = shard
+            .current_graph_index(CELL, &edge_type)
+            .await?
+            .expect("measure-only mode needs a published generation to build from");
+        println!(
+            "previous generation {} at wal id {}",
+            previous.generation, previous.last_wal_id
+        );
+        flush();
+        let started = Instant::now();
+        let (generation, path_taken) = shard.build_graph_index_auto(CELL, &edge_type).await?;
+        let elapsed_ms = started.elapsed().as_millis();
+        let span = generation.last_wal_id.saturating_sub(previous.last_wal_id);
+        println!(
+            "measure-only {edge_type}: {elapsed_ms} ms over {span} wal files [{}] \
+             ({:.1} ms/file)",
+            describe(&path_taken),
+            elapsed_ms as f64 / span.max(1) as f64,
+        );
+        flush();
+        let started = Instant::now();
+        let full = shard.build_graph_index(CELL, &edge_type).await?;
+        println!(
+            "full rebuild at same seq: {} ms [{} edges]",
+            started.elapsed().as_millis(),
+            full.edge_count
+        );
+        flush();
+        shard.close().await?;
+        return Ok(());
+    }
+
     let shard = GraphShard::open_standalone_writer_with_limits(
         format!("bench/wal-tail-trickle-{run_id}").as_str(),
         store,
@@ -175,6 +223,13 @@ async fn main() -> Result<()> {
 
     shard.close().await?;
     Ok(())
+}
+
+/// Stdout is block-buffered when piped; a killed process loses whatever sat
+/// in the buffer, so each measurement line is flushed the moment it exists.
+fn flush() {
+    use std::io::Write as _;
+    let _ = std::io::stdout().flush();
 }
 
 fn describe(path: &GraphIndexBuildPath) -> String {

--- a/examples/wal_tail_trickle_bench.rs
+++ b/examples/wal_tail_trickle_bench.rs
@@ -1,0 +1,188 @@
+//! Reproduces the staging WAL-tail regression and measures the fix.
+//!
+//! The staging failure mode (`interactive/incremental-build-cost.html`): a
+//! tenant trickles small writes, every ~commit becomes its own WAL file, and
+//! the next incremental index build pays one object-store round trip per file
+//! — cost proportional to *write activity*, not to the delta or the graph. A
+//! bulk-seeded bench never sees this, so this harness manufactures it: after
+//! seeding and a baseline generation, it commits `TRICKLE` single-edge writes
+//! per edge type, then times the builds that must walk that span.
+//!
+//! Two edge types share the database, as in production, so the second
+//! incremental build measures the per-shard parsed-file cache: its span was
+//! already downloaded by the first build's walk.
+//!
+//! A/B against the serial walk this replaced:
+//! `GRAPH_WAL_TAIL_FETCH_CONCURRENCY=1` reproduces old behavior (minus the
+//! cache, which the second edge type isolates anyway).
+//!
+//! Usage: cargo run --release --example wal_tail_trickle_bench \
+//!            [SEED [TRICKLE [ENV_FILE]]]
+//! Defaults: 100_000 seed edges per type, 500 trickle commits per type,
+//! in-memory store. The env file is the same `CLOUD_PROVIDER=aws` format the
+//! other benches take; pass one pointing at real S3 to measure real latency.
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use slatedb::object_store::memory::InMemory;
+use slatedb::object_store::ObjectStore;
+use slatedb_graph_kernel::{
+    object_store_from_env, GraphIndexBuildPath, GraphLimits, GraphShard, Result,
+};
+
+const CELL: &str = "bench-cell";
+const EDGE_TYPES: [&str; 2] = ["FOLLOWS", "REPLIES"];
+const OUT_DEGREE: u64 = 8;
+
+fn arg(index: usize, default: u64) -> u64 {
+    std::env::args()
+        .nth(index)
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(default)
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let seed_edges = arg(1, 100_000);
+    let trickle = arg(2, 500);
+
+    let store: Arc<dyn ObjectStore> = match std::env::args().nth(3) {
+        Some(env_file) => {
+            println!("using object store from {env_file}");
+            object_store_from_env(Some(env_file))?
+        }
+        None => Arc::new(InMemory::new()),
+    };
+    let run_id = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("clock before unix epoch")
+        .as_millis();
+    // The gate under test must not fire here — the point is to measure the
+    // walk itself, so the cap is lifted well past any span this run creates.
+    let limits = GraphLimits {
+        max_wal_tail_files: 1_000_000,
+        max_artifact_build_edges: 50_000_000,
+        ..GraphLimits::default()
+    };
+    let shard = GraphShard::open_standalone_writer_with_limits(
+        format!("bench/wal-tail-trickle-{run_id}").as_str(),
+        store,
+        limits,
+    )
+    .await?;
+
+    let concurrency = std::env::var("GRAPH_WAL_TAIL_FETCH_CONCURRENCY")
+        .unwrap_or_else(|_| "16 (default)".to_string());
+    println!(
+        "seed {seed_edges} edges x {} types, trickle {trickle} commits/type, \
+         tail fetch concurrency {concurrency}",
+        EDGE_TYPES.len()
+    );
+
+    let started = Instant::now();
+    for edge_type in EDGE_TYPES {
+        shard
+            .write_edges_batch_chunked(
+                CELL,
+                edge_type,
+                (0..seed_edges).map(|index| (index / OUT_DEGREE, seed_edges + index)),
+                &format!("trickle-seed-{edge_type}"),
+                10_000,
+            )
+            .await?;
+    }
+    println!("seeded in {} ms", started.elapsed().as_millis());
+
+    let mut baselines = Vec::new();
+    for edge_type in EDGE_TYPES {
+        let started = Instant::now();
+        let generation = shard.build_graph_index(CELL, edge_type).await?;
+        println!(
+            "baseline full build {edge_type}: {} edges in {} ms (last_wal_id {})",
+            generation.edge_count,
+            started.elapsed().as_millis(),
+            generation.last_wal_id,
+        );
+        baselines.push(generation);
+    }
+
+    // The trickle. One committed write per call, alternating edge types —
+    // each durable commit flushes its own WAL file(s), which is exactly the
+    // shape a small-batch ingestion pipeline leaves behind.
+    println!("\ntrickling {trickle} single-edge commits per type...");
+    let started = Instant::now();
+    for index in 0..trickle {
+        for (offset, edge_type) in EDGE_TYPES.iter().enumerate() {
+            shard
+                .write_edges_batch(
+                    CELL,
+                    edge_type,
+                    [(
+                        2 * seed_edges + index / OUT_DEGREE + offset as u64 * seed_edges,
+                        3 * seed_edges + index + offset as u64 * seed_edges,
+                    )],
+                    &format!("trickle-{edge_type}-{index}"),
+                )
+                .await?;
+        }
+    }
+    println!("trickled in {} ms", started.elapsed().as_millis());
+
+    // First incremental build: a cold walk over the whole trickled span.
+    let started = Instant::now();
+    let (cold_generation, cold_path) = shard.build_graph_index_auto(CELL, EDGE_TYPES[0]).await?;
+    let cold_ms = started.elapsed().as_millis();
+    let cold_span = cold_generation
+        .last_wal_id
+        .saturating_sub(baselines[0].last_wal_id);
+
+    // Second incremental build: same span, already parsed and cached by the
+    // first walk — the cross-edge-type sharing the fix adds.
+    let started = Instant::now();
+    let (warm_generation, warm_path) = shard.build_graph_index_auto(CELL, EDGE_TYPES[1]).await?;
+    let warm_ms = started.elapsed().as_millis();
+    let warm_span = warm_generation
+        .last_wal_id
+        .saturating_sub(baselines[1].last_wal_id);
+
+    // The old path, timed at the same durable sequence.
+    let started = Instant::now();
+    let full = shard.build_graph_index(CELL, EDGE_TYPES[0]).await?;
+    let full_ms = started.elapsed().as_millis();
+
+    println!("\nwal span walked: {cold_span} files (cold), {warm_span} files (warm)");
+    println!(
+        "incremental {} (cold walk):  {cold_ms} ms  [{}]",
+        EDGE_TYPES[0],
+        describe(&cold_path)
+    );
+    println!(
+        "incremental {} (warm cache): {warm_ms} ms  [{}]",
+        EDGE_TYPES[1],
+        describe(&warm_path)
+    );
+    println!(
+        "full rebuild at same seq:        {full_ms} ms  [{} edges]",
+        full.edge_count
+    );
+    println!(
+        "\ncold walk per file: {:.1} ms; warm/cold: {:.2}; incremental(cold)/full: {:.2}",
+        cold_ms as f64 / cold_span.max(1) as f64,
+        warm_ms as f64 / cold_ms.max(1) as f64,
+        cold_ms as f64 / full_ms.max(1) as f64,
+    );
+
+    shard.close().await?;
+    Ok(())
+}
+
+fn describe(path: &GraphIndexBuildPath) -> String {
+    match path {
+        GraphIndexBuildPath::Incremental { delta_edges } => {
+            format!("incremental, {delta_edges} delta edges")
+        }
+        GraphIndexBuildPath::Full { edges } => format!("FULL FALLBACK, {edges} edges"),
+        GraphIndexBuildPath::Current => "already current".to_string(),
+    }
+}

--- a/interactive/README.md
+++ b/interactive/README.md
@@ -22,6 +22,7 @@ textbooks: no tooltips, and they carry their own inline styles rather than
 | One Cell, One Writer | `write-routing-problem.html` | why a write cannot reach the correct single-writer node today |
 | Routing the Write | `write-routing-solutions.html` | four ways to place the writer, scored — TiDB/TiKV and sleet as reference |
 | Placing the Writer | `write-routing-placement.html` | the landed fix — rendezvous hashing, heartbeat liveness, the don't-promote rule, and why the duel is bounded rather than prevented. Five interactive SVG widgets (W1–W5), self-contained |
+| Requests, Not Bytes | `incremental-build-cost.html` | why the incremental index build inverted on staging — request-bound vs data-bound cost anatomy, measured ledger, why the read path never noticed, break-even calculator widget, and the L0–L3 fix ladder with implementation sketches |
 
 ## The interactive layer (after the [interactive-textbook skill](https://github.com/alharkan7/skills))
 

--- a/interactive/incremental-build-cost.html
+++ b/interactive/incremental-build-cost.html
@@ -1,0 +1,603 @@
+!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Requests, Not Bytes — why the incremental index build inverted</title>
+<style>
+  :root {
+    --bg: #faf9f7;
+    --ink: #1f2427;
+    --muted: #5b6670;
+    --accent: #0e6e66;
+    --accent-soft: #0e6e6614;
+    --rule: #d8d5d0;
+    --card: #ffffff;
+    --bad: #b3403a;
+    --bad-soft: #b3403a12;
+    --good: #2e6e40;
+    --good-soft: #2e6e4012;
+    --mono-bg: #f0efec;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #16191c;
+      --ink: #e4e1db;
+      --muted: #9aa4ad;
+      --accent: #4fc3b8;
+      --accent-soft: #4fc3b81a;
+      --rule: #32383d;
+      --card: #1d2125;
+      --bad: #e07a74;
+      --bad-soft: #e07a7418;
+      --good: #7dc58f;
+      --good-soft: #7dc58f16;
+      --mono-bg: #23282d;
+    }
+  }
+  :root[data-theme="light"] {
+    --bg: #faf9f7; --ink: #1f2427; --muted: #5b6670; --accent: #0e6e66;
+    --accent-soft: #0e6e6614; --rule: #d8d5d0; --card: #ffffff;
+    --bad: #b3403a; --bad-soft: #b3403a12; --good: #2e6e40; --good-soft: #2e6e4012;
+    --mono-bg: #f0efec;
+  }
+  :root[data-theme="dark"] {
+    --bg: #16191c; --ink: #e4e1db; --muted: #9aa4ad; --accent: #4fc3b8;
+    --accent-soft: #4fc3b81a; --rule: #32383d; --card: #1d2125;
+    --bad: #e07a74; --bad-soft: #e07a7418; --good: #7dc58f; --good-soft: #7dc58f16;
+    --mono-bg: #23282d;
+  }
+  * { box-sizing: border-box; }
+  html { -webkit-text-size-adjust: 100%; }
+  body {
+    margin: 0; background: var(--bg); color: var(--ink);
+    font: 17px/1.65 Charter, Georgia, 'Times New Roman', serif;
+  }
+  main { max-width: 46rem; margin: 0 auto; padding: 3rem 1.25rem 6rem; }
+  header.doc { border-bottom: 2px solid var(--ink); padding-bottom: 1.4rem; margin-bottom: 2.5rem; }
+  .eyebrow {
+    font: 600 0.72rem/1 system-ui, sans-serif; letter-spacing: 0.14em;
+    text-transform: uppercase; color: var(--accent); margin: 0 0 0.9rem;
+  }
+  h1 {
+    font-size: 2.1rem; line-height: 1.15; margin: 0 0 0.8rem;
+    letter-spacing: -0.01em; text-wrap: balance;
+  }
+  .dek { color: var(--muted); font-size: 1.05rem; margin: 0; max-width: 40rem; }
+  .meta { font: 0.78rem/1.6 system-ui, sans-serif; color: var(--muted); margin-top: 1rem; }
+  h2 {
+    font-size: 1.35rem; margin: 3rem 0 0.9rem; letter-spacing: -0.005em;
+    text-wrap: balance;
+  }
+  h2 .no { color: var(--accent); font-variant-numeric: tabular-nums; margin-right: 0.45rem; }
+  h3 { font-size: 1.02rem; margin: 1.8rem 0 0.5rem; }
+  p { margin: 0 0 1.05rem; }
+  code, pre {
+    font-family: ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
+    font-size: 0.86em;
+  }
+  code { background: var(--mono-bg); padding: 0.1em 0.35em; border-radius: 4px; }
+  pre {
+    background: var(--mono-bg); border: 1px solid var(--rule); border-radius: 8px;
+    padding: 0.9rem 1.1rem; overflow-x: auto; line-height: 1.55; margin: 0 0 1.05rem;
+  }
+  pre code { background: none; padding: 0; }
+  .scroll { overflow-x: auto; margin: 0 0 1.05rem; }
+  table {
+    border-collapse: collapse; width: 100%;
+    font: 0.85rem/1.5 system-ui, sans-serif;
+    font-variant-numeric: tabular-nums;
+  }
+  th {
+    text-align: left; font-size: 0.72rem; letter-spacing: 0.07em; text-transform: uppercase;
+    color: var(--muted); border-bottom: 2px solid var(--ink); padding: 0.4rem 0.9rem 0.4rem 0;
+  }
+  td { border-bottom: 1px solid var(--rule); padding: 0.5rem 0.9rem 0.5rem 0; vertical-align: top; }
+  tr:last-child td { border-bottom: none; }
+  .num { text-align: right; }
+  th.num { text-align: right; }
+  .callout {
+    border-left: 3px solid var(--accent); background: var(--accent-soft);
+    padding: 0.9rem 1.15rem; border-radius: 0 8px 8px 0; margin: 1.4rem 0;
+  }
+  .callout.bad { border-color: var(--bad); background: var(--bad-soft); }
+  .callout p:last-child { margin-bottom: 0; }
+  .ledger { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin: 1.4rem 0; }
+  @media (max-width: 620px) { .ledger { grid-template-columns: 1fr; } }
+  .ledger .col {
+    background: var(--card); border: 1px solid var(--rule); border-radius: 10px;
+    padding: 1rem 1.15rem;
+  }
+  .ledger h4 {
+    margin: 0 0 0.6rem; font: 600 0.78rem/1.3 system-ui, sans-serif;
+    letter-spacing: 0.08em; text-transform: uppercase;
+  }
+  .ledger .col.full h4 { color: var(--good); }
+  .ledger .col.incr h4 { color: var(--bad); }
+  .ledger ul { margin: 0; padding-left: 1.1rem; font-size: 0.92rem; }
+  .ledger li { margin-bottom: 0.35rem; }
+  .ledger .sum {
+    margin-top: 0.7rem; padding-top: 0.6rem; border-top: 1px dashed var(--rule);
+    font: 600 0.95rem/1.4 system-ui, sans-serif;
+  }
+  .full .sum { color: var(--good); }
+  .incr .sum { color: var(--bad); }
+  .diagram {
+    background: var(--card); border: 1px solid var(--rule); border-radius: 10px;
+    padding: 1.1rem 1.2rem; margin: 1.4rem 0; overflow-x: auto;
+  }
+  .diagram pre { background: none; border: none; padding: 0; margin: 0; font-size: 0.78rem; }
+  .diagram figcaption {
+    font: 0.78rem/1.5 system-ui, sans-serif; color: var(--muted);
+    margin-top: 0.8rem; border-top: 1px solid var(--rule); padding-top: 0.6rem;
+  }
+  .k { color: var(--accent); font-weight: 600; }
+  .b { color: var(--bad); font-weight: 600; }
+  .g { color: var(--good); font-weight: 600; }
+  /* calculator */
+  .calc {
+    background: var(--card); border: 1px solid var(--rule); border-radius: 10px;
+    padding: 1.2rem 1.3rem; margin: 1.6rem 0; font-family: system-ui, sans-serif;
+  }
+  .calc h4 { margin: 0 0 1rem; font-size: 0.95rem; }
+  .calc .row { display: flex; align-items: center; gap: 0.8rem; margin-bottom: 0.7rem; flex-wrap: wrap; }
+  .calc label { font-size: 0.83rem; width: 17rem; color: var(--muted); }
+  .calc input[type=range] { flex: 1; min-width: 8rem; accent-color: var(--accent); }
+  .calc output {
+    font-variant-numeric: tabular-nums; font-size: 0.85rem; width: 6.2rem;
+    text-align: right; font-weight: 600;
+  }
+  .calc .verdict {
+    margin-top: 1rem; padding-top: 0.9rem; border-top: 1px solid var(--rule);
+    display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 0.8rem; text-align: center;
+  }
+  @media (max-width: 620px) { .calc .verdict { grid-template-columns: 1fr; } }
+  .calc .verdict > div { border-radius: 8px; padding: 0.7rem 0.5rem; }
+  .calc .verdict .label { font-size: 0.68rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--muted); }
+  .calc .verdict .val { font-size: 1.25rem; font-weight: 700; font-variant-numeric: tabular-nums; }
+  .calc .vfull { background: var(--good-soft); }
+  .calc .vfull .val { color: var(--good); }
+  .calc .vincr { background: var(--bad-soft); }
+  .calc .vincr .val { color: var(--bad); }
+  .calc .vwin { background: var(--accent-soft); }
+  .calc .vwin .val { color: var(--accent); font-size: 1.02rem; padding-top: 0.2rem; }
+  .fixes { counter-reset: fix; }
+  .fix {
+    background: var(--card); border: 1px solid var(--rule); border-radius: 10px;
+    padding: 1.05rem 1.2rem; margin-bottom: 1rem;
+  }
+  .fix h4 { margin: 0 0 0.45rem; font-size: 1rem; }
+  .fix h4 .lvl {
+    display: inline-block; font: 700 0.7rem/1 system-ui, sans-serif; color: var(--accent);
+    background: var(--accent-soft); border-radius: 999px; padding: 0.3em 0.7em;
+    margin-right: 0.55rem; letter-spacing: 0.05em; vertical-align: 0.12em;
+  }
+  .fix p { font-size: 0.95rem; }
+  .fix p:last-child { margin-bottom: 0; }
+  .fix .tag { font: 0.75rem/1.4 system-ui, sans-serif; color: var(--muted); }
+  a { color: var(--accent); }
+  .footnote { font-size: 0.85rem; color: var(--muted); border-top: 1px solid var(--rule); margin-top: 3rem; padding-top: 1rem; }
+</style>
+</head>
+<body>
+<main>
+<header class="doc">
+  <p class="eyebrow">TurboLay design note</p>
+  <h1>Requests, Not Bytes</h1>
+  <p class="dek">Why loading a 100&#8239;k-edge delta got slower than scanning the whole
+  1&#8239;M-edge graph — a cost anatomy of the incremental index build, measured on
+  staging, and the design that restores the bet.</p>
+  <p class="meta">2026-08-05 · staging incident analysis · companion to
+  <code>docs/benchmarks/2026-08-03-incremental-index-build.md</code> · code refs at
+  <code>src/shard/topology_tail.rs:75</code>, <code>src/engine/index_store.rs</code></p>
+</header>
+
+<h2><span class="no">1</span>The bet, and the assumption smuggled inside it</h2>
+<p>The incremental build banks on one inequality: the change set is always far smaller
+than the graph. A million-edge graph gets a hundred thousand new edges in a busy
+half hour; touching 100&#8239;k things must beat touching 1&#8239;M things. The bet is
+correct — <em>as a statement about work per item</em>. The 5&#8239;M-edge benchmark proved
+the apply-and-re-encode side handily: 26× faster than a full rebuild.</p>
+<p>The smuggled assumption is in the word <em>loading</em>. It reads as
+&ldquo;cost&nbsp;∝&nbsp;items&rdquo;. But nothing in a storage system charges you per item.
+You are charged per <strong>request</strong>, and a request costs the same
+~50&#8239;ms against S3 whether it returns one useful edge or forty thousand. So the real
+inequality that decides the winner is:</p>
+<div class="callout">
+<p><strong>items ÷ items-per-request</strong> is what you pay — not items.
+The full scan gets its 1&#8239;M edges at ~40&#8239;k useful edges per request. The tail walk gets
+its delta at <em>~0.01 useful edges per request</em>. That is a six-orders-of-magnitude
+per-item handicap, and it flips the bet.</p>
+</div>
+
+<h2><span class="no">2</span>Where each copy of the truth lives</h2>
+<p>The same edges exist in three shapes, and the shapes — not the counts — set the price.</p>
+<figure class="diagram">
+<pre>
+S3, per scope+cell database
+┌──────────────────────────────────────────────────────────────────────┐
+│ <span class="g">SHAPE A — current state (compacted SSTs + L0)</span>                        │
+│   sorted by key, packed ~thousands of edges per block, a few big     │
+│   files · read in bulk, block-cached locally after first touch       │
+│                                                                      │
+│ <span class="b">SHAPE B — history (the WAL)</span>                                          │
+│   one tiny file per ~100 ms of write activity · time-ordered, so     │
+│   one edge type's changes are shredded across ALL of them,           │
+│   interleaved with every other edge type, property write and tomb    │
+│                                                                      │
+│ SHAPE C — the published index (CSC payload + manifest)               │
+└──────────────────────────────────────────────────────────────────────┘
+        │                                    │
+        │ replay once per visit,             │ re-download per build,
+        │ bounded span (writer ckpt → now)   │ unbounded span (prev gen → now),
+        ▼                                    ▼ once per edge type — <span class="b">×8</span>
+┌───────────────────────────┐      ┌───────────────────────────┐
+│ <span class="g">reader RAM + block cache</span>  │      │ <span class="b">topology_tail_since walk</span>  │
+│ merged key→value state    │      │ serial GET per WAL file   │
+│ (history discarded!)      │      │ (topology_tail.rs:75)     │
+└───────────┬───────────────┘      └───────────┬───────────────┘
+            │ full build scans this            │ incremental build waits on this
+            ▼                                  ▼
+      <span class="g">cost ∝ graph size</span>                <span class="b">cost ∝ write activity × RTT</span>
+</pre>
+<figcaption>Both builds run in the indexer against the same scope database. The full
+build's data source is Shape A via local state; the incremental build's <em>delta
+derivation</em> is chained to Shape B in S3. Note what the reader does with the WAL it
+replays: it folds entries into current state and <em>discards the history</em> — which is
+the only part the incremental build needed.</figcaption>
+</figure>
+<p>Three consequences fall out of Shape B being the delta source:</p>
+<p><strong>The delta is never stored as &ldquo;100&#8239;k edges you can load.&rdquo;</strong>
+It is stored as <em>N</em> tiny files where <em>N</em> counts <em>write flushes</em>, not
+edges. A tenant trickling 200 edges over 20 minutes produces ~2,000 files; a bulk load
+writing 100&#8239;k edges in 10 seconds produces ~100. Same delta size, 20× different price.
+Write <em>pattern</em>, not write volume, sets the cost.</p>
+<p><strong>The walk is serial.</strong> <code>topology_tail.rs:75</code> awaits each file
+before requesting the next: <code>span × RTT</code> wall-clock, no overlap.</p>
+<p><strong>The walk repeats.</strong> All 8 edge types share one database, the
+per-edge-type filter runs <em>after</em> download, and nothing remembers the walk between
+builds. The same file is downloaded by the reader's replay, then up to 8 more times by
+builds — 9 purchases of the same bytes, 8 discarded.</p>
+
+<h2><span class="no">3</span>The measured ledger (staging, Aug 4–5)</h2>
+<p>Same scope, same snapshot, same 1–3&#8239;k-edge graphs. Every number below is measured,
+not modeled.<sup>1</sup></p>
+<div class="ledger">
+  <div class="col full">
+    <h4>Full build · ~1 s</h4>
+    <ul>
+      <li>refresh reader — replays only <em>new</em> WAL since the writer's checkpoint; bounded, shared</li>
+      <li>pin snapshot — free</li>
+      <li>scan adjacency from RAM/block cache — <strong>zero S3 in the loop</strong></li>
+      <li>encode CSC, publish — milliseconds</li>
+    </ul>
+    <p class="sum">cost ∝ graph size · ~12&#8239;µs per edge at 5&#8239;M-edge scale</p>
+  </div>
+  <div class="col incr">
+    <h4>Incremental build · 27–302 s</h4>
+    <ul>
+      <li>same refresh + snapshot — same price</li>
+      <li>fetch previous CSC payload — 1 GET, cheap</li>
+      <li><strong>tail walk: 100–10,000 serial GETs</strong> at 40–80&#8239;ms each</li>
+      <li>apply 4–25 delta edges, re-encode — milliseconds</li>
+    </ul>
+    <p class="sum">cost ∝ WAL files since last build · ~10 s per <em>delta</em> edge</p>
+  </div>
+</div>
+<div class="scroll">
+<table>
+  <thead><tr>
+    <th>WAL files since previous build</th><th class="num">builds</th>
+    <th class="num">avg build</th><th class="num">max build</th><th class="num">graph size</th>
+  </tr></thead>
+  <tbody>
+    <tr><td>11 – 100</td><td class="num">87</td><td class="num">3.6 s</td><td class="num">9.6 s</td><td class="num">~700 edges</td></tr>
+    <tr><td>101 – 1,000</td><td class="num">140</td><td class="num">32 s</td><td class="num">112 s</td><td class="num">~1,100 edges</td></tr>
+    <tr><td>1,000 – 10,000</td><td class="num">62</td><td class="num">149 s</td><td class="num">274 s</td><td class="num">~1,000 edges</td></tr>
+    <tr><td>&gt; 10,000</td><td class="num">2</td><td class="num">191 s</td><td class="num">302 s</td><td class="num">~2,700 edges</td></tr>
+  </tbody>
+</table>
+</div>
+<p>Build time tracks the file count and is indifferent to graph size — the signature of a
+request-bound, not data-bound, workload. The slope, ~50&#8239;ms per file, is one S3
+round-trip.</p>
+
+<h2><span class="no">4</span>The request arithmetic, priced</h2>
+<p>A reasonable first analogy: <em>&ldquo;both paths hit S3; the full path just makes ~10×
+fewer GET calls and takes ~100× more data per call.&rdquo;</em> The direction is right;
+the magnitude is not even close — and the gap is not one number but three multiplied
+together: <strong>request count × useful payload × amortization</strong>.</p>
+<div class="scroll">
+<table>
+  <thead><tr>
+    <th>per build of one edge type</th><th class="num">S3 requests</th>
+    <th>payload per request</th><th class="num">useful edges / request</th><th>paid again next build?</th>
+  </tr></thead>
+  <tbody>
+    <tr><td><strong>Full, steady state</strong> (reader warm within the visit)</td>
+      <td class="num">~0 in the scan loop</td><td>— (RAM + block cache)</td>
+      <td class="num">∞, effectively</td><td>—</td></tr>
+    <tr><td><strong>Full, cold open</strong> (manifest + bounded replay + SST blocks)</td>
+      <td class="num">tens</td><td>large, densely packed — thousands of edges per fetch</td>
+      <td class="num">~10³–10⁴</td><td><span class="g">no</span> — cached for every edge type &amp; build in the visit</td></tr>
+    <tr><td><strong>Incremental tail walk</strong> (staging, measured)</td>
+      <td class="num">100 – 10,000</td><td>a few KB, mostly irrelevant entries</td>
+      <td class="num"><strong>0.002 – 0.1</strong></td><td><span class="b">yes</span> — uncached, repeated per edge type, per build</td></tr>
+  </tbody>
+</table>
+</div>
+<p>So it is not &ldquo;10× fewer calls at 100× the data.&rdquo; It is <em>tens</em> of
+amortized calls at ~10&#8239;⁴ useful edges each, versus <em>thousands</em> of unamortized calls
+at ~10&#8239;⁻² useful edges each — a per-edge price gap of six to eight orders of magnitude.</p>
+<div class="callout bad">
+<p><strong>And the &ldquo;worst case that will never happen&rdquo; happened — and was
+undershot.</strong> The intuitive worst case is one request per delta edge (a tenant
+trickling one edge per ~100&#8239;ms flush: 100&#8239;k edges → 100&#8239;k files → 100&#8239;k GETs). Staging
+measured <em>worse than one request per edge, routinely</em>: builds paid 2,000 requests
+to recover 15-edge deltas — 0.0075 useful edges per request. Two reasons: WAL files
+interleave all 8 edge types plus vertex/property writes, so most files contain
+<em>zero</em> entries for the edge type being built; and each of the 8 edge types re-walks
+the same files, dividing the useful yield again. The sub-worst case is the
+<em>common</em> case.</p>
+</div>
+
+<h2><span class="no">5</span>Two feedback loops made it worse every day</h2>
+<p><strong>Loop 1 — staleness compounds.</strong> Slow builds stretch the indexer cycle
+(7 min → 15–40 min). A longer cycle means more WAL accumulates before the next visit,
+which means a longer walk, which stretches the cycle further. Average build: 27 s on
+Aug 4, 48 s on Aug 5.</p>
+<p><strong>Loop 2 — the fleet grew under it.</strong> Registered scopes went from ~110 to
+~300 in four days, and the cycle visits every scope serially at 3–4 s each (open reader,
+establish checkpoint via manifest CAS, check dirty, close, delete checkpoint) — ~20
+minutes of fixed overhead per cycle before any build runs. Not caused by the incremental
+change, but it multiplies Loop&nbsp;1 by delaying every revisit.</p>
+<div class="callout bad">
+<p>The design hole in one sentence: the builder declines the incremental path when the
+delta is <em>unavailable</em> (a WAL file was garbage-collected) but never when it is
+merely <em>ruinously expensive</em> — it has a correctness gate and no cost gate, so it
+grinds through 10,000 round-trips to discover 15 edges rather than falling back to a
+1-second scan.</p>
+</div>
+
+<h2><span class="no">6</span>Why the read path never noticed</h2>
+<p>The obvious objection: queries use the <em>same</em> tail walk
+(<code>shard/query.rs:5525</code> calls the very same <code>topology_tail_since</code>) to
+overlay freshness onto a compiled matrix. If the walk is ruinous, reads should have been
+screaming for months. They weren't — and the reason is the design lesson of this whole
+incident, so it deserves its own anatomy.</p>
+<p>First, the objection's premise is right about one thing: <em>everyone loads data
+eventually</em>. A cold read pays the manifest, the bounded replay, and SST block fetches
+— the same cold-open tens-of-requests the full build pays. The difference is
+<em>which shape</em> each consumer <strong>depends on</strong>. Every read route
+terminates in Shape&nbsp;A — bulk, packed, cached, amortized. No read route
+<em>requires</em> Shape&nbsp;B. Reads sample the shredded history opportunistically, and
+every gate on the way out fails <em>toward</em> Shape&nbsp;A:</p>
+<div class="scroll">
+<table>
+  <thead><tr>
+    <th>gate on the matrix + overlay route</th><th>where</th><th>on failure</th>
+  </tr></thead>
+  <tbody>
+    <tr><td>1 · Sparse-kernel policy is <code>Adjacency</code> — compiled route disabled
+      wholesale</td><td><code>matrix_cache.rs:52</code></td>
+      <td>snapshot scan (Shape&nbsp;A)</td></tr>
+    <tr><td>2 · No compiled matrix cached or hydratable for the current generation</td>
+      <td><code>query.rs:5492</code></td><td>snapshot scan (Shape&nbsp;A)</td></tr>
+    <tr><td>3 · Generation already covers the read epoch — the common case when the
+      indexer keeps up</td><td><code>topology_tail.rs:65</code></td>
+      <td>empty overlay, zero walk</td></tr>
+    <tr><td>4 · Walk under way but a file is missing (GC) or the query deadline
+      (<code>QueryBudget</code>, checked per file) fires</td>
+      <td><code>topology_tail.rs:76,85</code></td>
+      <td>abort mid-walk → snapshot scan (Shape&nbsp;A)</td></tr>
+  </tbody>
+</table>
+</div>
+<p>So the read path and the incremental builder are not &ldquo;the same code, different
+luck.&rdquo; They are the same <em>walk</em> under opposite <em>contracts</em>: for a read
+the walk is an optional accelerator with an abort lever and a cheap, always-correct
+fallback standing behind it; for the builder it was the primary data source with no abort
+lever for cost — only for correctness. The builder was the only caller in the system
+<em>required</em> to finish the walk.</p>
+<p>Staging evidence that the gates, not luck, did the work: 16,500 <code>query.execute</code>
+spans over three days averaging 118&#8239;ms with p99 2.5&#8239;s, and <strong>zero</strong>
+<code>storage.wal_tail</code> spans from the nodes in seven days — the span is
+tail-sampled away unless it errors, and none errored. Which is also the uncomfortable
+part: reads were <em>silently</em> fine. If they had been quietly aborting expensive
+walks every query, the telemetry would look identical. That observability hole is a
+first-class deliverable of the fix (§8), not a footnote.</p>
+<div class="callout">
+<p><strong>The transferable lesson:</strong> any consumer of Shape&nbsp;B must either
+hold a stateful position in it (the reader's replay marker) or hold an exit to
+Shape&nbsp;A priced in advance (the read path's gates). The incremental builder shipped
+with neither — it held a <em>stateless</em> position and an exit that only opened on
+missing data, never on cost.</p>
+</div>
+
+<h2><span class="no">7</span>Feel the crossover</h2>
+<p>Incremental wins iff <code>walk cost &lt; full-scan cost</code>, i.e.
+<code>(files ÷ concurrency) × RTT &nbsp;&lt;&nbsp; edges × scan-rate</code>. Drag the
+sliders — defaults match a staging burst; set edges to 1&#8239;M and files to 18,000 to see
+your 100&#8239;k-in-30-min example.</p>
+<div class="calc" id="calc">
+  <h4>Break-even calculator</h4>
+  <div class="row"><label>Graph size (edges)</label>
+    <input type="range" id="c-edges" min="3" max="7.5" step="0.05" value="6">
+    <output id="o-edges"></output></div>
+  <div class="row"><label>WAL files since last build</label>
+    <input type="range" id="c-files" min="1" max="4.5" step="0.05" value="3.3">
+    <output id="o-files"></output></div>
+  <div class="row"><label>S3 round-trip (ms)</label>
+    <input type="range" id="c-rtt" min="1" max="80" step="1" value="50">
+    <output id="o-rtt"></output></div>
+  <div class="row"><label>Walk concurrency</label>
+    <input type="range" id="c-conc" min="0" max="5" step="1" value="0">
+    <output id="o-conc"></output></div>
+  <div class="row"><label>Edge types sharing one walk</label>
+    <input type="range" id="c-share" min="1" max="8" step="7" value="1">
+    <output id="o-share"></output></div>
+  <div class="verdict">
+    <div class="vfull"><div class="label">full scan</div><div class="val" id="v-full"></div></div>
+    <div class="vincr"><div class="label">incremental (per edge type)</div><div class="val" id="v-incr"></div></div>
+    <div class="vwin"><div class="label">verdict</div><div class="val" id="v-win"></div></div>
+  </div>
+</div>
+<p>Three things to notice while dragging. Concurrency divides the walk but never changes
+its <em>class</em> — at 18,000 files even 32-way still pays 560 sequential rounds.
+The RTT slider is why the MinIO benchmark (RTT ≈ 1&#8239;ms) missed this completely.
+And no slider setting can beat a delta source whose cost is
+<em>zero extra requests</em> — which is what Level&nbsp;2 below builds.</p>
+
+<h2><span class="no">8</span>The fix: make delta derivation obey the bet</h2>
+<p>The invariant to enforce, mechanically: <strong>the incremental path must never cost
+more than the full path — it estimates its derivation cost up front and forfeits when it
+would lose.</strong> Then, separately, shrink the derivation cost until forfeits are rare.</p>
+<div class="fixes">
+  <div class="fix">
+    <h4><span class="lvl">L0</span>Cost gate — the missing decline</h4>
+    <p>The builder already knows the span for free:
+    <code>durable_wal_id − generation.last_wal_id</code>. If
+    <code>span × RTT<sub>est</sub> &gt; full-scan<sub>est</sub></code>, decline → full
+    build → re-base. Extends the existing decline-not-guess design from correctness to
+    cost; restores the invariant <em>by construction</em>, with everything else purely
+    improving the win rate.</p>
+    <p>Lands at the top of the incremental branch in
+    <code>index_store.rs</code>, before any S3 work:</p>
+    <pre><code>let span = durable_wal_id.saturating_sub(previous.last_wal_id);
+if span &gt; max_tail_files {          // v1: static knob,
+    return self.build_full(..,       // GRAPH_INDEXER_MAX_TAIL_FILES
+        DeclineReason::TailTooExpensive).await;
+}</code></pre>
+    <p>The decline increments the existing fallback counter with a new
+    <code>reason</code> label, so the dashboard separates &ldquo;chain broken&rdquo; from
+    &ldquo;chain too long&rdquo; — today's 98-fallback panel can't tell them apart.</p>
+    <p class="tag">size: small · one PR with L1 · new decline reason on the fallback counter</p>
+  </div>
+  <div class="fix">
+    <h4><span class="lvl">L1</span>One walk, shared and concurrent</h4>
+    <p>Walk the span <em>once per scope-cell per cycle</em>, collecting affected keys for
+    all 8 edge types in a single pass (the per-type filter is a per-key string match —
+    trivially widened), fetching 16–32 files concurrently. Turns 8 × 100 s into ~6 s for
+    a 2,000-file span: a ~130× wall-clock win that changes no interface. The class stays
+    O(write activity) — L0 remains the backstop.</p>
+    <p>Mechanically: a sibling of <code>topology_tail_since</code> in
+    <code>topology_tail.rs</code> returning
+    <code>BTreeMap&lt;EdgeType, GraphTopologyOverlay&gt;</code>;
+    <code>collect_topology_entry</code> already parses the edge type out of the key, so
+    the filter widens from <code>== edge_type</code> to <code>∈ registered set</code>.
+    Fetches go through <code>futures::stream::iter(ids).map(get).buffer_unordered(N)</code>;
+    per-file iterators drain as they arrive; the per-entry sequence guards
+    (<code>seq ≤ base</code>, <code>seq &gt; read</code>) are unchanged — note the base
+    sequence differs per edge type's generation, so the shared walk keeps entries down to
+    the <em>oldest</em> base among dirty types and each type's overlay applies its own
+    guard. One subtlety: a missing file now declines <em>all</em> edge types sharing the
+    walk — which is the same outcome they'd each reach alone.</p>
+    <p class="tag">size: small-medium · same PR as L0</p>
+  </div>
+  <div class="fix">
+    <h4><span class="lvl">L2</span>Capture history where it already flows</h4>
+    <p>The reader's replay downloads every WAL file exactly once, at exactly the right
+    moment — then discards the history. Tee it instead: during replay, append topology
+    change events <code>(edge_type, src, dst, seq)</code> to a small per-scope changelog
+    the builder keeps. Delta derivation becomes a RAM lookup — zero additional S3, cost
+    ∝ delta size, the bet honored by construction.</p>
+    <p>Shape of the hook, on our SlateDB fork (we own the pin):</p>
+    <pre><code>// fork: DbReaderOptions grows an observer the replay loop invokes
+pub trait WalReplayObserver: Send + Sync {
+    fn entry(&amp;self, wal_id: u64, key: &amp;[u8], value: &amp;ValueDeletable, seq: u64);
+}
+// kernel: observer feeds a per-scope ring keyed by seq, recording
+// (edge_type, src, dst) via the same parser as collect_topology_entry.
+// Builder asks: changelog.entries_since(base_seq)
+//   → Some(delta)  if base_seq ≥ changelog.low_water  → apply, done, 0 GETs
+//   → None         otherwise                          → L0 decline → full build</code></pre>
+    <p>The changelog knows its own coverage (<code>low_water</code> = the seq where its
+    history begins), so correctness is a range check, not a hope. Memory is bounded by
+    ring size; overflow just raises <code>low_water</code> — degrading to a decline,
+    never to a wrong answer. The remaining requirement is that the changelog
+    <em>outlive the visit</em>, which points at keeping hot scopes open across cycles
+    (LRU) — the same lifecycle change that dissolves Loop&nbsp;2's 20 minutes of
+    open/close churn. After restart or eviction: L0 declines once, re-bases, resumes.
+    Same self-healing shape as the GC fallback.</p>
+    <p class="tag">size: medium, own design round · fixes both fires with one lifecycle change</p>
+  </div>
+  <div class="fix">
+    <h4><span class="lvl">L3</span>Delta-shaped generations</h4>
+    <p>The builder publishes deltas alongside periodic full generations; readers compose.
+    No consumer depends on WAL retention or replay at all. The endgame — already the
+    phase-2 plan — and unblocked, not replaced, by L0–L2.</p>
+    <p class="tag">size: large · phase 2</p>
+  </div>
+</div>
+
+<h2><span class="no">9</span>Open questions for discussion</h2>
+<p><strong>Where does the changelog live?</strong> In the builder (fork exposes a replay
+callback; kernel stays generic) or inside the fork's reader itself (reusable by the read
+path's overlay too — which today re-derives the same tail per query and survives only by
+falling back)? The second is more invasive but pays twice.</p>
+<p><strong>Keep-open LRU sizing.</strong> ~300 scopes and growing; a reader holds
+memory + a checkpoint. What's the residency budget — and should
+dirtiness (cheap S3 list) gate <em>visiting</em> at all, so quiet scopes cost nothing?</p>
+<p><strong>L0's estimator.</strong> Static file-count threshold (simple, one knob) vs
+measured EWMA of per-file RTT and per-edge scan rate (self-tuning, more moving parts)?</p>
+<p><strong>Observability debt.</strong> A <code>build_duration_seconds</code> histogram
+labeled by path, a counter for declined-for-cost, and keeping (not sampling away) the
+read path's declined-tail spans — this failure mode was invisible by construction; the
+next one shouldn't be.</p>
+
+<p class="footnote"><sup>1</sup> Sources: SigNoz traces
+(<code>artifact.build</code>, <code>artifact.publish</code> spans, Aug 1–5), Prometheus
+<code>graph_indexer_*</code> counters, indexer pod logs, staging cluster
+<code>turbolay-staging</code>. WAL-span buckets join each build's duration to
+<code>last_wal_id</code> deltas between consecutive publishes of the same scope and edge
+type. Pre-deploy baselines from Aug 1–2 full-only operation. Benchmark comparison:
+<code>docs/benchmarks/2026-08-03-incremental-index-build.md</code>.</p>
+</main>
+<script>
+(function () {
+  var $ = function (id) { return document.getElementById(id); };
+  var edges = $('c-edges'), files = $('c-files'), rtt = $('c-rtt'),
+      conc = $('c-conc'), share = $('c-share');
+  function fmtN(n) {
+    if (n >= 1e6) return (n / 1e6).toFixed(n >= 3e6 ? 0 : 1) + 'M';
+    if (n >= 1e3) return (n / 1e3).toFixed(n >= 10e3 ? 0 : 1) + 'k';
+    return String(Math.round(n));
+  }
+  function fmtS(s) {
+    if (s >= 60) return (s / 60).toFixed(1) + ' min';
+    if (s >= 1) return s.toFixed(1) + ' s';
+    return (s * 1000).toFixed(0) + ' ms';
+  }
+  function update() {
+    var E = Math.pow(10, parseFloat(edges.value));
+    var F = Math.round(Math.pow(10, parseFloat(files.value)));
+    var R = parseFloat(rtt.value) / 1000;
+    var C = Math.pow(2, parseInt(conc.value, 10));
+    var S = parseInt(share.value, 10);
+    $('o-edges').textContent = fmtN(E);
+    $('o-files').textContent = fmtN(F);
+    $('o-rtt').textContent = rtt.value + ' ms';
+    $('o-conc').textContent = C + '×';
+    $('o-share').textContent = S === 1 ? 'none' : 'all 8';
+    // full: fixed ~0.5s overhead + 12µs/edge (measured at 5M scale)
+    var full = 0.5 + E * 12e-6;
+    // incremental: fixed ~0.2s + walk, amortized across sharing edge types
+    var walk = (F / C) * R / S;
+    var incr = 0.2 + walk;
+    $('v-full').textContent = fmtS(full);
+    $('v-incr').textContent = fmtS(incr);
+    var win = $('v-win');
+    if (incr < full) {
+      win.textContent = 'incremental wins ' + (full / incr).toFixed(1) + '×';
+    } else {
+      win.textContent = 'FULL wins ' + (incr / full).toFixed(1) + '× — decline!';
+    }
+  }
+  [edges, files, rtt, conc, share].forEach(function (el) {
+    el.addEventListener('input', update);
+  });
+  update();
+})();
+</script>
+</body>
+</html>

--- a/interactive/incremental-build-cost.html
+++ b/interactive/incremental-build-cost.html
@@ -530,7 +530,60 @@ pub trait WalReplayObserver: Send + Sync {
   </div>
 </div>
 
-<h2><span class="no">9</span>Open questions for discussion</h2>
+<h2><span class="no">9</span>Landed: L0 + L1, measured on real S3</h2>
+<p>Branch <code>feat/wal-tail-cost-gate</code> implements the first two rungs
+(commit <code>80b922d</code>): the cost gate
+(<code>GraphLimits::max_wal_tail_files</code>, default 4096,
+<code>GRAPH_INDEXER_MAX_TAIL_FILES</code> in the indexer), the 16-way concurrent
+fetch (<code>GRAPH_WAL_TAIL_FETCH_CONCURRENCY</code>; <code>1</code> reproduces
+the old serial walk), and the per-shard parsed-file cache
+(<code>WalTailFileCache</code>) that lets the 8 edge types share one span's
+downloads. Declines log their reason at info. Two new regression tests pin the
+behavior: a span over the cap declines to a correct full rebuild, and the second
+edge type's walk downloads nothing.</p>
+<p>Measured against <strong>real AWS S3</strong> (bucket
+<code>hydradb-local-turbolay</code>, us-east-1) with
+<code>examples/wal_tail_trickle_bench.rs</code>, which manufactures the staging
+shape: 100&#8239;k seeded edges per type, then 500 single-edge commits per type —
+each its own WAL flush — before one build walks the span.</p>
+<div class="scroll">
+<table id="s3-results">
+  <thead><tr>
+    <th>build over the same ~1,000-file trickled span</th><th class="num">time</th><th>note</th>
+  </tr></thead>
+  <tbody>
+    <tr><td>Old serial walk (concurrency 1)</td><td class="num"><strong>&gt; 600 s, did not finish</strong></td>
+      <td>killed at the bench timeout mid-walk — the staging pathology, reproduced</td></tr>
+    <tr><td>Fixed walk (concurrency 16 + shared parse)</td><td class="num">478 s, completed</td>
+      <td>residual was ~500 <em>serial</em> cold-cache existence resolves — the next
+      bottleneck the run exposed, parallelized the same way in <code>29ba6a5</code></td></tr>
+    <tr><td>Full rebuild at the same sequence</td><td class="num">290 s</td>
+      <td>the bar both must beat</td></tr>
+    <tr><td>Later re-measure: span already collected by WAL GC</td><td class="num">312 s</td>
+      <td><strong>declined → full rebuild → correct output</strong> — the decline
+      path demonstrated end-to-end on real S3</td></tr>
+  </tbody>
+</table>
+</div>
+<p>Two honest caveats and one controlled number. The client ran far from
+us-east-1 (~300–800 ms per request — an in-cluster indexer sees 1–5 ms), so the
+<em>absolute</em> times above are inflated ~100×; the <em>ratios and outcomes</em>
+are what transfer. And because remote absolute numbers are junk for regression
+tracking, <code>examples/tail_concurrency_probe.rs</code> re-measures the walk
+under a deterministic injected latency (<code>ThrottledStore</code>, 25 ms/GET,
+100-file span): <strong>16.8 s serial vs 4.7 s fixed</strong> — the walk itself
+parallelizes ~16×, and the remaining serial cost is SlateDB's own WAL replay
+inside reader refresh, which only the L2 work can remove.</p>
+<div class="callout">
+<p><strong>A finding the benchmark threw in for free:</strong> re-opening the
+shard over the freshly trickled span stalls in SlateDB's own WAL replay — the
+open performs the same serial file-by-file walk before the database is usable.
+The indexer's per-cycle open/close of every scope pays this too, which is more
+evidence for the keep-scopes-open LRU in L2: replay cost should be paid
+incrementally by a long-lived reader, not repeatedly by fresh opens.</p>
+</div>
+
+<h2><span class="no">10</span>Open questions for discussion</h2>
 <p><strong>Where does the changelog live?</strong> In the builder (fork exposes a replay
 callback; kernel stays generic) or inside the fork's reader itself (reusable by the read
 path's overlay too — which today re-derives the same tail per query and survives only by

--- a/interactive/incremental-build-cost.html
+++ b/interactive/incremental-build-cost.html
@@ -1,4 +1,4 @@
-!doctype html>
+<!doctype html>
 <html lang="en">
 <head>
 <meta charset="utf-8">
@@ -540,7 +540,15 @@ the old serial walk), and the per-shard parsed-file cache
 (<code>WalTailFileCache</code>) that lets the 8 edge types share one span's
 downloads. Declines log their reason at info. Two new regression tests pin the
 behavior: a span over the cap declines to a correct full rebuild, and the second
-edge type's walk downloads nothing.</p>
+edge type's walk downloads nothing. A third test proves a malformed record for
+one cell or edge type cannot fail another build sharing the WAL file.</p>
+<p>The same branch now bounds the fleet-level fixed cost too. Registered scopes
+run in eight-wide batches by default, and each completed batch advances a
+CAS-protected cursor in object storage. A restart resumes after the last durable
+batch; if it stops mid-batch, that batch is replayed rather than skipped. This
+parallelizes open/check/build/close across scopes and prevents restart starvation.
+It does not keep readers open between cycles, so SlateDB replay on each fresh open
+remains the L2 opportunity described below.</p>
 <p>Measured against <strong>real AWS S3</strong> (bucket
 <code>hydradb-local-turbolay</code>, us-east-1) with
 <code>examples/wal_tail_trickle_bench.rs</code>, which manufactures the staging

--- a/interactive/incremental-build-cost.html
+++ b/interactive/incremental-build-cost.html
@@ -545,10 +545,12 @@ one cell or edge type cannot fail another build sharing the WAL file.</p>
 <p>The same branch now bounds the fleet-level fixed cost too. Registered scopes
 run in eight-wide batches by default, and each completed batch advances a
 CAS-protected cursor in object storage. A restart resumes after the last durable
-batch; if it stops mid-batch, that batch is replayed rather than skipped. This
-parallelizes open/check/build/close across scopes and prevents restart starvation.
-It does not keep readers open between cycles, so SlateDB replay on each fresh open
-remains the L2 opportunity described below.</p>
+batch; if it stops mid-batch, that batch is replayed rather than skipped. Scope
+readers remain open in a bounded LRU
+(<code>GRAPH_INDEXER_MAX_OPEN_SCOPES</code>, default 128), so a warm scope refreshes
+only newly durable WAL instead of reconstructing the same reader on every cycle.
+This parallelizes scope work, prevents restart starvation, and removes repeated
+reader-open replay from steady-state sweeps.</p>
 <p>Measured against <strong>real AWS S3</strong> (bucket
 <code>hydradb-local-turbolay</code>, us-east-1) with
 <code>examples/wal_tail_trickle_bench.rs</code>, which manufactures the staging
@@ -580,15 +582,17 @@ are what transfer. And because remote absolute numbers are junk for regression
 tracking, <code>examples/tail_concurrency_probe.rs</code> re-measures the walk
 under a deterministic injected latency (<code>ThrottledStore</code>, 25 ms/GET,
 100-file span): <strong>16.8 s serial vs 4.7 s fixed</strong> — the walk itself
-parallelizes ~16×, and the remaining serial cost is SlateDB's own WAL replay
-inside reader refresh, which only the L2 work can remove.</p>
+parallelizes ~16×. The benchmark predates the long-lived scope-reader cache, so
+its remaining reader-open replay is a cold-start cost rather than a cost paid on
+every steady-state cycle.</p>
 <div class="callout">
 <p><strong>A finding the benchmark threw in for free:</strong> re-opening the
 shard over the freshly trickled span stalls in SlateDB's own WAL replay — the
 open performs the same serial file-by-file walk before the database is usable.
-The indexer's per-cycle open/close of every scope pays this too, which is more
-evidence for the keep-scopes-open LRU in L2: replay cost should be paid
-incrementally by a long-lived reader, not repeatedly by fresh opens.</p>
+The old indexer paid this on every per-cycle scope open. The bounded keep-open
+LRU now pays it on admission and then advances the same reader incrementally.
+Eviction and process restart still make the next access cold, which is why the
+cache remains explicitly bounded and observable.</p>
 </div>
 
 <h2><span class="no">10</span>Open questions for discussion</h2>
@@ -596,9 +600,11 @@ incrementally by a long-lived reader, not repeatedly by fresh opens.</p>
 callback; kernel stays generic) or inside the fork's reader itself (reusable by the read
 path's overlay too — which today re-derives the same tail per query and survives only by
 falling back)? The second is more invasive but pays twice.</p>
-<p><strong>Keep-open LRU sizing.</strong> ~300 scopes and growing; a reader holds
-memory + a checkpoint. What's the residency budget — and should
-dirtiness (cheap S3 list) gate <em>visiting</em> at all, so quiet scopes cost nothing?</p>
+<p><strong>Keep-open LRU sizing.</strong> The default retains 128 scopes and staging
+can size the bound to its observed scope count. Reader residency is exposed by
+<code>graph_indexer_scope_cache_entries</code>, with hit, miss, eviction, and close
+failure counters. A future dirtiness gate could avoid visiting quiet scopes, but
+it is no longer required to prevent repeated full reader reconstruction.</p>
 <p><strong>L0's estimator.</strong> Static file-count threshold (simple, one knob) vs
 measured EWMA of per-file RTT and per-edge scan rate (self-tuning, more moving parts)?</p>
 <p><strong>Observability debt.</strong> A <code>build_duration_seconds</code> histogram

--- a/src/bin/graph-indexer.rs
+++ b/src/bin/graph-indexer.rs
@@ -11,8 +11,10 @@ use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use axum::routing::get;
 use axum::Router;
+use bytes::Bytes;
 use futures::StreamExt;
 use slatedb::object_store::path::Path;
+use slatedb::object_store::{ObjectStoreExt, PutMode, UpdateVersion};
 use slatedb_graph_kernel::{
     object_store_from_env, GraphCluster, GraphError, GraphId, GraphIndexBuildPath,
     GraphIndexGeneration, GraphLimits, GraphOpenOptions, GraphScope, NamespaceId, NamespacePath,
@@ -26,6 +28,20 @@ use tracing::Instrument;
 use turbolay_telemetry::{semconv, ErrorClass, Outcome, ServiceIdentity, TelemetryConfig};
 
 type RuntimeResult<T> = Result<T, Box<dyn std::error::Error + Send + Sync>>;
+
+const DEFAULT_SCOPE_CONCURRENCY: usize = 8;
+const MAX_SCOPE_CONCURRENCY: usize = 64;
+const MAX_SCOPE_CURSOR_BYTES: usize = 4_096;
+
+struct ScopeCursor {
+    last_scope: Option<String>,
+    update_version: Option<UpdateVersion>,
+}
+
+enum ScopeCursorAdvance {
+    Advanced(ScopeCursor),
+    LostRace,
+}
 
 /// One indexing failure, with the context that identifies it kept structured.
 ///
@@ -448,6 +464,17 @@ async fn main() -> RuntimeResult<()> {
     // faster incrementally. Tune per deployment cache size.
     let incremental_min_edges =
         env_value("GRAPH_INDEXER_INCREMENTAL_MIN_EDGES", "250000").parse::<u64>()?;
+    let scope_concurrency = env_value(
+        "GRAPH_INDEXER_SCOPE_CONCURRENCY",
+        &DEFAULT_SCOPE_CONCURRENCY.to_string(),
+    )
+    .parse::<usize>()?;
+    if !(1..=MAX_SCOPE_CONCURRENCY).contains(&scope_concurrency) {
+        return Err(format!(
+            "GRAPH_INDEXER_SCOPE_CONCURRENCY must be between 1 and {MAX_SCOPE_CONCURRENCY}"
+        )
+        .into());
+    }
     // The tail cost gate. Each WAL file in the span between the previous
     // generation and the durable head is one object-store round trip, and the
     // span grows with write activity, not graph size — an uncapped walk can
@@ -488,6 +515,7 @@ async fn main() -> RuntimeResult<()> {
         build_mode = build_mode.as_str(),
         incremental_min_edges,
         max_wal_tail_files,
+        scope_concurrency,
         "graph indexer started"
     );
 
@@ -515,6 +543,7 @@ async fn main() -> RuntimeResult<()> {
             retain_previous,
             build_mode,
             incremental_min_edges,
+            scope_concurrency,
             &open_options,
             &metrics,
         )
@@ -608,10 +637,18 @@ async fn run_registered_scopes_cycle(
     retain_previous: usize,
     build_mode: IndexBuildMode,
     incremental_min_edges: u64,
+    scope_concurrency: usize,
     open_options: &GraphOpenOptions,
     metrics: &IndexerMetrics,
 ) -> Result<(), CycleFailures> {
     let mut failures = CycleFailures::default();
+    if !(1..=MAX_SCOPE_CONCURRENCY).contains(&scope_concurrency) {
+        failures.push(IndexFailure::config(
+            "scope_scheduler",
+            format!("scope concurrency must be between 1 and {MAX_SCOPE_CONCURRENCY}"),
+        ));
+        return Err(failures);
+    }
 
     let discovery_span = tracing::info_span!(
         "index.scope_discovery",
@@ -619,7 +656,7 @@ async fn run_registered_scopes_cycle(
         turbolay.outcome = Empty,
         error.class = Empty,
     );
-    let scopes = match scope_directory
+    let mut scopes = match scope_directory
         .list()
         .instrument(discovery_span.clone())
         .await
@@ -641,7 +678,88 @@ async fn run_registered_scopes_cycle(
         }
     };
 
-    for scope in scopes {
+    if scopes.is_empty() {
+        return Ok(());
+    }
+
+    let cursor_path = scope_cursor_path(data_path, scope_directory.root_scope());
+    let mut cursor = match load_scope_cursor(&object_store, &cursor_path).await {
+        Ok(cursor) => cursor,
+        Err(error) => {
+            let failure = IndexFailure::kernel(
+                "scope_cursor_load",
+                format!("load indexer scope cursor {cursor_path}"),
+                &error,
+            );
+            failures.push(failure);
+            return Err(failures);
+        }
+    };
+    rotate_scopes_after(&mut scopes, cursor.last_scope.as_deref());
+
+    for batch in scopes.chunks(scope_concurrency) {
+        let batch_last_scope = batch.last().map(ToString::to_string).unwrap_or_default();
+        let runs = futures::stream::iter(batch.iter().cloned())
+            .map(|scope| {
+                run_registered_scope(
+                    data_path,
+                    scope,
+                    cells,
+                    Arc::clone(&object_store),
+                    retain_previous,
+                    build_mode,
+                    incremental_min_edges,
+                    open_options,
+                    metrics,
+                )
+            })
+            .buffer_unordered(scope_concurrency);
+        let mut runs = std::pin::pin!(runs);
+        while let Some(scope_failures) = runs.next().await {
+            failures.absorb(scope_failures);
+        }
+
+        match advance_scope_cursor(&object_store, &cursor_path, cursor, &batch_last_scope).await {
+            Ok(ScopeCursorAdvance::Advanced(next)) => cursor = next,
+            Ok(ScopeCursorAdvance::LostRace) => {
+                tracing::info!(
+                    cursor = %cursor_path,
+                    last_scope = %batch_last_scope,
+                    "another indexer advanced the scope cursor"
+                );
+                // Do not overwrite the winner with a cursor based on stale
+                // progress. Rediscovery on the next cycle resumes from the
+                // winner's durable boundary.
+                break;
+            }
+            Err(error) => {
+                failures.push(IndexFailure::kernel(
+                    "scope_cursor_advance",
+                    format!("advance indexer scope cursor {cursor_path}"),
+                    &error,
+                ));
+                break;
+            }
+        }
+    }
+
+    failures.into_result()
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn run_registered_scope(
+    data_path: &str,
+    scope: GraphScope,
+    cells: &[String],
+    object_store: Arc<dyn slatedb::object_store::ObjectStore>,
+    retain_previous: usize,
+    build_mode: IndexBuildMode,
+    incremental_min_edges: u64,
+    open_options: &GraphOpenOptions,
+    metrics: &IndexerMetrics,
+) -> CycleFailures {
+    let mut failures = CycleFailures::default();
+    {
         let scope_name = scope.to_string();
         let scope_span = tracing::info_span!(
             "index.scope",
@@ -672,12 +790,9 @@ async fn run_registered_scopes_cycle(
                 has_data_span.record("has_data", false);
                 has_data_span.record(semconv::OUTCOME, Outcome::Skipped.as_str());
                 scope_span.record(semconv::OUTCOME, Outcome::Skipped.as_str());
-                continue;
+                return failures;
             }
             Err(error) => {
-                // This used to be a `?`, which discarded every failure already
-                // accumulated on the way here. The scan still stops — no work
-                // changes — but what stops is only the scan, not the record.
                 let failure = IndexFailure::kernel(
                     "scope_has_data",
                     format!("scan scope {scope_name}"),
@@ -687,7 +802,7 @@ async fn run_registered_scopes_cycle(
                 record_failure(&has_data_span, &failure);
                 scope_span.record(semconv::OUTCOME, Outcome::Failed.as_str());
                 failures.push(failure);
-                break;
+                return failures;
             }
         }
 
@@ -724,7 +839,7 @@ async fn run_registered_scopes_cycle(
                 record_failure(&open_span, &failure);
                 scope_span.record(semconv::OUTCOME, Outcome::Failed.as_str());
                 failures.push(failure);
-                continue;
+                return failures;
             }
         };
 
@@ -771,8 +886,99 @@ async fn run_registered_scopes_cycle(
             record_success(&scope_span);
         }
     }
+    failures
+}
 
-    failures.into_result()
+fn scope_cursor_path(data_path: &str, root_scope: GraphScope) -> Path {
+    Path::from(format!(
+        "{data_path}/_graph_indexer/v1/{root_scope}/scope-cursor"
+    ))
+}
+
+fn rotate_scopes_after(scopes: &mut [GraphScope], last_scope: Option<&str>) {
+    if scopes.is_empty() {
+        return;
+    }
+    let Some(last_scope) = last_scope else {
+        return;
+    };
+    let Some(position) = scopes
+        .iter()
+        .position(|scope| scope.to_string() == last_scope)
+    else {
+        return;
+    };
+    let next = position.saturating_add(1) % scopes.len();
+    scopes.rotate_left(next);
+}
+
+async fn load_scope_cursor(
+    object_store: &Arc<dyn slatedb::object_store::ObjectStore>,
+    path: &Path,
+) -> slatedb_graph_kernel::Result<ScopeCursor> {
+    match object_store.get(path).await {
+        Ok(result) => {
+            let update_version = UpdateVersion {
+                e_tag: result.meta.e_tag.clone(),
+                version: result.meta.version.clone(),
+            };
+            let value = result.bytes().await?;
+            if value.len() > MAX_SCOPE_CURSOR_BYTES {
+                return Err(GraphError::CorruptValue {
+                    key: path.to_string(),
+                    reason: format!(
+                        "indexer scope cursor is {} bytes; maximum is {MAX_SCOPE_CURSOR_BYTES}",
+                        value.len()
+                    ),
+                });
+            }
+            let last_scope =
+                std::str::from_utf8(&value).map_err(|error| GraphError::CorruptValue {
+                    key: path.to_string(),
+                    reason: format!("indexer scope cursor is not UTF-8: {error}"),
+                })?;
+            Ok(ScopeCursor {
+                last_scope: Some(last_scope.to_string()),
+                update_version: Some(update_version),
+            })
+        }
+        Err(slatedb::object_store::Error::NotFound { .. }) => Ok(ScopeCursor {
+            last_scope: None,
+            update_version: None,
+        }),
+        Err(error) => Err(error.into()),
+    }
+}
+
+async fn advance_scope_cursor(
+    object_store: &Arc<dyn slatedb::object_store::ObjectStore>,
+    path: &Path,
+    cursor: ScopeCursor,
+    last_scope: &str,
+) -> slatedb_graph_kernel::Result<ScopeCursorAdvance> {
+    let mode = cursor
+        .update_version
+        .map_or(PutMode::Create, PutMode::Update);
+    match object_store
+        .put_opts(
+            path,
+            Bytes::copy_from_slice(last_scope.as_bytes()).into(),
+            mode.into(),
+        )
+        .await
+    {
+        Ok(result) => Ok(ScopeCursorAdvance::Advanced(ScopeCursor {
+            last_scope: Some(last_scope.to_string()),
+            update_version: Some(UpdateVersion {
+                e_tag: result.e_tag,
+                version: result.version,
+            }),
+        })),
+        Err(slatedb::object_store::Error::AlreadyExists { .. })
+        | Err(slatedb::object_store::Error::Precondition { .. })
+        | Err(slatedb::object_store::Error::NotFound { .. }) => Ok(ScopeCursorAdvance::LostRace),
+        Err(error) => Err(error.into()),
+    }
 }
 
 async fn scope_has_data(
@@ -1448,6 +1654,98 @@ mod tests {
         );
     }
 
+    #[test]
+    fn scope_order_resumes_after_the_durable_cursor() {
+        let root = NamespacePath::root(NamespaceId::new("production").unwrap());
+        let graph_id = GraphId::new("hydradb").unwrap();
+        let scope = |tenant: &str| {
+            GraphScope::new(
+                root.child(NamespaceId::new(tenant).unwrap()).unwrap(),
+                graph_id.clone(),
+            )
+        };
+        let first = scope("tenant-a");
+        let second = scope("tenant-b");
+        let third = scope("tenant-c");
+        let mut scopes = vec![first.clone(), second.clone(), third.clone()];
+
+        rotate_scopes_after(&mut scopes, Some(&second.to_string()));
+
+        assert_eq!(scopes, vec![third, first, second]);
+    }
+
+    #[tokio::test]
+    async fn scope_cursor_cas_never_overwrites_another_indexer() {
+        let object_store = Arc::new(InMemory::new()) as Arc<dyn slatedb::object_store::ObjectStore>;
+        let path = Path::from("graph/data/_graph_indexer/test/scope-cursor");
+        let first_observer = load_scope_cursor(&object_store, &path).await.unwrap();
+        let stale_observer = load_scope_cursor(&object_store, &path).await.unwrap();
+
+        let ScopeCursorAdvance::Advanced(first_cursor) =
+            advance_scope_cursor(&object_store, &path, first_observer, "scope-a")
+                .await
+                .unwrap()
+        else {
+            panic!("the first indexer must create the cursor");
+        };
+        assert!(matches!(
+            advance_scope_cursor(&object_store, &path, stale_observer, "scope-b")
+                .await
+                .unwrap(),
+            ScopeCursorAdvance::LostRace
+        ));
+        assert_eq!(
+            load_scope_cursor(&object_store, &path)
+                .await
+                .unwrap()
+                .last_scope
+                .as_deref(),
+            Some("scope-a"),
+            "a stale indexer must not replace the winning cursor"
+        );
+
+        assert!(matches!(
+            advance_scope_cursor(&object_store, &path, first_cursor, "scope-b")
+                .await
+                .unwrap(),
+            ScopeCursorAdvance::Advanced(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn scope_scheduler_rejects_unsafe_concurrency_without_panicking() {
+        let object_store = Arc::new(InMemory::new()) as Arc<dyn slatedb::object_store::ObjectStore>;
+        let root = NamespacePath::root(NamespaceId::new("production").unwrap());
+        let directory = ObjectStoreGraphScopeDirectory::new(
+            "graph/data",
+            root,
+            GraphId::new("hydradb").unwrap(),
+            Arc::clone(&object_store),
+        );
+
+        for invalid in [0, MAX_SCOPE_CONCURRENCY + 1] {
+            let failures = run_registered_scopes_cycle(
+                "graph/data",
+                &directory,
+                &["cell-0".to_string()],
+                Arc::clone(&object_store),
+                1,
+                IndexBuildMode::Full,
+                250_000,
+                invalid,
+                &GraphOpenOptions::default(),
+                &IndexerMetrics::default(),
+            )
+            .await
+            .expect_err("unsafe concurrency must be rejected before chunking scopes");
+
+            assert_eq!(
+                failures.first().map(|failure| failure.stage),
+                Some("scope_scheduler")
+            );
+        }
+    }
+
     #[tokio::test]
     async fn indexer_discovers_registered_scopes_and_ignores_empty_ones() {
         let object_store = Arc::new(InMemory::new()) as Arc<dyn slatedb::object_store::ObjectStore>;
@@ -1477,6 +1775,7 @@ mod tests {
             1,
             IndexBuildMode::Full,
             250_000,
+            1,
             &GraphOpenOptions::default(),
             &metrics,
         )
@@ -1514,6 +1813,7 @@ mod tests {
             1,
             IndexBuildMode::Full,
             250_000,
+            1,
             &GraphOpenOptions::default(),
             &metrics,
         )

--- a/src/bin/graph-indexer.rs
+++ b/src/bin/graph-indexer.rs
@@ -1,5 +1,5 @@
 use std::borrow::Cow;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::net::SocketAddr;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -21,7 +21,7 @@ use slatedb_graph_kernel::{
     ObjectStoreGraphScopeDirectory,
 };
 use tokio::net::TcpListener;
-use tokio::sync::watch;
+use tokio::sync::{watch, Mutex as AsyncMutex};
 use tokio::task::JoinHandle;
 use tracing::field::Empty;
 use tracing::Instrument;
@@ -31,6 +31,8 @@ type RuntimeResult<T> = Result<T, Box<dyn std::error::Error + Send + Sync>>;
 
 const DEFAULT_SCOPE_CONCURRENCY: usize = 8;
 const MAX_SCOPE_CONCURRENCY: usize = 64;
+const DEFAULT_MAX_OPEN_SCOPES: usize = 128;
+const MAX_OPEN_SCOPES: usize = 4_096;
 const MAX_SCOPE_CURSOR_BYTES: usize = 4_096;
 
 struct ScopeCursor {
@@ -41,6 +43,240 @@ struct ScopeCursor {
 enum ScopeCursorAdvance {
     Advanced(ScopeCursor),
     LostRace,
+}
+
+struct CachedScopeCluster {
+    cluster: Arc<GraphCluster>,
+    last_used: u64,
+}
+
+/// Long-lived read-only scope handles for the indexer.
+///
+/// Opening a SlateDB reader reconstructs its durable WAL view. Closing every
+/// scope after every five-second sweep paid that reconstruction cost over and
+/// over, even when nothing changed. This cache keeps the reader and its parsed
+/// WAL state alive, while an LRU bound prevents the indexer from retaining an
+/// unbounded number of tenant scopes.
+struct IndexerScopeCache {
+    data_path: String,
+    cells: Vec<String>,
+    object_store: Arc<dyn slatedb::object_store::ObjectStore>,
+    open_options: GraphOpenOptions,
+    max_open_scopes: usize,
+    access_clock: AtomicU64,
+    clusters: AsyncMutex<BTreeMap<GraphScope, CachedScopeCluster>>,
+    metrics: Arc<IndexerMetrics>,
+}
+
+impl IndexerScopeCache {
+    fn new(
+        data_path: String,
+        cells: Vec<String>,
+        object_store: Arc<dyn slatedb::object_store::ObjectStore>,
+        open_options: GraphOpenOptions,
+        max_open_scopes: usize,
+        metrics: Arc<IndexerMetrics>,
+    ) -> Self {
+        Self {
+            data_path,
+            cells,
+            object_store,
+            open_options,
+            max_open_scopes,
+            access_clock: AtomicU64::new(0),
+            clusters: AsyncMutex::new(BTreeMap::new()),
+            metrics,
+        }
+    }
+
+    async fn cluster_for_scope(
+        &self,
+        scope: &GraphScope,
+    ) -> slatedb_graph_kernel::Result<Arc<GraphCluster>> {
+        let access = self.access_clock.fetch_add(1, Ordering::Relaxed) + 1;
+        {
+            let mut clusters = self.clusters.lock().await;
+            if let Some(entry) = clusters.get_mut(scope) {
+                entry.last_used = access;
+                self.metrics
+                    .scope_cache_hits
+                    .fetch_add(1, Ordering::Relaxed);
+                return Ok(Arc::clone(&entry.cluster));
+            }
+        }
+
+        self.metrics
+            .scope_cache_misses
+            .fetch_add(1, Ordering::Relaxed);
+        let opened = Arc::new(
+            GraphCluster::open_cells_scoped_with_options(
+                self.data_path.clone(),
+                scope.clone(),
+                self.cells.clone(),
+                Arc::clone(&self.object_store),
+                self.open_options.clone(),
+            )
+            .await?,
+        );
+
+        let mut evicted = None;
+        let mut admission_error = None;
+        let selected = {
+            let mut clusters = self.clusters.lock().await;
+            if let Some(entry) = clusters.get_mut(scope) {
+                entry.last_used = access;
+                Some(Arc::clone(&entry.cluster))
+            } else {
+                if clusters.len() >= self.max_open_scopes {
+                    let candidate = clusters
+                        .iter()
+                        .filter(|(_, entry)| Arc::strong_count(&entry.cluster) == 1)
+                        .min_by_key(|(_, entry)| entry.last_used)
+                        .map(|(scope, _)| scope.clone());
+                    if let Some(candidate) = candidate {
+                        evicted = clusters.remove(&candidate).map(|entry| entry.cluster);
+                        self.metrics
+                            .scope_cache_evictions
+                            .fetch_add(1, Ordering::Relaxed);
+                    } else {
+                        admission_error = Some(GraphError::AdmissionRejected {
+                            operation: "indexer_open_scopes",
+                            actual: clusters.len().saturating_add(1) as u64,
+                            limit: self.max_open_scopes as u64,
+                        });
+                    }
+                }
+                if admission_error.is_some() {
+                    None
+                } else {
+                    clusters.insert(
+                        scope.clone(),
+                        CachedScopeCluster {
+                            cluster: Arc::clone(&opened),
+                            last_used: access,
+                        },
+                    );
+                    self.metrics
+                        .scope_cache_entries
+                        .store(clusters.len() as u64, Ordering::Release);
+                    Some(Arc::clone(&opened))
+                }
+            }
+        };
+
+        let Some(selected) = selected else {
+            if let Err(error) = opened.close().await {
+                self.record_close_failure(scope, "admission_rejected", &error);
+            }
+            return Err(admission_error.expect("admission error must accompany a rejected open"));
+        };
+
+        if !Arc::ptr_eq(&selected, &opened) {
+            if let Err(error) = opened.close().await {
+                self.record_close_failure(scope, "duplicate_open", &error);
+            }
+        }
+        if let Some(cluster) = evicted {
+            if let Err(error) = cluster.close().await {
+                self.record_close_failure(scope, "eviction", &error);
+            }
+        }
+        Ok(selected)
+    }
+
+    async fn invalidate(
+        &self,
+        scope: &GraphScope,
+        expected: &Arc<GraphCluster>,
+    ) -> slatedb_graph_kernel::Result<()> {
+        let removed = {
+            let mut clusters = self.clusters.lock().await;
+            let matches = clusters
+                .get(scope)
+                .is_some_and(|entry| Arc::ptr_eq(&entry.cluster, expected));
+            let removed = matches.then(|| clusters.remove(scope)).flatten();
+            self.metrics
+                .scope_cache_entries
+                .store(clusters.len() as u64, Ordering::Release);
+            removed.map(|entry| entry.cluster)
+        };
+        if let Some(cluster) = removed {
+            cluster.close().await?;
+        }
+        Ok(())
+    }
+
+    async fn invalidate_scope(&self, scope: &GraphScope) -> slatedb_graph_kernel::Result<()> {
+        let removed = {
+            let mut clusters = self.clusters.lock().await;
+            let removed = clusters.remove(scope).map(|entry| entry.cluster);
+            self.metrics
+                .scope_cache_entries
+                .store(clusters.len() as u64, Ordering::Release);
+            removed
+        };
+        if let Some(cluster) = removed {
+            cluster.close().await?;
+        }
+        Ok(())
+    }
+
+    async fn retain_registered(&self, registered: &BTreeSet<GraphScope>) {
+        let removed = {
+            let mut clusters = self.clusters.lock().await;
+            let stale = clusters
+                .iter()
+                .filter(|(scope, entry)| {
+                    !registered.contains(*scope) && Arc::strong_count(&entry.cluster) == 1
+                })
+                .map(|(scope, _)| scope.clone())
+                .collect::<Vec<_>>();
+            let removed = stale
+                .into_iter()
+                .filter_map(|scope| clusters.remove(&scope).map(|entry| (scope, entry.cluster)))
+                .collect::<Vec<_>>();
+            self.metrics
+                .scope_cache_entries
+                .store(clusters.len() as u64, Ordering::Release);
+            removed
+        };
+        for (scope, cluster) in removed {
+            if let Err(error) = cluster.close().await {
+                self.record_close_failure(&scope, "scope_removed", &error);
+            }
+        }
+    }
+
+    async fn close(&self) -> slatedb_graph_kernel::Result<()> {
+        let clusters = std::mem::take(&mut *self.clusters.lock().await);
+        self.metrics.scope_cache_entries.store(0, Ordering::Release);
+        let mut failures = Vec::new();
+        for (scope, entry) in clusters {
+            if let Err(error) = entry.cluster.close().await {
+                failures.push(format!("{scope}: {error}"));
+            }
+        }
+        if failures.is_empty() {
+            Ok(())
+        } else {
+            Err(GraphError::CorruptValue {
+                key: "indexer/scope-cache/close".to_string(),
+                reason: failures.join("; "),
+            })
+        }
+    }
+
+    fn record_close_failure(&self, scope: &GraphScope, reason: &str, error: &GraphError) {
+        self.metrics
+            .scope_cache_close_failures
+            .fetch_add(1, Ordering::Relaxed);
+        tracing::warn!(
+            turbolay.scope = %scope,
+            reason,
+            error = %error,
+            "indexer scope cache could not close reader"
+        );
+    }
 }
 
 /// One indexing failure, with the context that identifies it kept structured.
@@ -323,6 +559,11 @@ struct IndexerMetrics {
     successful_cycles: AtomicU64,
     failed_cycles: AtomicU64,
     open_failures: AtomicU64,
+    scope_cache_hits: AtomicU64,
+    scope_cache_misses: AtomicU64,
+    scope_cache_evictions: AtomicU64,
+    scope_cache_close_failures: AtomicU64,
+    scope_cache_entries: AtomicU64,
     /// `generations_published`, `generation_failures` and `generations_deleted`,
     /// keyed by `{cell_id, edge_type}`.
     ///
@@ -475,6 +716,17 @@ async fn main() -> RuntimeResult<()> {
         )
         .into());
     }
+    let max_open_scopes = env_value(
+        "GRAPH_INDEXER_MAX_OPEN_SCOPES",
+        &DEFAULT_MAX_OPEN_SCOPES.to_string(),
+    )
+    .parse::<usize>()?;
+    if !(scope_concurrency..=MAX_OPEN_SCOPES).contains(&max_open_scopes) {
+        return Err(format!(
+            "GRAPH_INDEXER_MAX_OPEN_SCOPES must be between GRAPH_INDEXER_SCOPE_CONCURRENCY ({scope_concurrency}) and {MAX_OPEN_SCOPES}"
+        )
+        .into());
+    }
     // The tail cost gate. Each WAL file in the span between the previous
     // generation and the durable head is one object-store round trip, and the
     // span grows with write activity, not graph size — an uncapped walk can
@@ -508,6 +760,14 @@ async fn main() -> RuntimeResult<()> {
         root_scope.graph_id.clone(),
         Arc::clone(&object_store),
     );
+    let scope_cache = Arc::new(IndexerScopeCache::new(
+        data_path.clone(),
+        cells.clone(),
+        Arc::clone(&object_store),
+        open_options.clone(),
+        max_open_scopes,
+        Arc::clone(&metrics),
+    ));
     let mut shutdown = Box::pin(shutdown_signal());
     tracing::info!(
         scope = %root_scope,
@@ -516,6 +776,7 @@ async fn main() -> RuntimeResult<()> {
         incremental_min_edges,
         max_wal_tail_files,
         scope_concurrency,
+        max_open_scopes,
         "graph indexer started"
     );
 
@@ -538,13 +799,12 @@ async fn main() -> RuntimeResult<()> {
         let outcome = run_registered_scopes_cycle(
             &data_path,
             &scope_directory,
-            &cells,
             Arc::clone(&object_store),
             retain_previous,
             build_mode,
             incremental_min_edges,
             scope_concurrency,
-            &open_options,
+            &scope_cache,
             &metrics,
         )
         .instrument(cycle_span.clone())
@@ -622,6 +882,7 @@ async fn main() -> RuntimeResult<()> {
         }
     }
     metrics.ready.store(false, Ordering::Release);
+    scope_cache.close().await?;
     admin.stop().await?;
     tracing::info!(scope = %root_scope, "graph indexer stopped");
     telemetry.shutdown();
@@ -632,13 +893,12 @@ async fn main() -> RuntimeResult<()> {
 async fn run_registered_scopes_cycle(
     data_path: &str,
     scope_directory: &ObjectStoreGraphScopeDirectory,
-    cells: &[String],
     object_store: Arc<dyn slatedb::object_store::ObjectStore>,
     retain_previous: usize,
     build_mode: IndexBuildMode,
     incremental_min_edges: u64,
     scope_concurrency: usize,
-    open_options: &GraphOpenOptions,
+    scope_cache: &Arc<IndexerScopeCache>,
     metrics: &IndexerMetrics,
 ) -> Result<(), CycleFailures> {
     let mut failures = CycleFailures::default();
@@ -678,6 +938,8 @@ async fn run_registered_scopes_cycle(
         }
     };
 
+    let registered = scopes.iter().cloned().collect::<BTreeSet<_>>();
+    scope_cache.retain_registered(&registered).await;
     if scopes.is_empty() {
         return Ok(());
     }
@@ -702,14 +964,11 @@ async fn run_registered_scopes_cycle(
         let runs = futures::stream::iter(batch.iter().cloned())
             .map(|scope| {
                 run_registered_scope(
-                    data_path,
                     scope,
-                    cells,
-                    Arc::clone(&object_store),
                     retain_previous,
                     build_mode,
                     incremental_min_edges,
-                    open_options,
+                    scope_cache,
                     metrics,
                 )
             })
@@ -748,14 +1007,11 @@ async fn run_registered_scopes_cycle(
 
 #[allow(clippy::too_many_arguments)]
 async fn run_registered_scope(
-    data_path: &str,
     scope: GraphScope,
-    cells: &[String],
-    object_store: Arc<dyn slatedb::object_store::ObjectStore>,
     retain_previous: usize,
     build_mode: IndexBuildMode,
     incremental_min_edges: u64,
-    open_options: &GraphOpenOptions,
+    scope_cache: &IndexerScopeCache,
     metrics: &IndexerMetrics,
 ) -> CycleFailures {
     let mut failures = CycleFailures::default();
@@ -776,9 +1032,14 @@ async fn run_registered_scope(
             turbolay.outcome = Empty,
             error.class = Empty,
         );
-        match scope_has_data(data_path, &scope, cells, &object_store)
-            .instrument(has_data_span.clone())
-            .await
+        match scope_has_data(
+            &scope_cache.data_path,
+            &scope,
+            &scope_cache.cells,
+            &scope_cache.object_store,
+        )
+        .instrument(has_data_span.clone())
+        .await
         {
             Ok(true) => {
                 has_data_span.record("has_data", true);
@@ -790,6 +1051,16 @@ async fn run_registered_scope(
                 has_data_span.record("has_data", false);
                 has_data_span.record(semconv::OUTCOME, Outcome::Skipped.as_str());
                 scope_span.record(semconv::OUTCOME, Outcome::Skipped.as_str());
+                if let Err(error) = scope_cache.invalidate_scope(&scope).await {
+                    let failure = IndexFailure::kernel(
+                        "cluster_close",
+                        format!("close empty scope {scope_name}"),
+                        &error,
+                    )
+                    .with_scope(&scope_name);
+                    record_failure(&scope_span, &failure);
+                    failures.push(failure);
+                }
                 return failures;
             }
             Err(error) => {
@@ -810,19 +1081,14 @@ async fn run_registered_scope(
             parent: &scope_span,
             "index.cluster_open",
             turbolay.scope = %scope_name,
-            cell_count = cells.len(),
+            cell_count = scope_cache.cells.len(),
             turbolay.outcome = Empty,
             error.class = Empty,
         );
-        let cluster = match GraphCluster::open_cells_scoped_with_options(
-            data_path.to_string(),
-            scope.clone(),
-            cells.to_vec(),
-            Arc::clone(&object_store),
-            open_options.clone(),
-        )
-        .instrument(open_span.clone())
-        .await
+        let cluster = match scope_cache
+            .cluster_for_scope(&scope)
+            .instrument(open_span.clone())
+            .await
         {
             Ok(cluster) => {
                 record_success(&open_span);
@@ -849,7 +1115,7 @@ async fn run_registered_scope(
         if let Err(inner) = run_index_cycle(
             &cluster,
             &scope_name,
-            cells,
+            &scope_cache.cells,
             retain_previous,
             build_mode,
             incremental_min_edges,
@@ -862,22 +1128,17 @@ async fn run_registered_scope(
             failures.absorb(inner);
         }
 
-        let close_span = tracing::info_span!(
-            parent: &scope_span,
-            "index.cluster_close",
-            turbolay.scope = %scope_name,
-            turbolay.outcome = Empty,
-            error.class = Empty,
-        );
-        if let Err(error) = cluster.close().instrument(close_span.clone()).await {
-            let failure =
-                IndexFailure::kernel("cluster_close", format!("close scope {scope_name}"), &error)
-                    .with_scope(&scope_name);
-            record_failure(&close_span, &failure);
-            scope_failed = true;
-            failures.push(failure);
-        } else {
-            record_success(&close_span);
+        if scope_failed {
+            if let Err(error) = scope_cache.invalidate(&scope, &cluster).await {
+                let failure = IndexFailure::kernel(
+                    "cluster_close",
+                    format!("close failed scope {scope_name}"),
+                    &error,
+                )
+                .with_scope(&scope_name);
+                record_failure(&scope_span, &failure);
+                failures.push(failure);
+            }
         }
 
         if scope_failed {
@@ -1457,12 +1718,27 @@ fn render_metrics(metrics: &IndexerMetrics) -> String {
             "graph_indexer_failed_cycles {}\n",
             "# TYPE graph_indexer_open_failures counter\n",
             "graph_indexer_open_failures {}\n",
+            "# TYPE graph_indexer_scope_cache_hits counter\n",
+            "graph_indexer_scope_cache_hits {}\n",
+            "# TYPE graph_indexer_scope_cache_misses counter\n",
+            "graph_indexer_scope_cache_misses {}\n",
+            "# TYPE graph_indexer_scope_cache_evictions counter\n",
+            "graph_indexer_scope_cache_evictions {}\n",
+            "# TYPE graph_indexer_scope_cache_close_failures counter\n",
+            "graph_indexer_scope_cache_close_failures {}\n",
+            "# TYPE graph_indexer_scope_cache_entries gauge\n",
+            "graph_indexer_scope_cache_entries {}\n",
         ),
         u8::from(metrics.ready.load(Ordering::Acquire)),
         metrics.cycles.load(Ordering::Relaxed),
         metrics.successful_cycles.load(Ordering::Relaxed),
         metrics.failed_cycles.load(Ordering::Relaxed),
         metrics.open_failures.load(Ordering::Relaxed),
+        metrics.scope_cache_hits.load(Ordering::Relaxed),
+        metrics.scope_cache_misses.load(Ordering::Relaxed),
+        metrics.scope_cache_evictions.load(Ordering::Relaxed),
+        metrics.scope_cache_close_failures.load(Ordering::Relaxed),
+        metrics.scope_cache_entries.load(Ordering::Acquire),
     );
     append_dimensioned(&mut output, &metrics.dimensioned_snapshot());
     output.push_str(&format!(
@@ -1632,6 +1908,21 @@ mod tests {
 
     use super::*;
 
+    fn test_scope_cache(
+        object_store: Arc<dyn slatedb::object_store::ObjectStore>,
+        metrics: Arc<IndexerMetrics>,
+        max_open_scopes: usize,
+    ) -> Arc<IndexerScopeCache> {
+        Arc::new(IndexerScopeCache::new(
+            "graph/data".to_string(),
+            vec!["cell-0".to_string()],
+            object_store,
+            GraphOpenOptions::default(),
+            max_open_scopes,
+            metrics,
+        ))
+    }
+
     /// The kill switch defaults to the pre-existing behaviour, and refuses a
     /// spelling it does not understand rather than silently choosing one — an
     /// operator who typos `incremenal` during an incident must be told, not
@@ -1713,6 +2004,37 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn scope_cache_reuses_and_evicts_idle_readers() {
+        let object_store = Arc::new(InMemory::new()) as Arc<dyn slatedb::object_store::ObjectStore>;
+        let metrics = Arc::new(IndexerMetrics::default());
+        let cache = test_scope_cache(object_store, Arc::clone(&metrics), 1);
+        let root = NamespacePath::root(NamespaceId::new("production").unwrap());
+        let first_scope = GraphScope::new(
+            root.child(NamespaceId::new("tenant-a").unwrap()).unwrap(),
+            GraphId::new("hydradb").unwrap(),
+        );
+        let second_scope = GraphScope::new(
+            root.child(NamespaceId::new("tenant-b").unwrap()).unwrap(),
+            GraphId::new("hydradb").unwrap(),
+        );
+
+        let first = cache.cluster_for_scope(&first_scope).await.unwrap();
+        let reused = cache.cluster_for_scope(&first_scope).await.unwrap();
+        assert!(Arc::ptr_eq(&first, &reused));
+        drop(first);
+        drop(reused);
+
+        let second = cache.cluster_for_scope(&second_scope).await.unwrap();
+        drop(second);
+
+        assert_eq!(metrics.scope_cache_hits.load(Ordering::Relaxed), 1);
+        assert_eq!(metrics.scope_cache_misses.load(Ordering::Relaxed), 2);
+        assert_eq!(metrics.scope_cache_evictions.load(Ordering::Relaxed), 1);
+        assert_eq!(metrics.scope_cache_entries.load(Ordering::Acquire), 1);
+        cache.close().await.unwrap();
+    }
+
+    #[tokio::test]
     async fn scope_scheduler_rejects_unsafe_concurrency_without_panicking() {
         let object_store = Arc::new(InMemory::new()) as Arc<dyn slatedb::object_store::ObjectStore>;
         let root = NamespacePath::root(NamespaceId::new("production").unwrap());
@@ -1722,19 +2044,20 @@ mod tests {
             GraphId::new("hydradb").unwrap(),
             Arc::clone(&object_store),
         );
+        let metrics = Arc::new(IndexerMetrics::default());
+        let cache = test_scope_cache(Arc::clone(&object_store), Arc::clone(&metrics), 1);
 
         for invalid in [0, MAX_SCOPE_CONCURRENCY + 1] {
             let failures = run_registered_scopes_cycle(
                 "graph/data",
                 &directory,
-                &["cell-0".to_string()],
                 Arc::clone(&object_store),
                 1,
                 IndexBuildMode::Full,
                 250_000,
                 invalid,
-                &GraphOpenOptions::default(),
-                &IndexerMetrics::default(),
+                &cache,
+                &metrics,
             )
             .await
             .expect_err("unsafe concurrency must be rejected before chunking scopes");
@@ -1765,18 +2088,18 @@ mod tests {
             Arc::clone(&object_store),
         );
         directory.register(&scope).await.unwrap();
-        let metrics = IndexerMetrics::default();
+        let metrics = Arc::new(IndexerMetrics::default());
+        let cache = test_scope_cache(Arc::clone(&object_store), Arc::clone(&metrics), 1);
 
         run_registered_scopes_cycle(
             "graph/data",
             &directory,
-            &["cell-0".to_string()],
             Arc::clone(&object_store),
             1,
             IndexBuildMode::Full,
             250_000,
             1,
-            &GraphOpenOptions::default(),
+            &cache,
             &metrics,
         )
         .await
@@ -1808,13 +2131,48 @@ mod tests {
         run_registered_scopes_cycle(
             "graph/data",
             &directory,
-            &["cell-0".to_string()],
             Arc::clone(&object_store),
             1,
             IndexBuildMode::Full,
             250_000,
             1,
-            &GraphOpenOptions::default(),
+            &cache,
+            &metrics,
+        )
+        .await
+        .unwrap();
+
+        let writer = GraphCluster::open_cells_standalone_writers_scoped(
+            "graph/data",
+            scope.clone(),
+            ["cell-0"],
+            Arc::clone(&object_store),
+        )
+        .await
+        .unwrap();
+        writer
+            .shard("cell-0")
+            .unwrap()
+            .write_edge(EdgeMutation {
+                cell_id: "cell-0".to_string(),
+                edge_type: "FOLLOWS".to_string(),
+                src: 2,
+                dst: 3,
+                idempotency_key: "indexer-scope-later-write".to_string(),
+            })
+            .await
+            .unwrap();
+        writer.close().await.unwrap();
+
+        run_registered_scopes_cycle(
+            "graph/data",
+            &directory,
+            Arc::clone(&object_store),
+            1,
+            IndexBuildMode::Full,
+            250_000,
+            1,
+            &cache,
             &metrics,
         )
         .await
@@ -1824,33 +2182,45 @@ mod tests {
             BTreeMap::from([(
                 ("cell-0".to_string(), "FOLLOWS".to_string()),
                 DimensionedCounters {
-                    generations_published: 1,
+                    generations_published: 2,
                     generation_failures: 0,
                     generations_deleted: 0,
-                    // One edge (1 -> 2) in the published generation, scanned
-                    // by the full build that produced it.
-                    full_build_edges: 1,
+                    // The warm cached reader must refresh before the second
+                    // build, so it scans one edge and then both edges.
+                    full_build_edges: 3,
                     incremental_delta_edges: 0,
                     incremental_fallbacks: 0,
                 },
             )]),
             "the publish should be attributed to the cell and edge type that produced it",
         );
+        assert_eq!(metrics.scope_cache_misses.load(Ordering::Relaxed), 1);
+        assert_eq!(metrics.scope_cache_hits.load(Ordering::Relaxed), 1);
+        assert_eq!(metrics.scope_cache_entries.load(Ordering::Acquire), 1);
 
-        let reader = GraphCluster::open_cells_scoped("graph/data", scope, ["cell-0"], object_store)
-            .await
-            .unwrap();
-        assert!(reader
-            .shard("cell-0")
-            .unwrap()
-            .current_graph_index("cell-0", "FOLLOWS")
-            .await
-            .unwrap()
-            .is_some());
+        let reader = GraphCluster::open_cells_scoped(
+            "graph/data",
+            scope,
+            ["cell-0"],
+            Arc::clone(&object_store),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            reader
+                .shard("cell-0")
+                .unwrap()
+                .current_graph_index("cell-0", "FOLLOWS")
+                .await
+                .unwrap()
+                .map(|generation| generation.edge_count),
+            Some(2)
+        );
         reader.close().await.unwrap();
+        cache.close().await.unwrap();
     }
 
-    /// The fourteen series a scrape sees when nothing has been indexed yet.
+    /// Every series a scrape sees when nothing has been indexed yet.
     ///
     /// Pinned in full rather than probed, because the point of this change is
     /// that the process-global half did *not* move: `ready` through
@@ -1876,6 +2246,16 @@ mod tests {
                 "graph_indexer_failed_cycles 0\n",
                 "# TYPE graph_indexer_open_failures counter\n",
                 "graph_indexer_open_failures 0\n",
+                "# TYPE graph_indexer_scope_cache_hits counter\n",
+                "graph_indexer_scope_cache_hits 0\n",
+                "# TYPE graph_indexer_scope_cache_misses counter\n",
+                "graph_indexer_scope_cache_misses 0\n",
+                "# TYPE graph_indexer_scope_cache_evictions counter\n",
+                "graph_indexer_scope_cache_evictions 0\n",
+                "# TYPE graph_indexer_scope_cache_close_failures counter\n",
+                "graph_indexer_scope_cache_close_failures 0\n",
+                "# TYPE graph_indexer_scope_cache_entries gauge\n",
+                "graph_indexer_scope_cache_entries 0\n",
                 "# TYPE graph_indexer_generations_published counter\n",
                 "# TYPE graph_indexer_generation_failures counter\n",
                 "# TYPE graph_indexer_generations_deleted counter\n",

--- a/src/bin/graph-indexer.rs
+++ b/src/bin/graph-indexer.rs
@@ -15,7 +15,8 @@ use futures::StreamExt;
 use slatedb::object_store::path::Path;
 use slatedb_graph_kernel::{
     object_store_from_env, GraphCluster, GraphError, GraphId, GraphIndexBuildPath,
-    GraphIndexGeneration, GraphScope, NamespaceId, NamespacePath, ObjectStoreGraphScopeDirectory,
+    GraphIndexGeneration, GraphLimits, GraphOpenOptions, GraphScope, NamespaceId, NamespacePath,
+    ObjectStoreGraphScopeDirectory,
 };
 use tokio::net::TcpListener;
 use tokio::sync::watch;
@@ -447,6 +448,25 @@ async fn main() -> RuntimeResult<()> {
     // faster incrementally. Tune per deployment cache size.
     let incremental_min_edges =
         env_value("GRAPH_INDEXER_INCREMENTAL_MIN_EDGES", "250000").parse::<u64>()?;
+    // The tail cost gate. Each WAL file in the span between the previous
+    // generation and the durable head is one object-store round trip, and the
+    // span grows with write activity, not graph size — an uncapped walk can
+    // spend minutes deriving a delta of a few edges (the staging regression
+    // behind `interactive/incremental-build-cost.html`). Past the cap the
+    // incremental attempt declines and the full rebuild runs instead, which
+    // past that point is the cheaper of the two.
+    let max_wal_tail_files = env_value(
+        "GRAPH_INDEXER_MAX_TAIL_FILES",
+        &GraphLimits::default().max_wal_tail_files.to_string(),
+    )
+    .parse::<u64>()?;
+    // `GraphOpenOptions` is `#[non_exhaustive]`: constructed from `default()`
+    // with fields assigned, per its own docs.
+    let mut open_options = GraphOpenOptions::default();
+    open_options.limits = GraphLimits {
+        max_wal_tail_files,
+        ..GraphLimits::default()
+    };
     let admin_addr = env_value("GRAPH_INDEXER_ADMIN_ADDR", "0.0.0.0:9091").parse::<SocketAddr>()?;
 
     let metrics = Arc::new(IndexerMetrics::default());
@@ -467,6 +487,7 @@ async fn main() -> RuntimeResult<()> {
         ?cells,
         build_mode = build_mode.as_str(),
         incremental_min_edges,
+        max_wal_tail_files,
         "graph indexer started"
     );
 
@@ -494,6 +515,7 @@ async fn main() -> RuntimeResult<()> {
             retain_previous,
             build_mode,
             incremental_min_edges,
+            &open_options,
             &metrics,
         )
         .instrument(cycle_span.clone())
@@ -586,6 +608,7 @@ async fn run_registered_scopes_cycle(
     retain_previous: usize,
     build_mode: IndexBuildMode,
     incremental_min_edges: u64,
+    open_options: &GraphOpenOptions,
     metrics: &IndexerMetrics,
 ) -> Result<(), CycleFailures> {
     let mut failures = CycleFailures::default();
@@ -676,11 +699,12 @@ async fn run_registered_scopes_cycle(
             turbolay.outcome = Empty,
             error.class = Empty,
         );
-        let cluster = match GraphCluster::open_cells_scoped(
+        let cluster = match GraphCluster::open_cells_scoped_with_options(
             data_path.to_string(),
             scope.clone(),
             cells.to_vec(),
             Arc::clone(&object_store),
+            open_options.clone(),
         )
         .instrument(open_span.clone())
         .await
@@ -1453,6 +1477,7 @@ mod tests {
             1,
             IndexBuildMode::Full,
             250_000,
+            &GraphOpenOptions::default(),
             &metrics,
         )
         .await
@@ -1489,6 +1514,7 @@ mod tests {
             1,
             IndexBuildMode::Full,
             250_000,
+            &GraphOpenOptions::default(),
             &metrics,
         )
         .await

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -25,6 +25,16 @@ pub struct GraphLimits {
     pub max_query_index_candidates: usize,
     pub max_query_scan_edges: u64,
     pub max_query_runtime_ms: Option<u64>,
+    /// Cost cap on the WAL tail walk: the most WAL files a single
+    /// `topology_tail_since` may read. Every file is one object-store
+    /// round trip, and the span between an old index generation and the
+    /// durable head grows with write *activity* (one file per WAL flush),
+    /// not with graph size — so an uncapped walk can cost minutes to
+    /// derive a delta of a few edges. Past the cap the tail declines
+    /// (`Unavailable`), which sends the incremental index build to the
+    /// full rebuild and the read path to snapshot adjacency: both cheaper
+    /// than the walk the cap refused.
+    pub max_wal_tail_files: u64,
 }
 
 impl Default for GraphLimits {
@@ -39,6 +49,10 @@ impl Default for GraphLimits {
             max_query_index_candidates: 250_000,
             max_query_scan_edges: 1_000_000,
             max_query_runtime_ms: Some(30_000),
+            // ~4096 files at 16-way concurrency is ~13 s of tail fetches
+            // against real S3 — below a full rebuild at the scales where
+            // the incremental path is worth attempting at all.
+            max_wal_tail_files: 4_096,
         }
     }
 }

--- a/src/core/state.rs
+++ b/src/core/state.rs
@@ -102,6 +102,7 @@ pub struct GraphShard {
         Mutex<BoundedGraphCache<RelationshipPropertyRowsCacheKey, RelationshipRowsCacheValue>>,
     #[cfg(feature = "opencypher")]
     pub(crate) native_path_page_cursors: Mutex<NativePathPageCursorStore>,
+    pub(crate) wal_tail_file_cache: Mutex<crate::shard::topology_tail::WalTailFileCache>,
 }
 
 #[derive(Clone)]

--- a/src/engine/cluster.rs
+++ b/src/engine/cluster.rs
@@ -34,8 +34,25 @@ impl GraphCluster {
         cell_ids: impl IntoIterator<Item = impl Into<String>>,
         object_store: Arc<dyn ObjectStore>,
     ) -> Result<Self> {
+        Self::open_cells_scoped_with_options(
+            base_path,
+            scope,
+            cell_ids,
+            object_store,
+            GraphOpenOptions::default(),
+        )
+        .await
+    }
+
+    pub async fn open_cells_scoped_with_options(
+        base_path: impl Into<String>,
+        scope: GraphScope,
+        cell_ids: impl IntoIterator<Item = impl Into<String>>,
+        object_store: Arc<dyn ObjectStore>,
+        options: GraphOpenOptions,
+    ) -> Result<Self> {
         let store_path = scope.scoped_store_path(&base_path.into());
-        Self::open_cells_at_path(store_path, scope, cell_ids, object_store, false).await
+        Self::open_cells_at_path(store_path, scope, cell_ids, object_store, false, options).await
     }
 
     pub async fn open_cells_standalone_writers(
@@ -59,7 +76,15 @@ impl GraphCluster {
         object_store: Arc<dyn ObjectStore>,
     ) -> Result<Self> {
         let store_path = scope.scoped_store_path(&base_path.into());
-        Self::open_cells_at_path(store_path, scope, cell_ids, object_store, true).await
+        Self::open_cells_at_path(
+            store_path,
+            scope,
+            cell_ids,
+            object_store,
+            true,
+            GraphOpenOptions::default(),
+        )
+        .await
     }
 
     async fn open_cells_at_path(
@@ -68,6 +93,7 @@ impl GraphCluster {
         cell_ids: impl IntoIterator<Item = impl Into<String>>,
         object_store: Arc<dyn ObjectStore>,
         writable: bool,
+        options: GraphOpenOptions,
     ) -> Result<Self> {
         let cell_ids = cell_ids
             .into_iter()
@@ -80,9 +106,15 @@ impl GraphCluster {
         for cell_id in cell_ids {
             let path = format!("{base_path}/{cell_id}");
             let opened = if writable {
-                GraphShard::open_standalone_writer(path, Arc::clone(&object_store)).await
+                GraphShard::open_standalone_writer_with_options(
+                    path,
+                    Arc::clone(&object_store),
+                    options.clone(),
+                )
+                .await
             } else {
-                GraphShard::open(path, Arc::clone(&object_store)).await
+                GraphShard::open_with_options(path, Arc::clone(&object_store), options.clone())
+                    .await
             };
             let shard = match opened {
                 Ok(shard) => shard,

--- a/src/engine/index_store.rs
+++ b/src/engine/index_store.rs
@@ -243,12 +243,35 @@ impl GraphShard {
             Err(GraphError::AdmissionRejected {
                 operation: "graph_index_wal_affected_edges",
                 ..
-            }) => return Ok(None),
+            }) => {
+                tracing::info!(
+                    cell_id,
+                    edge_type,
+                    reason = "delta_exceeds_scan_limit",
+                    "incremental index build declined; falling back to full rebuild"
+                );
+                return Ok(None);
+            }
             Err(error) => return Err(error),
         };
         let overlay = match tail {
             crate::shard::topology_tail::GraphTopologyTail::Complete(overlay) => overlay,
             crate::shard::topology_tail::GraphTopologyTail::Unavailable => {
+                // Either a WAL file spanning the gap was collected (the delta
+                // is unrecoverable) or the span exceeded
+                // `max_wal_tail_files` (the delta is recoverable but costs
+                // more round trips than the rebuild it would save — the
+                // staging regression in
+                // `interactive/incremental-build-cost.html`). The tail logs
+                // which at debug; either way the full rebuild is the answer.
+                tracing::info!(
+                    cell_id,
+                    edge_type,
+                    wal_span = last_wal_id.saturating_sub(previous.last_wal_id),
+                    wal_span_limit = self.limits.max_wal_tail_files,
+                    reason = "wal_tail_unavailable_or_capped",
+                    "incremental index build declined; falling back to full rebuild"
+                );
                 return Ok(None);
             }
         };
@@ -259,7 +282,16 @@ impl GraphShard {
         let mut adjacency: crate::sparse_kernel::Adjacency =
             match self.graph_index_csc(&previous).await? {
                 Some(csc) => csc.to_adjacency()?,
-                None => return Ok(None),
+                None => {
+                    tracing::info!(
+                        cell_id,
+                        edge_type,
+                        generation = %previous.generation,
+                        reason = "previous_payload_missing",
+                        "incremental index build declined; falling back to full rebuild"
+                    );
+                    return Ok(None);
+                }
             };
         // Apply the overlay. Entries are resolved final states, not
         // operations, so order does not matter and re-application is

--- a/src/shard/lifecycle.rs
+++ b/src/shard/lifecycle.rs
@@ -225,6 +225,7 @@ impl GraphShard {
             )),
             #[cfg(feature = "opencypher")]
             native_path_page_cursors: Mutex::new(Default::default()),
+            wal_tail_file_cache: Mutex::new(Default::default()),
         })
     }
 

--- a/src/shard/topology_tail.rs
+++ b/src/shard/topology_tail.rs
@@ -85,14 +85,45 @@ impl GraphTopologyOverlay {
 /// Parsed for *every* cell and edge type in the file, not just the caller's:
 /// all edge types share one database, so a per-caller parse would re-download
 /// and re-parse the same file once per edge type. Callers filter by
-/// `cell_id`/`edge_type`/`seq` at use time.
+/// `cell_id`/`edge_type`/`seq` at use time. Corruption is retained as an entry
+/// owned by the record's cell and edge type, then raised only if that owner is
+/// requested. A malformed REPLIES record must not break a CHAIN build that
+/// happens to share its WAL file.
 #[derive(Clone, Debug)]
 pub(crate) struct WalTopologyEntry {
     pub(crate) cell_id: String,
     pub(crate) edge_type: String,
-    pub(crate) src: VertexId,
-    pub(crate) dst: VertexId,
     pub(crate) seq: u64,
+    decoded: WalTopologyEntryDecoded,
+}
+
+#[derive(Clone, Debug)]
+enum WalTopologyEntryDecoded {
+    Edge { src: VertexId, dst: VertexId },
+    Corrupt { key: String, reason: String },
+}
+
+impl WalTopologyEntry {
+    fn affected_edge_for(
+        &self,
+        generation: &crate::GraphIndexGeneration,
+        read_sequence: StorageSequence,
+    ) -> Result<Option<(VertexId, VertexId)>> {
+        if self.seq <= generation.base_sequence
+            || self.seq > read_sequence
+            || self.cell_id != generation.cell_id
+            || self.edge_type != generation.edge_type
+        {
+            return Ok(None);
+        }
+        match &self.decoded {
+            WalTopologyEntryDecoded::Edge { src, dst } => Ok(Some((*src, *dst))),
+            WalTopologyEntryDecoded::Corrupt { key, reason } => Err(GraphError::CorruptValue {
+                key: key.clone(),
+                reason: reason.clone(),
+            }),
+        }
+    }
 }
 
 /// Per-shard cache of parsed WAL files, keyed by WAL id.
@@ -243,7 +274,7 @@ impl GraphShard {
                                 &entry.value,
                                 entry.seq,
                                 &mut parsed,
-                            )?;
+                            );
                         }
                         Ok::<_, crate::GraphError>((wal_id, WalFileFetch::Parsed(parsed)))
                     }
@@ -274,13 +305,10 @@ impl GraphShard {
         for parsed in files.values() {
             for entry in parsed.iter() {
                 budget.check("graph_index_wal_entry")?;
-                if entry.seq <= generation.base_sequence || entry.seq > read_sequence {
+                let Some(edge) = entry.affected_edge_for(generation, read_sequence)? else {
                     continue;
-                }
-                if entry.cell_id != generation.cell_id || entry.edge_type != generation.edge_type {
-                    continue;
-                }
-                affected.insert((entry.src, entry.dst));
+                };
+                affected.insert(edge);
                 ensure_limit(
                     "graph_index_wal_affected_edges",
                     affected.len() as u64,
@@ -332,50 +360,81 @@ fn collect_wal_topology_entry(
     value: &ValueDeletable,
     seq: u64,
     parsed: &mut Vec<WalTopologyEntry>,
-) -> Result<()> {
+) {
     let Ok(key) = std::str::from_utf8(key) else {
-        return Ok(());
+        return;
     };
     let fields = key.split('/').collect::<Vec<_>>();
     match fields.as_slice() {
         ["cell", cell, "e", "out", edge_type, src, dst] => {
-            parsed.push(WalTopologyEntry {
-                cell_id: (*cell).to_string(),
-                edge_type: (*edge_type).to_string(),
-                src: parse_u64(key, src, "src")?,
-                dst: parse_u64(key, dst, "dst")?,
-                seq,
-            });
+            push_wal_topology_edge(parsed, cell, edge_type, key, src, dst, seq);
         }
         ["cell", cell, "seg", "tomb", "out", edge_type, src, dst] => {
-            parsed.push(WalTopologyEntry {
-                cell_id: (*cell).to_string(),
-                edge_type: (*edge_type).to_string(),
-                src: parse_u64(key, src, "src")?,
-                dst: parse_u64(key, dst, "dst")?,
-                seq,
-            });
+            push_wal_topology_edge(parsed, cell, edge_type, key, src, dst, seq);
         }
         ["cell", cell, "seg", "out", edge_type, _, _, _] => {
             if let Some(value) = value.as_bytes() {
-                let segment = decode_out_edge_segment(key, &value)?;
-                parsed.extend(
-                    segment
-                        .destinations
-                        .into_iter()
-                        .map(|dst| WalTopologyEntry {
+                match decode_out_edge_segment(key, &value) {
+                    Ok(segment) => parsed.extend(segment.destinations.into_iter().map(|dst| {
+                        WalTopologyEntry {
                             cell_id: (*cell).to_string(),
                             edge_type: (*edge_type).to_string(),
-                            src: segment.src,
-                            dst,
                             seq,
-                        }),
-                );
+                            decoded: WalTopologyEntryDecoded::Edge {
+                                src: segment.src,
+                                dst,
+                            },
+                        }
+                    })),
+                    Err(error) => {
+                        parsed.push(corrupt_wal_topology_entry(cell, edge_type, key, seq, error))
+                    }
+                }
             }
         }
         _ => {}
     }
-    Ok(())
+}
+
+fn push_wal_topology_edge(
+    parsed: &mut Vec<WalTopologyEntry>,
+    cell_id: &str,
+    edge_type: &str,
+    key: &str,
+    src: &str,
+    dst: &str,
+    seq: u64,
+) {
+    let decoded =
+        parse_u64(key, src, "src").and_then(|src| parse_u64(key, dst, "dst").map(|dst| (src, dst)));
+    parsed.push(match decoded {
+        Ok((src, dst)) => WalTopologyEntry {
+            cell_id: cell_id.to_string(),
+            edge_type: edge_type.to_string(),
+            seq,
+            decoded: WalTopologyEntryDecoded::Edge { src, dst },
+        },
+        Err(error) => corrupt_wal_topology_entry(cell_id, edge_type, key, seq, error),
+    });
+}
+
+fn corrupt_wal_topology_entry(
+    cell_id: &str,
+    edge_type: &str,
+    fallback_key: &str,
+    seq: u64,
+    error: GraphError,
+) -> WalTopologyEntry {
+    let (key, reason) = match error {
+        GraphError::CorruptValue { key, reason } => (key, reason),
+        error => (fallback_key.to_string(), error.to_string()),
+    };
+    WalTopologyEntry {
+        cell_id: cell_id.to_string(),
+        edge_type: edge_type.to_string(),
+        seq,
+        decoded: WalTopologyEntryDecoded::Corrupt { key, reason },
+    }
 }
 
 pub(crate) fn expand_range_with_overlay(
@@ -436,4 +495,62 @@ pub(crate) fn expand_range_with_overlay(
         // The overlay walk runs on whichever compiled kernel the matrix baked in.
         backend: crate::sparse_kernel::compiled_graphblas_kernel(compiled),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn malformed_wal_topology_isolated_to_its_cell_and_edge_type() {
+        let mut parsed = Vec::new();
+        collect_wal_topology_entry(
+            b"cell/cell-a/e/out/CHAIN/1/2",
+            &ValueDeletable::Tombstone,
+            11,
+            &mut parsed,
+        );
+        collect_wal_topology_entry(
+            b"cell/cell-a/e/out/REPLIES/not-a-vertex/9",
+            &ValueDeletable::Tombstone,
+            12,
+            &mut parsed,
+        );
+        collect_wal_topology_entry(
+            b"cell/cell-b/e/out/CHAIN/also-bad/8",
+            &ValueDeletable::Tombstone,
+            13,
+            &mut parsed,
+        );
+
+        let generation = crate::GraphIndexGeneration {
+            cell_id: "cell-a".to_string(),
+            edge_type: "CHAIN".to_string(),
+            base_sequence: 10,
+            last_wal_id: 0,
+            edge_count: 0,
+            checksum: 0,
+            generation: "fault-isolation".to_string(),
+        };
+        let affected = parsed
+            .iter()
+            .map(|entry| entry.affected_edge_for(&generation, 13))
+            .collect::<Result<Vec<_>>>()
+            .expect("unrelated malformed records must not fail CHAIN in cell-a");
+        assert_eq!(
+            affected.into_iter().flatten().collect::<Vec<_>>(),
+            vec![(1, 2)]
+        );
+
+        let malformed_generation = crate::GraphIndexGeneration {
+            edge_type: "REPLIES".to_string(),
+            ..generation
+        };
+        let error = parsed
+            .iter()
+            .map(|entry| entry.affected_edge_for(&malformed_generation, 13))
+            .collect::<Result<Vec<_>>>()
+            .expect_err("the malformed record must still fail its owning edge type");
+        assert!(matches!(error, GraphError::CorruptValue { .. }));
+    }
 }

--- a/src/shard/topology_tail.rs
+++ b/src/shard/topology_tail.rs
@@ -1,4 +1,5 @@
 use super::*;
+use futures::StreamExt as _;
 use slatedb::ValueDeletable;
 
 #[derive(Clone, Debug, Default)]
@@ -79,6 +80,93 @@ impl GraphTopologyOverlay {
     }
 }
 
+/// One topology-affecting WAL record, parsed once per file.
+///
+/// Parsed for *every* cell and edge type in the file, not just the caller's:
+/// all edge types share one database, so a per-caller parse would re-download
+/// and re-parse the same file once per edge type. Callers filter by
+/// `cell_id`/`edge_type`/`seq` at use time.
+#[derive(Clone, Debug)]
+pub(crate) struct WalTopologyEntry {
+    pub(crate) cell_id: String,
+    pub(crate) edge_type: String,
+    pub(crate) src: VertexId,
+    pub(crate) dst: VertexId,
+    pub(crate) seq: u64,
+}
+
+/// Per-shard cache of parsed WAL files, keyed by WAL id.
+///
+/// A WAL id names an immutable object, so a cached parse never goes stale —
+/// eviction exists only to bound memory. Eviction drops the *smallest* id
+/// first: tail walks always move forward, so the oldest file is the least
+/// likely to be asked for again.
+#[derive(Default)]
+pub(crate) struct WalTailFileCache {
+    files: BTreeMap<u64, Arc<Vec<WalTopologyEntry>>>,
+    total_entries: usize,
+}
+
+/// Memory bound for [`WalTailFileCache`], in parsed entries (an entry is two
+/// small strings and three integers — the cap is single-digit MiB per shard).
+const WAL_TAIL_CACHE_MAX_ENTRIES: usize = 65_536;
+
+/// Concurrent object-store fetches per tail walk. Each WAL file is a tiny
+/// object whose cost is dominated by request latency, so the walk is
+/// round-trip-bound and parallel fetches divide wall clock almost linearly.
+pub(crate) const WAL_TAIL_FETCH_CONCURRENCY: usize = 16;
+
+/// `GRAPH_WAL_TAIL_FETCH_CONCURRENCY` overrides the default, for tuning and
+/// for A/B benchmarks (`1` reproduces the serial walk this replaced).
+/// Resolved once, on first use, so `std::env::var` stays off the tail path —
+/// the same shape as `env_default_kernel` in `sparse_kernel/mod.rs`.
+fn wal_tail_fetch_concurrency() -> usize {
+    static RESOLVED: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+    *RESOLVED.get_or_init(|| {
+        std::env::var("GRAPH_WAL_TAIL_FETCH_CONCURRENCY")
+            .ok()
+            .and_then(|value| value.parse::<usize>().ok())
+            .filter(|value| *value >= 1)
+            .unwrap_or(WAL_TAIL_FETCH_CONCURRENCY)
+    })
+}
+
+impl WalTailFileCache {
+    fn get(&self, wal_id: u64) -> Option<Arc<Vec<WalTopologyEntry>>> {
+        self.files.get(&wal_id).cloned()
+    }
+
+    fn insert(&mut self, wal_id: u64, entries: Arc<Vec<WalTopologyEntry>>) {
+        // A single file larger than the whole budget would evict everything
+        // and then exceed the cap anyway; serve it uncached instead.
+        if entries.len() > WAL_TAIL_CACHE_MAX_ENTRIES {
+            return;
+        }
+        if let Some(previous) = self.files.insert(wal_id, entries) {
+            self.total_entries = self.total_entries.saturating_sub(previous.len());
+        }
+        self.total_entries = self.total_entries.saturating_add(self.files[&wal_id].len());
+        while self.total_entries > WAL_TAIL_CACHE_MAX_ENTRIES {
+            let Some((_, evicted)) = self.files.pop_first() else {
+                break;
+            };
+            self.total_entries = self.total_entries.saturating_sub(evicted.len());
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn cached_file_count(&self) -> usize {
+        self.files.len()
+    }
+}
+
+/// A fetched file is either parsed or gone; a hard error is neither and
+/// propagates through `Result` instead.
+enum WalFileFetch {
+    Parsed(Vec<WalTopologyEntry>),
+    Unavailable,
+}
+
 impl GraphShard {
     pub(crate) async fn topology_tail_since(
         &self,
@@ -98,33 +186,101 @@ impl GraphShard {
             return Ok(GraphTopologyTail::Complete(GraphTopologyOverlay::default()));
         }
 
-        let mut affected = BTreeSet::new();
-        let wal_reader = self.db.wal_reader();
-        for wal_id in generation.last_wal_id.saturating_add(1)..=last_wal_id {
-            budget.check("graph_index_wal_file")?;
-            let mut entries = match wal_reader.get(wal_id).iterator().await {
-                Ok(entries) => entries,
-                Err(error) => {
-                    tracing::debug!(
-                        wal_id,
-                        error = %error,
-                        "graph index WAL tail is unavailable; using snapshot adjacency"
-                    );
-                    return Ok(GraphTopologyTail::Unavailable);
+        // The cost gate. The span counts object-store round trips, and it
+        // scales with write activity since the generation — not with the
+        // size of the delta, which may be a handful of edges. Past the cap,
+        // declining is cheaper than walking: the index build falls back to
+        // a full rebuild and the read path to snapshot adjacency.
+        let span = last_wal_id.saturating_sub(generation.last_wal_id);
+        if span > self.limits.max_wal_tail_files {
+            tracing::debug!(
+                span,
+                limit = self.limits.max_wal_tail_files,
+                base_wal_id = generation.last_wal_id,
+                last_wal_id,
+                "graph index WAL tail span exceeds the file cap; declining"
+            );
+            return Ok(GraphTopologyTail::Unavailable);
+        }
+
+        let wal_ids =
+            (generation.last_wal_id.saturating_add(1)..=last_wal_id).collect::<Vec<u64>>();
+        let mut files = BTreeMap::new();
+        let mut missing = Vec::new();
+        {
+            let cache = self.wal_tail_file_cache.lock().await;
+            for wal_id in &wal_ids {
+                match cache.get(*wal_id) {
+                    Some(parsed) => {
+                        files.insert(*wal_id, parsed);
+                    }
+                    None => missing.push(*wal_id),
                 }
-            };
-            while let Some(entry) = entries.next().await? {
+            }
+        }
+
+        {
+            let fetches = futures::stream::iter(missing.iter().copied())
+                .map(|wal_id| {
+                    let wal_reader = self.db.wal_reader();
+                    async move {
+                        budget.check("graph_index_wal_file")?;
+                        let mut entries = match wal_reader.get(wal_id).iterator().await {
+                            Ok(entries) => entries,
+                            Err(error) => {
+                                tracing::debug!(
+                                    wal_id,
+                                    error = %error,
+                                    "graph index WAL tail is unavailable; using snapshot adjacency"
+                                );
+                                return Ok((wal_id, WalFileFetch::Unavailable));
+                            }
+                        };
+                        let mut parsed = Vec::new();
+                        while let Some(entry) = entries.next().await? {
+                            collect_wal_topology_entry(
+                                &entry.key,
+                                &entry.value,
+                                entry.seq,
+                                &mut parsed,
+                            )?;
+                        }
+                        Ok::<_, crate::GraphError>((wal_id, WalFileFetch::Parsed(parsed)))
+                    }
+                })
+                .buffered(wal_tail_fetch_concurrency());
+            let mut fetches = std::pin::pin!(fetches);
+            while let Some(fetched) = fetches.next().await {
+                let (wal_id, fetch) = fetched?;
+                match fetch {
+                    WalFileFetch::Unavailable => return Ok(GraphTopologyTail::Unavailable),
+                    WalFileFetch::Parsed(parsed) => {
+                        files.insert(wal_id, Arc::new(parsed));
+                    }
+                }
+            }
+        }
+
+        {
+            let mut cache = self.wal_tail_file_cache.lock().await;
+            for wal_id in &missing {
+                if let Some(parsed) = files.get(wal_id) {
+                    cache.insert(*wal_id, Arc::clone(parsed));
+                }
+            }
+        }
+
+        let mut affected = BTreeSet::new();
+        for parsed in files.values() {
+            for entry in parsed.iter() {
                 budget.check("graph_index_wal_entry")?;
                 if entry.seq <= generation.base_sequence || entry.seq > read_sequence {
                     continue;
                 }
-                collect_topology_entry(
-                    &entry.key,
-                    &entry.value,
-                    &generation.cell_id,
-                    &generation.edge_type,
-                    &mut affected,
-                )?;
+                if entry.cell_id != generation.cell_id || entry.edge_type != generation.edge_type {
+                    continue;
+                }
+                affected.insert((entry.src, entry.dst));
                 ensure_limit(
                     "graph_index_wal_affected_edges",
                     affected.len() as u64,
@@ -150,40 +306,56 @@ impl GraphShard {
         }
         Ok(GraphTopologyTail::Complete(overlay))
     }
+
+    #[cfg(test)]
+    pub(crate) async fn test_wal_tail_cached_file_count(&self) -> usize {
+        self.wal_tail_file_cache.lock().await.cached_file_count()
+    }
 }
 
-fn collect_topology_entry(
+fn collect_wal_topology_entry(
     key: &[u8],
     value: &ValueDeletable,
-    cell_id: &str,
-    edge_type: &str,
-    affected: &mut BTreeSet<(VertexId, VertexId)>,
+    seq: u64,
+    parsed: &mut Vec<WalTopologyEntry>,
 ) -> Result<()> {
     let Ok(key) = std::str::from_utf8(key) else {
         return Ok(());
     };
     let fields = key.split('/').collect::<Vec<_>>();
     match fields.as_slice() {
-        ["cell", key_cell, "e", "out", key_type, src, dst]
-            if *key_cell == cell_id && *key_type == edge_type =>
-        {
-            affected.insert((parse_u64(key, src, "src")?, parse_u64(key, dst, "dst")?));
+        ["cell", cell, "e", "out", edge_type, src, dst] => {
+            parsed.push(WalTopologyEntry {
+                cell_id: (*cell).to_string(),
+                edge_type: (*edge_type).to_string(),
+                src: parse_u64(key, src, "src")?,
+                dst: parse_u64(key, dst, "dst")?,
+                seq,
+            });
         }
-        ["cell", key_cell, "seg", "tomb", "out", key_type, src, dst]
-            if *key_cell == cell_id && *key_type == edge_type =>
-        {
-            affected.insert((parse_u64(key, src, "src")?, parse_u64(key, dst, "dst")?));
+        ["cell", cell, "seg", "tomb", "out", edge_type, src, dst] => {
+            parsed.push(WalTopologyEntry {
+                cell_id: (*cell).to_string(),
+                edge_type: (*edge_type).to_string(),
+                src: parse_u64(key, src, "src")?,
+                dst: parse_u64(key, dst, "dst")?,
+                seq,
+            });
         }
-        ["cell", key_cell, "seg", "out", key_type, _, _, _]
-            if *key_cell == cell_id && *key_type == edge_type =>
-        {
+        ["cell", cell, "seg", "out", edge_type, _, _, _] => {
             if let Some(value) = value.as_bytes() {
                 let segment = decode_out_edge_segment(key, &value)?;
-                affected.extend(
+                parsed.extend(
                     segment
                         .destinations
                         .into_iter()
-                        .map(|dst| (segment.src, dst)),
+                        .map(|dst| WalTopologyEntry {
+                            cell_id: (*cell).to_string(),
+                            edge_type: (*edge_type).to_string(),
+                            src: segment.src,
+                            dst,
+                            seq,
+                        }),
                 );
             }
         }

--- a/src/shard/topology_tail.rs
+++ b/src/shard/topology_tail.rs
@@ -289,20 +289,34 @@ impl GraphShard {
             }
         }
 
+        // Resolving each affected pair is a point read against the snapshot —
+        // a cold block is an object-store round trip, so this loop is
+        // request-bound exactly like the file walk above and parallelized the
+        // same way. Reads against a pinned snapshot commute; the overlay is
+        // keyed by (src, dst), so arrival order cannot change the result.
         let mut overlay = GraphTopologyOverlay::default();
-        for (src, dst) in affected {
-            budget.check("graph_index_wal_resolve_edge")?;
-            let exists = self
-                .edge_exists_in_storage_snapshot(
-                    snapshot,
-                    &generation.cell_id,
-                    &generation.edge_type,
-                    src,
-                    dst,
-                    read_sequence,
-                )
-                .await?;
-            overlay.set(src, dst, exists);
+        {
+            let resolves = futures::stream::iter(affected.iter().copied())
+                .map(|(src, dst)| async move {
+                    budget.check("graph_index_wal_resolve_edge")?;
+                    let exists = self
+                        .edge_exists_in_storage_snapshot(
+                            snapshot,
+                            &generation.cell_id,
+                            &generation.edge_type,
+                            src,
+                            dst,
+                            read_sequence,
+                        )
+                        .await?;
+                    Ok::<_, crate::GraphError>((src, dst, exists))
+                })
+                .buffered(wal_tail_fetch_concurrency());
+            let mut resolves = std::pin::pin!(resolves);
+            while let Some(resolved) = resolves.next().await {
+                let (src, dst, exists) = resolved?;
+                overlay.set(src, dst, exists);
+            }
         }
         Ok(GraphTopologyTail::Complete(overlay))
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -14434,3 +14434,137 @@ async fn writer_built_generations_record_the_wal_position() {
         full.last_wal_id
     );
 }
+
+/// The tail cost gate (`GraphLimits::max_wal_tail_files`): a WAL span wider
+/// than the cap must *decline* the incremental build — every file in the span
+/// is one object-store round trip, and the span scales with write activity
+/// rather than delta size, so past the cap the full rebuild is the cheaper
+/// path. With the cap at zero any new WAL at all exceeds it, which makes the
+/// decline deterministic without having to manufacture thousands of files.
+#[tokio::test]
+async fn incremental_build_declines_when_wal_span_exceeds_cap() {
+    let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let shard = GraphShard::open_standalone_writer_with_limits(
+        "graph/tail-span-cap",
+        object_store,
+        GraphLimits {
+            max_wal_tail_files: 0,
+            ..GraphLimits::default()
+        },
+    )
+    .await
+    .unwrap();
+    let cell_id = "reddit-home";
+    let edge_type = "CHAIN";
+
+    shard
+        .write_edge(typed_mutation(cell_id, edge_type, 1, 2, "cap-seed"))
+        .await
+        .unwrap();
+    let full = shard.build_graph_index(cell_id, edge_type).await.unwrap();
+
+    shard
+        .write_edge(typed_mutation(cell_id, edge_type, 2, 3, "cap-add"))
+        .await
+        .unwrap();
+    let declined = shard
+        .build_graph_index_incremental(cell_id, edge_type)
+        .await
+        .unwrap();
+    assert!(
+        declined.is_none(),
+        "a span above the cap must decline, not walk"
+    );
+
+    // The decline is a routing verdict, not a failure: the auto entry point
+    // must land on a correct full rebuild.
+    let (generation, path) = shard
+        .build_graph_index_auto(cell_id, edge_type)
+        .await
+        .unwrap();
+    assert!(
+        matches!(path, crate::GraphIndexBuildPath::Full { edges: 2 }),
+        "expected the fallback full rebuild over both edges, got {path:?}"
+    );
+    assert!(
+        generation.base_sequence > full.base_sequence,
+        "the fallback must publish the newer snapshot: {} <= {}",
+        generation.base_sequence,
+        full.base_sequence
+    );
+}
+
+/// All edge types share one database, so their tail walks read the *same* WAL
+/// files. The per-shard file cache exists so the second edge type's build
+/// reuses the first's downloads: after the first incremental build parses its
+/// span, the second build over the same span must add nothing to the cache —
+/// and both builds must still patch their own edge type correctly.
+#[tokio::test]
+async fn wal_tail_file_parse_is_shared_across_edge_types() {
+    let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let shard = GraphShard::open_standalone_writer("graph/tail-shared-parse", object_store)
+        .await
+        .unwrap();
+    let cell_id = "reddit-home";
+
+    shard
+        .write_edge(typed_mutation(cell_id, "CHAIN", 1, 2, "shared-seed-a"))
+        .await
+        .unwrap();
+    shard
+        .write_edge(typed_mutation(cell_id, "REPLIES", 1, 9, "shared-seed-b"))
+        .await
+        .unwrap();
+    shard.build_graph_index(cell_id, "CHAIN").await.unwrap();
+    shard.build_graph_index(cell_id, "REPLIES").await.unwrap();
+
+    shard
+        .write_edge(typed_mutation(cell_id, "CHAIN", 2, 3, "shared-add-a"))
+        .await
+        .unwrap();
+    shard
+        .write_edge(typed_mutation(cell_id, "REPLIES", 9, 10, "shared-add-b"))
+        .await
+        .unwrap();
+
+    let (chain, chain_path) = shard
+        .build_graph_index_incremental(cell_id, "CHAIN")
+        .await
+        .unwrap()
+        .expect("a short tail on a fresh store is buildable");
+    assert!(
+        matches!(
+            chain_path,
+            crate::GraphIndexBuildPath::Incremental { delta_edges: 1 }
+        ),
+        "CHAIN sees only its own delta, got {chain_path:?}"
+    );
+    let cached_after_first = shard.test_wal_tail_cached_file_count().await;
+    assert!(
+        cached_after_first > 0,
+        "the first walk must leave its parsed files behind"
+    );
+
+    // REPLIES was published after CHAIN, so its span is a subset of the files
+    // the CHAIN walk just parsed; nothing new to fetch.
+    let (replies, replies_path) = shard
+        .build_graph_index_incremental(cell_id, "REPLIES")
+        .await
+        .unwrap()
+        .expect("the second edge type's tail is buildable from cache");
+    assert!(
+        matches!(
+            replies_path,
+            crate::GraphIndexBuildPath::Incremental { delta_edges: 1 }
+        ),
+        "REPLIES sees only its own delta, got {replies_path:?}"
+    );
+    assert_eq!(
+        shard.test_wal_tail_cached_file_count().await,
+        cached_after_first,
+        "the second walk's span is already cached; it must download nothing"
+    );
+
+    assert_eq!(chain.edge_count, 2, "CHAIN patched to two edges");
+    assert_eq!(replies.edge_count, 2, "REPLIES patched to two edges");
+}


### PR DESCRIPTION
## The staging regression this fixes

After #12 went live on staging with the size floor zeroed, average artifact build time went from ~1 s to 27–48 s (p95 233 s) and indexer cycles stretched from ~7 min to 15–40 min. Trace correlation showed build time scaling with **WAL files walked** (~50 ms per file) and not with graph size: `topology_tail_since` re-downloaded every WAL file between the previous generation and the durable head, serially, one object-store round trip per file, separately for each of the 8 edge types sharing a scope database. The span grows with write *activity* (one file per WAL flush), not with delta size — staging paid up to 10,000 round trips to derive 15-edge deltas, with a feedback loop (slow builds → longer cycles → bigger spans) making each day worse.

Full analysis with the measured data and the longer-term design ladder: `interactive/incremental-build-cost.html` (added here as a design note).

## The fix — one change per multiplier

- **Cost gate** (`GraphLimits::max_wal_tail_files`, default 4096; `GRAPH_INDEXER_MAX_TAIL_FILES` in the indexer): a span wider than the cap declines exactly as a GC-broken chain does — the builder falls back to the full rebuild, the read path to snapshot adjacency, both cheaper than the walk the cap refused. This restores the invariant that the incremental path can never lose to the full path: it forfeits instead.
- **Concurrent fetches**: the walk downloads 16 files at a time (`GRAPH_WAL_TAIL_FETCH_CONCURRENCY`; `1` reproduces the old serial walk for A/B). The same treatment applies to the per-edge existence resolves behind the walk, which real-S3 measurement exposed as the next serial request-bound loop.
- **Shared parse cache**: WAL files are parsed once per shard into a bounded cache keyed by WAL id (immutable objects — eviction is purely a memory bound, oldest id first). The 8 edge types previously re-downloaded and re-parsed the same span once each; now the first build's walk serves the rest.
- Declines log their reason (`wal_tail_unavailable_or_capped` / `previous_payload_missing` / `delta_exceeds_scan_limit`) at info, so fallback bursts are explainable from logs.

## Measured

Real S3 (`hydradb-local-turbolay`, us-east-1), ~1,000-file manufactured trickle span (`examples/wal_tail_trickle_bench.rs`, added here):

| build over the same span | result |
|---|---|
| old serial walk | **did not finish in 10 min** |
| fixed walk (16-way) | **478 s, completed** (client was ~300–800 ms from the bucket; in-cluster is ~100× closer) |
| full rebuild, same sequence | 290 s |
| re-measure after WAL GC collected the span | declined → full rebuild → correct output (312 s) |

Deterministic regression numbers via `examples/tail_concurrency_probe.rs` (`ThrottledStore`, 25 ms/GET, 100-file span): **16.8 s serial vs 4.7 s fixed**; the walk itself parallelizes ~16×, and the remaining serial cost is SlateDB's own WAL replay inside reader refresh — the target of the phase-2 (replay-time changelog + keep-scopes-open) design.

## Tests

- `incremental_build_declines_when_wal_span_exceeds_cap` — a span above the cap declines and the auto path lands on a correct full rebuild.
- `wal_tail_file_parse_is_shared_across_edge_types` — the second edge type's build over an already-walked span downloads nothing and still patches correctly.
- All 181 default library tests, 8 indexer tests, clippy (default + runtime feature sets), fmt.

Follow-ups deliberately not in this PR: build-duration histogram by path, keep-scopes-open LRU + replay-time changelog (needs a fork hook — own design round), delta-shaped generations.
