### PR TITLE
Share routed writers within each graph node

### DIFF
--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use thiserror::Error;
 
 use crate::StorageSequence;
@@ -20,6 +22,15 @@ pub enum GraphError {
     UnsafeDurabilityConfig {
         operation: &'static str,
         reason: String,
+    },
+    #[error(
+        "routed writer configuration mismatch for {path} on node {node_id}: existing fence backoff {existing:?}, requested {requested:?}"
+    )]
+    RoutedWriterConfigMismatch {
+        path: String,
+        node_id: String,
+        existing: Duration,
+        requested: Duration,
     },
     #[error("invalid {component} key component: {value}")]
     InvalidKeyComponent {
@@ -316,7 +327,9 @@ impl GraphError {
             // Both are a refusal to act on how this process was configured, not
             // a failure of the operation itself: one rejects an unsafe
             // durability setting, the other a write to a shard opened read-only.
-            Self::UnsafeDurabilityConfig { .. } | Self::ReadOnlyShardStorage => Self::CLASS_CONFIG,
+            Self::UnsafeDurabilityConfig { .. }
+            | Self::RoutedWriterConfigMismatch { .. }
+            | Self::ReadOnlyShardStorage => Self::CLASS_CONFIG,
 
             Self::Slate(_) | Self::ObjectStore(_) => Self::CLASS_STORAGE,
 

--- a/src/core/state.rs
+++ b/src/core/state.rs
@@ -1,5 +1,5 @@
 use std::collections::BTreeMap;
-use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{
     Arc, Mutex as StdMutex, MutexGuard as StdMutexGuard, OnceLock, RwLock as StdRwLock, Weak,
 };
@@ -138,8 +138,8 @@ struct GraphStoreInner {
 struct ProcessWriterState {
     writer: StdRwLock<Option<Db>>,
     open_gate: Mutex<()>,
+    owners: StdMutex<usize>,
     closing: AtomicBool,
-    owners: AtomicUsize,
     heartbeat_interval: Duration,
     reopen_gate: StdMutex<WriterReopenGate>,
 }
@@ -178,15 +178,15 @@ fn process_writer_state(
         Arc::new(ProcessWriterState {
             writer: StdRwLock::new(None),
             open_gate: Mutex::new(()),
+            owners: StdMutex::new(0),
             closing: AtomicBool::new(false),
-            owners: AtomicUsize::new(0),
             heartbeat_interval,
             reopen_gate: StdMutex::new(WriterReopenGate::default()),
         })
     };
     let Some(node_id) = node_id else {
         let state = new_state();
-        state.owners.store(1, Ordering::Release);
+        state.add_owner();
         return state;
     };
     let key = ProcessWriterKey {
@@ -208,7 +208,7 @@ fn process_writer_state(
             state
         });
     debug_assert_eq!(state.heartbeat_interval, heartbeat_interval);
-    state.owners.fetch_add(1, Ordering::AcqRel);
+    state.add_owner();
     state
 }
 
@@ -327,19 +327,49 @@ impl WriterReopenGate {
 }
 
 impl ProcessWriterState {
+    fn owners(&self) -> StdMutexGuard<'_, usize> {
+        self.owners
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    fn add_owner(&self) {
+        *self.owners() += 1;
+    }
+
+    fn is_closing(&self) -> bool {
+        self.closing.load(Ordering::Acquire)
+    }
+
+    fn begin_release(&self) -> bool {
+        let mut owners = self.owners();
+        *owners = owners
+            .checked_sub(1)
+            .expect("process writer owner count underflow");
+        if *owners > 0 {
+            return false;
+        }
+        // Set this while owner registration is still excluded. A new owner
+        // either joins before the decrement (making it non-final), or joins
+        // after this flag is visible and waits for the old handle to close.
+        self.closing.store(true, Ordering::Release);
+        true
+    }
+
     async fn release_owner(&self) -> Result<()> {
         let _open_guard = self.open_gate.lock().await;
-        self.closing.store(true, Ordering::Release);
+        if !self.begin_release() {
+            // Another routed store still owns this handle. Do not publish a
+            // closing transition: surviving owners must keep using the writer
+            // without a transient read-only window.
+            return Ok(());
+        }
+
         // Scope eviction normally runs this close in a detached task, but the
         // guard also makes direct cancellation recoverable: once the open gate
         // is released, a replacement may promote instead of seeing `closing`
         // forever.
         let _closing_guard = WriterClosingGuard(&self.closing);
-        let previous = self.owners.fetch_sub(1, Ordering::AcqRel);
-        debug_assert!(previous > 0, "process writer owner count underflow");
-        if previous > 1 {
-            return Ok(());
-        }
 
         let writer = self
             .writer
@@ -472,9 +502,7 @@ impl GraphStore {
     }
 
     fn open_writer(&self) -> Option<Db> {
-        if self.inner.retiring.load(Ordering::Acquire)
-            || self.inner.writer_state.closing.load(Ordering::Acquire)
-        {
+        if self.inner.retiring.load(Ordering::Acquire) || self.inner.writer_state.is_closing() {
             return None;
         }
         self.inner
@@ -1228,6 +1256,22 @@ mod tests {
     /// them, so any origin works and none of these tests touch a real clock.
     fn origin() -> Instant {
         Instant::now()
+    }
+
+    #[test]
+    fn releasing_a_non_final_process_owner_never_hides_the_writer() {
+        let state = ProcessWriterState {
+            writer: StdRwLock::new(None),
+            open_gate: Mutex::new(()),
+            owners: StdMutex::new(2),
+            closing: AtomicBool::new(false),
+            heartbeat_interval: Duration::from_secs(5),
+            reopen_gate: StdMutex::new(WriterReopenGate::default()),
+        };
+
+        assert!(!state.begin_release());
+        assert_eq!(*state.owners(), 1);
+        assert!(!state.is_closing());
     }
 
     /// Decision 6's rules 1 and 2, which are the two that survive the write-path

--- a/src/core/state.rs
+++ b/src/core/state.rs
@@ -1,5 +1,8 @@
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::{Arc, Mutex as StdMutex, MutexGuard as StdMutexGuard, RwLock as StdRwLock};
+use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+use std::sync::{
+    Arc, Mutex as StdMutex, MutexGuard as StdMutexGuard, OnceLock, RwLock as StdRwLock, Weak,
+};
 use std::time::{Duration, Instant};
 
 use slatedb::bytes::Bytes;
@@ -121,20 +124,92 @@ struct GraphStoreInner {
     cache: GraphCacheConfig,
     storage_memory: GraphStorageMemoryConfig,
     durability: GraphDurabilityConfig,
-    writer: StdRwLock<Option<Db>>,
+    writer_state: Arc<ProcessWriterState>,
+    writer_owner_active: AtomicBool,
     reader: AsyncRwLock<Option<Arc<DbReader>>>,
     // A writer loss is acknowledged only by a reader refresh from the same or a later generation.
     reader_refresh_generation: AtomicU64,
     reader_refreshed_generation: AtomicU64,
-    writer_open_gate: Mutex<()>,
     reader_open_gate: Mutex<()>,
     reader_refresh_gate: Mutex<()>,
     retiring: AtomicBool,
-    // How long a fenced writer waits before re-promoting: exactly one heartbeat
-    // interval, so the rival has published a fresh view and stood down.
+}
+
+struct ProcessWriterState {
+    writer: StdRwLock<Option<Db>>,
+    open_gate: Mutex<()>,
+    closing: AtomicBool,
+    owners: AtomicUsize,
     heartbeat_interval: Duration,
-    // Armed by a fence or a failed refresh, consulted by the promotion gate.
-    writer_reopen_gate: StdMutex<WriterReopenGate>,
+    reopen_gate: StdMutex<WriterReopenGate>,
+}
+
+struct WriterClosingGuard<'a>(&'a AtomicBool);
+
+impl Drop for WriterClosingGuard<'_> {
+    fn drop(&mut self) {
+        self.0.store(false, Ordering::Release);
+    }
+}
+
+#[derive(Clone, Eq, Ord, PartialEq, PartialOrd)]
+struct ProcessWriterKey {
+    object_store: usize,
+    path: String,
+    node_id: String,
+}
+
+static PROCESS_WRITERS: OnceLock<StdMutex<BTreeMap<ProcessWriterKey, Weak<ProcessWriterState>>>> =
+    OnceLock::new();
+
+/// Return the one writer state a graph-node may own for this physical database.
+///
+/// Standalone shard opens deliberately remain independent: callers use those
+/// to model separate processes and SlateDB must still fence competing writers.
+/// Routed opens supply their node ID, so duplicate scope runtimes inside one
+/// graph-node converge on one handle without sharing across simulated nodes.
+fn process_writer_state(
+    path: &Path,
+    object_store: &Arc<dyn ObjectStore>,
+    heartbeat_interval: Duration,
+    node_id: Option<&str>,
+) -> Arc<ProcessWriterState> {
+    let new_state = || {
+        Arc::new(ProcessWriterState {
+            writer: StdRwLock::new(None),
+            open_gate: Mutex::new(()),
+            closing: AtomicBool::new(false),
+            owners: AtomicUsize::new(0),
+            heartbeat_interval,
+            reopen_gate: StdMutex::new(WriterReopenGate::default()),
+        })
+    };
+    let Some(node_id) = node_id else {
+        let state = new_state();
+        state.owners.store(1, Ordering::Release);
+        return state;
+    };
+    let key = ProcessWriterKey {
+        object_store: Arc::as_ptr(object_store) as *const () as usize,
+        path: path.to_string(),
+        node_id: node_id.to_string(),
+    };
+    let registry = PROCESS_WRITERS.get_or_init(|| StdMutex::new(BTreeMap::new()));
+    let mut registry = registry
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    registry.retain(|_, state| state.strong_count() > 0);
+    let state = registry
+        .get(&key)
+        .and_then(Weak::upgrade)
+        .unwrap_or_else(|| {
+            let state = new_state();
+            registry.insert(key, Arc::downgrade(&state));
+            state
+        });
+    debug_assert_eq!(state.heartbeat_interval, heartbeat_interval);
+    state.owners.fetch_add(1, Ordering::AcqRel);
+    state
 }
 
 static EMPTY_GRAPH_STORE: OnceCell<Db> = OnceCell::const_new();
@@ -251,6 +326,57 @@ impl WriterReopenGate {
     }
 }
 
+impl ProcessWriterState {
+    async fn release_owner(&self) -> Result<()> {
+        let _open_guard = self.open_gate.lock().await;
+        self.closing.store(true, Ordering::Release);
+        // Scope eviction normally runs this close in a detached task, but the
+        // guard also makes direct cancellation recoverable: once the open gate
+        // is released, a replacement may promote instead of seeing `closing`
+        // forever.
+        let _closing_guard = WriterClosingGuard(&self.closing);
+        let previous = self.owners.fetch_sub(1, Ordering::AcqRel);
+        debug_assert!(previous > 0, "process writer owner count underflow");
+        if previous > 1 {
+            return Ok(());
+        }
+
+        let writer = self
+            .writer
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .take();
+        match writer {
+            Some(writer) => writer.close().await.map_err(GraphError::from),
+            None => Ok(()),
+        }
+    }
+}
+
+impl Drop for GraphStoreInner {
+    fn drop(&mut self) {
+        if !self.writer_owner_active.swap(false, Ordering::AcqRel) {
+            return;
+        }
+        let writer_state = Arc::clone(&self.writer_state);
+        if let Ok(runtime) = tokio::runtime::Handle::try_current() {
+            runtime.spawn(async move {
+                if let Err(error) = writer_state.release_owner().await {
+                    tracing::warn!(%error, "failed to retire dropped process writer owner");
+                }
+            });
+        } else {
+            // There is no executor capable of draining SlateDB here. Preserve
+            // the shared handle until process teardown instead of creating a
+            // replacement writer that would fence it.
+            tracing::warn!(
+                path = %self.path,
+                "dropped graph store outside a Tokio runtime; retaining process writer"
+            );
+        }
+    }
+}
+
 pub(crate) enum GraphStorageSnapshot {
     Writer(Arc<DbSnapshot>),
     Reader(Arc<DbReaderSnapshot>),
@@ -318,7 +444,14 @@ impl GraphStore {
         storage_memory: GraphStorageMemoryConfig,
         durability: GraphDurabilityConfig,
         heartbeat_interval: Duration,
+        process_writer_node_id: Option<&str>,
     ) -> Self {
+        let writer_state = process_writer_state(
+            &path,
+            &object_store,
+            heartbeat_interval,
+            process_writer_node_id,
+        );
         Self {
             inner: Arc::new(GraphStoreInner {
                 path,
@@ -326,25 +459,26 @@ impl GraphStore {
                 cache,
                 storage_memory,
                 durability,
-                writer: StdRwLock::new(None),
+                writer_state,
+                writer_owner_active: AtomicBool::new(true),
                 reader: AsyncRwLock::new(None),
                 reader_refresh_generation: AtomicU64::new(0),
                 reader_refreshed_generation: AtomicU64::new(0),
-                writer_open_gate: Mutex::new(()),
                 reader_open_gate: Mutex::new(()),
                 reader_refresh_gate: Mutex::new(()),
                 retiring: AtomicBool::new(false),
-                heartbeat_interval,
-                writer_reopen_gate: StdMutex::new(WriterReopenGate::default()),
             }),
         }
     }
 
     fn open_writer(&self) -> Option<Db> {
-        if self.inner.retiring.load(Ordering::Acquire) {
+        if self.inner.retiring.load(Ordering::Acquire)
+            || self.inner.writer_state.closing.load(Ordering::Acquire)
+        {
             return None;
         }
         self.inner
+            .writer_state
             .writer
             .read()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
@@ -363,6 +497,7 @@ impl GraphStore {
     fn clear_closed_writer(&self) -> bool {
         let mut writer = self
             .inner
+            .writer_state
             .writer
             .write()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -477,7 +612,7 @@ impl GraphStore {
 
     /// The body of [`Self::refresh_writer_fence`], running inside its span.
     async fn refresh_writer_fence_traced(&self) -> Result<()> {
-        let _open_guard = self.inner.writer_open_gate.lock().await;
+        let _open_guard = self.inner.writer_state.open_gate.lock().await;
         // No writer at all is a read-only shard, not a fenced one: waiting
         // promotes nothing, so there is no delay to arm.
         let writer = self
@@ -500,7 +635,7 @@ impl GraphStore {
                 }
                 self.clear_closed_writer();
                 self.reopen_gate()
-                    .note_fence(Instant::now(), self.inner.heartbeat_interval);
+                    .note_fence(Instant::now(), self.inner.writer_state.heartbeat_interval);
                 self.log_fence_attribution(lost_epoch).await;
                 let error: GraphError = err.into();
                 // `fencing` is expected, not alarming — the class is here so a
@@ -605,7 +740,8 @@ impl GraphStore {
 
     fn reopen_gate(&self) -> StdMutexGuard<'_, WriterReopenGate> {
         self.inner
-            .writer_reopen_gate
+            .writer_state
+            .reopen_gate
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
     }
@@ -627,7 +763,7 @@ impl GraphStore {
         if self.open_writer().is_some() {
             return Ok(false);
         }
-        let _open_guard = self.inner.writer_open_gate.lock().await;
+        let _open_guard = self.inner.writer_state.open_gate.lock().await;
         if self.inner.retiring.load(Ordering::Acquire) {
             return Err(GraphError::ReadOnlyShardStorage);
         }
@@ -663,6 +799,7 @@ impl GraphStore {
         .await?;
         *self
             .inner
+            .writer_state
             .writer
             .write()
             .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(writer.clone());
@@ -833,23 +970,14 @@ impl GraphStore {
 
     pub(crate) async fn close(&self) -> Result<()> {
         self.inner.retiring.store(true, Ordering::Release);
-        let _writer_guard = self.inner.writer_open_gate.lock().await;
         let _reader_guard = self.inner.reader_open_gate.lock().await;
 
-        let writer = self
-            .inner
-            .writer
-            .write()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .take();
         let reader = self.inner.reader.write().await.take();
 
-        // Writer retirement is the ownership boundary. It must complete even
-        // when a detached read snapshot is still alive; otherwise reopening
-        // this scope creates a second SlateDB writer and fences the first one.
-        let writer_result = match writer {
-            Some(writer) => writer.close().await.map_err(GraphError::from),
-            None => Ok(()),
+        let writer_result = if self.inner.writer_owner_active.swap(false, Ordering::AcqRel) {
+            self.inner.writer_state.release_owner().await
+        } else {
+            Ok(())
         };
 
         if let Some(reader) = reader {

--- a/src/core/state.rs
+++ b/src/core/state.rs
@@ -173,7 +173,7 @@ fn process_writer_state(
     object_store: &Arc<dyn ObjectStore>,
     heartbeat_interval: Duration,
     node_id: Option<&str>,
-) -> Arc<ProcessWriterState> {
+) -> Result<Arc<ProcessWriterState>> {
     let new_state = || {
         Arc::new(ProcessWriterState {
             writer: StdRwLock::new(None),
@@ -187,7 +187,7 @@ fn process_writer_state(
     let Some(node_id) = node_id else {
         let state = new_state();
         state.add_owner();
-        return state;
+        return Ok(state);
     };
     let key = ProcessWriterKey {
         object_store: Arc::as_ptr(object_store) as *const () as usize,
@@ -207,9 +207,16 @@ fn process_writer_state(
             registry.insert(key, Arc::downgrade(&state));
             state
         });
-    debug_assert_eq!(state.heartbeat_interval, heartbeat_interval);
+    if state.heartbeat_interval != heartbeat_interval {
+        return Err(GraphError::RoutedWriterConfigMismatch {
+            path: path.to_string(),
+            node_id: node_id.to_string(),
+            existing: state.heartbeat_interval,
+            requested: heartbeat_interval,
+        });
+    }
     state.add_owner();
-    state
+    Ok(state)
 }
 
 static EMPTY_GRAPH_STORE: OnceCell<Db> = OnceCell::const_new();
@@ -475,14 +482,14 @@ impl GraphStore {
         durability: GraphDurabilityConfig,
         heartbeat_interval: Duration,
         process_writer_node_id: Option<&str>,
-    ) -> Self {
+    ) -> Result<Self> {
         let writer_state = process_writer_state(
             &path,
             &object_store,
             heartbeat_interval,
             process_writer_node_id,
-        );
-        Self {
+        )?;
+        Ok(Self {
             inner: Arc::new(GraphStoreInner {
                 path,
                 object_store,
@@ -498,7 +505,7 @@ impl GraphStore {
                 reader_refresh_gate: Mutex::new(()),
                 retiring: AtomicBool::new(false),
             }),
-        }
+        })
     }
 
     fn open_writer(&self) -> Option<Db> {

--- a/src/engine/cluster.rs
+++ b/src/engine/cluster.rs
@@ -369,11 +369,12 @@ impl RoutedGraphCluster {
         for cell_id in directory.cells().map(str::to_string) {
             let path = format!("{base_path}/{cell_id}");
             let opened = if promotable {
-                GraphShard::open_promotable_with_memory_options(
+                GraphShard::open_promotable_for_node_with_memory_options(
                     path,
                     Arc::clone(&object_store),
                     options.clone(),
                     memory.clone(),
+                    &local_node_id,
                 )
                 .await
             } else {
@@ -1739,6 +1740,111 @@ mod scoped_cluster_tests {
             .expect("the replacement writer commits without fencing the old handle");
         drop(reopened);
         runtime.close().await.expect("the runtime drains");
+    }
+
+    #[tokio::test]
+    async fn concurrent_writes_to_one_scope_share_one_cluster_and_writer() {
+        let runtime = runtime_at_capacity("graph/concurrent-scope-writes", 16);
+        let scope = tenant_scope(&runtime, "tenant-hot");
+
+        let clusters = futures::future::join_all(
+            (0..64).map(|_| runtime.cluster_for_scope_write(&scope, "cell-0")),
+        )
+        .await
+        .into_iter()
+        .collect::<Result<Vec<_>>>()
+        .expect("concurrent write acquisitions succeed");
+
+        let first = clusters.first().expect("at least one cluster was returned");
+        assert!(
+            clusters.iter().all(|cluster| Arc::ptr_eq(first, cluster)),
+            "one process must never construct two routed clusters for the same scope"
+        );
+        let epoch = first
+            .shard("cell-0")
+            .expect("the shard exists")
+            .db
+            .writer_epoch()
+            .expect("the shared writer is installed");
+        assert!(clusters.iter().all(|cluster| {
+            cluster
+                .shard("cell-0")
+                .ok()
+                .and_then(|shard| shard.db.writer_epoch())
+                == Some(epoch)
+        }));
+
+        drop(clusters);
+        runtime.close().await.expect("the runtime drains");
+    }
+
+    #[tokio::test]
+    async fn duplicate_routed_runtimes_share_one_process_writer() {
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let make_runtime = || {
+            let root = NamespacePath::root(NamespaceId::new("production").unwrap());
+            ScopedRoutedGraphCluster::new(
+                "graph/duplicate-runtime",
+                root,
+                GraphId::new("hydradb").unwrap(),
+                "node-a",
+                ObjectStoreNodeDirectory::new(["cell-0"], ["node-a"]).unwrap(),
+                PlacementView::new("node-a", ["node-a"], PlacementConfig::default()).unwrap(),
+                Arc::clone(&object_store),
+                GraphOpenOptions::default(),
+                GraphMemoryConfig::default(),
+                16,
+            )
+            .unwrap()
+        };
+        let first_runtime = make_runtime();
+        let second_runtime = make_runtime();
+        let scope = tenant_scope(&first_runtime, "tenant-hot");
+
+        let first = first_runtime
+            .cluster_for_scope_write(&scope, "cell-0")
+            .await
+            .expect("the first runtime acquires the writer");
+        let first_writer = first
+            .shard("cell-0")
+            .expect("the first shard exists")
+            .db
+            .writer()
+            .expect("the first writer is installed");
+        let second = second_runtime
+            .cluster_for_scope_write(&scope, "cell-0")
+            .await
+            .expect("the duplicate runtime reuses the writer");
+
+        first_writer
+            .refresh_manifest()
+            .await
+            .expect("the duplicate runtime must not fence the first handle");
+        assert_eq!(
+            first
+                .shard("cell-0")
+                .ok()
+                .and_then(|shard| shard.db.writer_epoch()),
+            second
+                .shard("cell-0")
+                .ok()
+                .and_then(|shard| shard.db.writer_epoch())
+        );
+
+        drop(first);
+        first_runtime
+            .close()
+            .await
+            .expect("closing one runtime preserves the shared writer");
+        second
+            .write_edge(scoped_edge("second-runtime-write"))
+            .await
+            .expect("the remaining runtime can still write");
+        drop(second);
+        second_runtime
+            .close()
+            .await
+            .expect("the final runtime drains");
     }
 
     #[tokio::test]

--- a/src/engine/cluster.rs
+++ b/src/engine/cluster.rs
@@ -1848,6 +1848,65 @@ mod scoped_cluster_tests {
     }
 
     #[tokio::test]
+    async fn duplicate_routed_runtimes_reject_mismatched_fence_backoff() {
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let make_runtime = |fence_backoff_interval| {
+            let root = NamespacePath::root(NamespaceId::new("production").unwrap());
+            ScopedRoutedGraphCluster::new(
+                "graph/duplicate-runtime-config",
+                root,
+                GraphId::new("hydradb").unwrap(),
+                "node-a",
+                ObjectStoreNodeDirectory::new(["cell-0"], ["node-a"]).unwrap(),
+                PlacementView::new("node-a", ["node-a"], PlacementConfig::default()).unwrap(),
+                Arc::clone(&object_store),
+                GraphOpenOptions {
+                    fence_backoff_interval,
+                    ..GraphOpenOptions::default()
+                },
+                GraphMemoryConfig::default(),
+                16,
+            )
+            .unwrap()
+        };
+        let first_interval = Duration::from_secs(5);
+        let second_interval = Duration::from_secs(9);
+        let first_runtime = make_runtime(first_interval);
+        let second_runtime = make_runtime(second_interval);
+        let scope = tenant_scope(&first_runtime, "tenant-hot");
+
+        let first = first_runtime
+            .cluster_for_scope_write(&scope, "cell-0")
+            .await
+            .expect("the first runtime acquires the writer");
+        let error = match second_runtime
+            .cluster_for_scope_write(&scope, "cell-0")
+            .await
+        {
+            Ok(_) => panic!("a duplicate runtime must not inherit another fencing interval"),
+            Err(error) => error,
+        };
+        assert!(matches!(
+            error,
+            GraphError::RoutedWriterConfigMismatch {
+                existing,
+                requested,
+                ..
+            } if existing == first_interval && requested == second_interval
+        ));
+
+        drop(first);
+        first_runtime
+            .close()
+            .await
+            .expect("the first runtime drains");
+        second_runtime
+            .close()
+            .await
+            .expect("the rejected runtime drains");
+    }
+
+    #[tokio::test]
     async fn a_cold_scope_open_does_not_lock_out_cached_scopes() {
         let runtime = runtime_at_capacity("graph/cold-open", 2);
         let hot = tenant_scope(&runtime, "tenant-hot");

--- a/src/shard/lifecycle.rs
+++ b/src/shard/lifecycle.rs
@@ -44,6 +44,7 @@ impl GraphShard {
             options,
             memory,
             GraphWriteAuthority::ReadOnly,
+            None,
         )
         .await
     }
@@ -98,15 +99,17 @@ impl GraphShard {
             options,
             memory,
             GraphWriteAuthority::Writer,
+            None,
         )
         .await
     }
 
-    pub(crate) async fn open_promotable_with_memory_options(
+    pub(crate) async fn open_promotable_for_node_with_memory_options(
         path: impl Into<Path>,
         object_store: Arc<dyn ObjectStore>,
         options: GraphOpenOptions,
         memory: GraphMemoryConfig,
+        local_node_id: &str,
     ) -> Result<Self> {
         Self::open_internal(
             path,
@@ -114,6 +117,7 @@ impl GraphShard {
             options,
             memory,
             GraphWriteAuthority::Promotable,
+            Some(local_node_id),
         )
         .await
     }
@@ -124,6 +128,7 @@ impl GraphShard {
         options: GraphOpenOptions,
         memory: GraphMemoryConfig,
         write_authority: GraphWriteAuthority,
+        process_writer_node_id: Option<&str>,
     ) -> Result<Self> {
         if !options.durability.await_durable_writes
             && !matches!(&write_authority, GraphWriteAuthority::ReadOnly)
@@ -142,6 +147,7 @@ impl GraphShard {
             memory.storage.clone(),
             options.durability.clone(),
             options.fence_backoff_interval,
+            process_writer_node_id,
         );
         match &write_authority {
             GraphWriteAuthority::ReadOnly => {

--- a/src/shard/lifecycle.rs
+++ b/src/shard/lifecycle.rs
@@ -148,7 +148,7 @@ impl GraphShard {
             options.durability.clone(),
             options.fence_backoff_interval,
             process_writer_node_id,
-        );
+        )?;
         match &write_authority {
             GraphWriteAuthority::ReadOnly => {
                 let _ = db.open_reader().await?;


### PR DESCRIPTION
## Summary
- Share one SlateDB writer handle and promotion gate across duplicate routed runtimes for the same node, scope, and cell.
- Close the shared writer only after the final local owner releases it.
- Keep non-final owner release invisible to surviving writers.
- Preserve independent standalone and cross-node writers so genuine SlateDB fencing still works.
- Add concurrency, duplicate-runtime, cancellation, shutdown, and owner-release regression coverage.

## Context
This replaces closed PR #32 after the repository history was rewritten for the AGPL licensing change. The two fencing-fix commits were replayed onto the new main; no discarded history is included.

## Validation
- RUST_MIN_STACK=16777216 cargo test --no-default-features (187 passed)
- RUST_MIN_STACK=16777216 cargo test --features query-transport (338 passed)
- cargo clippy --all-targets --features query-transport -- -D warnings
- cargo fmt --all -- --check