### PR TITLE
Keep pinned inbound reads on reverse indexes

### DIFF
--- a/src/shard/query.rs
+++ b/src/shard/query.rs
@@ -6153,8 +6153,7 @@ impl GraphShard {
     ) -> Result<Vec<VertexId>> {
         validate_component("cell_id", cell_id)?;
         validate_component("edge_type", edge_type)?;
-        let current_epoch = self.current_epoch(cell_id).await?;
-        if !self.writes_reverse_index() || read_epoch != current_epoch {
+        if !self.writes_reverse_index() {
             let mut neighbors = Vec::new();
             for edge in self
                 .edges_at_with_budget(cell_id, edge_type, read_epoch, Some(budget))
@@ -6169,8 +6168,13 @@ impl GraphShard {
             neighbors.dedup();
             return Ok(neighbors);
         }
+
+        let snapshot = self.snapshot_at(cell_id, read_epoch).await?;
         let prefix = keys::in_prefix(cell_id, edge_type, dst);
-        let mut iter = self.scan_remote_prefix(&prefix).await?;
+        let mut iter = snapshot
+            .storage_snapshot
+            .scan_prefix_with_options(prefix.as_bytes(), .., &remote_scan_options())
+            .await?;
         let mut neighbors = Vec::new();
         while let Some(kv) = iter.next().await? {
             budget.check("query_in_neighbors_reverse_scan")?;

--- a/src/shard/query_optimizer.rs
+++ b/src/shard/query_optimizer.rs
@@ -347,7 +347,10 @@ impl GraphShard {
     ) -> Result<Vec<OptimizedRowPattern>> {
         let current_epoch = self.current_epoch(cell_id).await?;
         let latest_snapshot = read_epoch == current_epoch;
-        let reverse_index_available = self.writes_reverse_index() && latest_snapshot;
+        // Reverse adjacency is stored in SlateDB and can be read from the same
+        // pinned snapshot as the rest of the query. It is not limited to the
+        // latest epoch.
+        let reverse_index_available = self.writes_reverse_index();
         let mut remaining: Vec<_> = patterns
             .iter()
             .cloned()
@@ -503,7 +506,7 @@ impl GraphShard {
     ) -> Result<RowQueryAccess> {
         let current_epoch = self.current_epoch(cell_id).await?;
         let latest_snapshot = read_epoch == current_epoch;
-        let reverse_index_available = self.writes_reverse_index() && latest_snapshot;
+        let reverse_index_available = self.writes_reverse_index();
         Ok(self
             .best_row_edge_access(
                 cell_id,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -12001,7 +12001,7 @@ async fn cypher_edge_match_uses_destination_id_reverse_index_without_full_scan()
             cell_id: "reddit-home".to_string(),
             edge_type: "FOLLOWS".to_string(),
             src: 4,
-            dst: 40,
+            dst: 20,
             idempotency_key: "cypher-dst-id-index-newer-write".to_string(),
         })
         .await

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -11995,13 +11995,27 @@ async fn cypher_edge_match_uses_destination_id_reverse_index_without_full_scan()
             .unwrap();
     }
 
-    let rows = shard
-        .execute_cypher_rows(
-            QueryContext::new("reddit-home", "cypher-dst-id-index-read"),
-            "MATCH (u)-[:FOLLOWS]->(v {id: 20}) RETURN u.id",
-        )
+    let pinned_snapshot = shard.db.snapshot().await.unwrap();
+    shard
+        .write_edge(EdgeMutation {
+            cell_id: "reddit-home".to_string(),
+            edge_type: "FOLLOWS".to_string(),
+            src: 4,
+            dst: 40,
+            idempotency_key: "cypher-dst-id-index-newer-write".to_string(),
+        })
         .await
         .unwrap();
+
+    let rows = crate::GraphStore::scope_snapshot(
+        pinned_snapshot,
+        shard.execute_cypher_rows(
+            QueryContext::new("reddit-home", "cypher-dst-id-index-read"),
+            "MATCH (u)-[:FOLLOWS]->(v {id: 20}) RETURN u.id",
+        ),
+    )
+    .await
+    .unwrap();
     assert_eq!(
         rows,
         QueryResultSet::new(

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -11996,6 +11996,7 @@ async fn cypher_edge_match_uses_destination_id_reverse_index_without_full_scan()
     }
 
     let pinned_snapshot = shard.db.snapshot().await.unwrap();
+    let pinned_epoch = pinned_snapshot.seq();
     shard
         .write_edge(EdgeMutation {
             cell_id: "reddit-home".to_string(),
@@ -12010,7 +12011,8 @@ async fn cypher_edge_match_uses_destination_id_reverse_index_without_full_scan()
     let rows = crate::GraphStore::scope_snapshot(
         pinned_snapshot,
         shard.execute_cypher_rows(
-            QueryContext::new("reddit-home", "cypher-dst-id-index-read"),
+            QueryContext::new("reddit-home", "cypher-dst-id-index-read")
+                .with_validated_storage_read_epoch(pinned_epoch, pinned_epoch),
             "MATCH (u)-[:FOLLOWS]->(v {id: 20}) RETURN u.id",
         ),
     )


### PR DESCRIPTION
## Summary
- keep inbound reverse-index reads on the query's pinned SlateDB snapshot
- allow the optimizer to select reverse-index access for pinned read epochs
- add regression coverage proving a post-snapshot matching edge is excluded

This replaces closed PR #28 after the repository history was rewritten for the AGPL license update. Only the three original PR commits were replayed onto the new `main` history.

## Validation
- `cargo fmt --all -- --check`
- `cargo test --no-default-features` (186 passed)
- `cargo test --features query-transport` (335 passed)
- `cargo clippy --all-targets --features query-transport -- -D warnings`