### PR TITLE
Add shared write-path spans for permit, lane lock, and fence validation

### DIFF
--- a/src/client/service.rs
+++ b/src/client/service.rs
@@ -1266,11 +1266,17 @@ impl ClientQueryService {
         let action = self.authorize_query(session, &request)?;
         let parsed_unwind = parse_opencypher_unwind_batch(&request.query)?;
         let (batch_operation, scalar_parameters) = match parsed_unwind {
-            Some(parsed) => (
-                Some(resolve_unwind_batch(parsed, &request.parameters)?),
-                BTreeMap::new(),
-            ),
-            None => (None, scalar_query_parameters(&request.parameters)?),
+            Some(parsed) => {
+                tracing::Span::current().record("turbolay.query.kind", "batch");
+                (
+                    Some(resolve_unwind_batch(parsed, &request.parameters)?),
+                    BTreeMap::new(),
+                )
+            }
+            None => {
+                tracing::Span::current().record("turbolay.query.kind", "scalar");
+                (None, scalar_query_parameters(&request.parameters)?)
+            }
         };
         if batch_operation.as_ref().is_some_and(|operation| {
             operation.is_write() != (action == QueryTransportAction::Write)
@@ -1561,11 +1567,17 @@ impl ClientQueryService {
 
         let parsed_unwind = parse_opencypher_unwind_batch(&request.query)?;
         let (batch_operation, scalar_parameters) = match parsed_unwind {
-            Some(parsed) => (
-                Some(resolve_unwind_batch(parsed, &request.parameters)?),
-                BTreeMap::new(),
-            ),
-            None => (None, scalar_query_parameters(&request.parameters)?),
+            Some(parsed) => {
+                tracing::Span::current().record("turbolay.query.kind", "batch");
+                (
+                    Some(resolve_unwind_batch(parsed, &request.parameters)?),
+                    BTreeMap::new(),
+                )
+            }
+            None => {
+                tracing::Span::current().record("turbolay.query.kind", "scalar");
+                (None, scalar_query_parameters(&request.parameters)?)
+            }
         };
 
         let columns = if let Some(operation) = &batch_operation {
@@ -2264,6 +2276,7 @@ pub(crate) fn client_root_span(
                 turbolay.caller.step = tracing::field::Empty,
                 turbolay.read_epoch = tracing::field::Empty,
                 turbolay.query.rows_returned = tracing::field::Empty,
+                turbolay.query.kind = tracing::field::Empty,
                 runtime_limit_ms = tracing::field::Empty,
                 error.class = tracing::field::Empty,
                 turbolay.sampling.tail_keep = tracing::field::Empty,

--- a/src/shard/write.rs
+++ b/src/shard/write.rs
@@ -2789,36 +2789,54 @@ impl GraphShard {
             (mutation.src, src_metadata),
             (mutation.dst, dst_metadata),
         ])?;
-        let _permit = self
-            .acquire_graph_write_permit("write_edge_with_vertex_metadata")
-            .await?;
-        let _writer = self.writer_lane(&mutation.cell_id).lock().await;
-        for attempt in 0..GRAPH_TXN_MAX_RETRIES {
-            match self
-                .write_edge_with_vertex_metadata_txn(&mutation, &metadata_updates)
-                .await
-            {
-                Err(err)
-                    if is_retryable_write_conflict(&err) && attempt + 1 < GRAPH_TXN_MAX_RETRIES =>
+        let span = write_txn_span(&mutation.cell_id, Some(&mutation.edge_type));
+        async {
+            let _permit = self
+                .acquire_graph_write_permit("write_edge_with_vertex_metadata")
+                .instrument(tracing::info_span!(
+                    "write.permit_acquire",
+                    turbolay.cell_id = %mutation.cell_id,
+                    error.class = tracing::field::Empty,
+                ))
+                .await?;
+            let _writer = self
+                .writer_lane(&mutation.cell_id)
+                .lock()
+                .instrument(tracing::info_span!(
+                    "write.lane_lock",
+                    turbolay.cell_id = %mutation.cell_id,
+                ))
+                .await;
+            for attempt in 0..GRAPH_TXN_MAX_RETRIES {
+                match self
+                    .write_edge_with_vertex_metadata_txn(&mutation, &metadata_updates)
+                    .await
                 {
-                    self.operation_metrics
-                        .write_retries
-                        .fetch_add(1, Ordering::Relaxed);
-                    tokio::task::yield_now().await;
+                    Err(err)
+                        if is_retryable_write_conflict(&err)
+                            && attempt + 1 < GRAPH_TXN_MAX_RETRIES =>
+                    {
+                        self.operation_metrics
+                            .write_retries
+                            .fetch_add(1, Ordering::Relaxed);
+                        tokio::task::yield_now().await;
+                    }
+                    Ok(result) => {
+                        self.operation_metrics
+                            .write_commits
+                            .fetch_add(1, Ordering::Relaxed);
+                        return Ok(result);
+                    }
+                    result => return result,
                 }
-                Ok(result) => {
-                    self.operation_metrics
-                        .write_commits
-                        .fetch_add(1, Ordering::Relaxed);
-                    return Ok(result);
-                }
-                result => return result,
             }
+            Err(GraphError::RetryExhausted {
+                operation: "graph transaction",
+                attempts: GRAPH_TXN_MAX_RETRIES,
+            })
         }
-        Err(GraphError::RetryExhausted {
-            operation: "graph transaction",
-            attempts: GRAPH_TXN_MAX_RETRIES,
-        })
+        .instrument(span)
+        .await
     }
 
     async fn write_edge_with_vertex_metadata_txn(
@@ -2859,36 +2877,54 @@ impl GraphShard {
             (mutation.src, src_metadata),
             (mutation.dst, dst_metadata),
         ])?;
-        let _permit = self
-            .acquire_graph_write_permit("write_edge_with_full_metadata")
-            .await?;
-        let _writer = self.writer_lane(&mutation.cell_id).lock().await;
-        for attempt in 0..GRAPH_TXN_MAX_RETRIES {
-            match self
-                .write_edge_with_full_metadata_txn(&mutation, &metadata_updates, &edge_metadata)
-                .await
-            {
-                Err(err)
-                    if is_retryable_write_conflict(&err) && attempt + 1 < GRAPH_TXN_MAX_RETRIES =>
+        let span = write_txn_span(&mutation.cell_id, Some(&mutation.edge_type));
+        async {
+            let _permit = self
+                .acquire_graph_write_permit("write_edge_with_full_metadata")
+                .instrument(tracing::info_span!(
+                    "write.permit_acquire",
+                    turbolay.cell_id = %mutation.cell_id,
+                    error.class = tracing::field::Empty,
+                ))
+                .await?;
+            let _writer = self
+                .writer_lane(&mutation.cell_id)
+                .lock()
+                .instrument(tracing::info_span!(
+                    "write.lane_lock",
+                    turbolay.cell_id = %mutation.cell_id,
+                ))
+                .await;
+            for attempt in 0..GRAPH_TXN_MAX_RETRIES {
+                match self
+                    .write_edge_with_full_metadata_txn(&mutation, &metadata_updates, &edge_metadata)
+                    .await
                 {
-                    self.operation_metrics
-                        .write_retries
-                        .fetch_add(1, Ordering::Relaxed);
-                    tokio::task::yield_now().await;
+                    Err(err)
+                        if is_retryable_write_conflict(&err)
+                            && attempt + 1 < GRAPH_TXN_MAX_RETRIES =>
+                    {
+                        self.operation_metrics
+                            .write_retries
+                            .fetch_add(1, Ordering::Relaxed);
+                        tokio::task::yield_now().await;
+                    }
+                    Ok(result) => {
+                        self.operation_metrics
+                            .write_commits
+                            .fetch_add(1, Ordering::Relaxed);
+                        return Ok(result);
+                    }
+                    result => return result,
                 }
-                Ok(result) => {
-                    self.operation_metrics
-                        .write_commits
-                        .fetch_add(1, Ordering::Relaxed);
-                    return Ok(result);
-                }
-                result => return result,
             }
+            Err(GraphError::RetryExhausted {
+                operation: "graph transaction",
+                attempts: GRAPH_TXN_MAX_RETRIES,
+            })
         }
-        Err(GraphError::RetryExhausted {
-            operation: "graph transaction",
-            attempts: GRAPH_TXN_MAX_RETRIES,
-        })
+        .instrument(span)
+        .await
     }
 
     async fn write_edge_with_full_metadata_txn(

--- a/src/shard/write.rs
+++ b/src/shard/write.rs
@@ -1308,8 +1308,22 @@ impl GraphShard {
         let span = write_txn_span(cell_id, Some(edge_type));
         async {
             let mut retries = WriteRetryCount::new();
-            let _permit = self.acquire_graph_write_permit(options.operation).await?;
-            let _writer = self.writer_lane(cell_id).lock().await;
+            let _permit = self
+                .acquire_graph_write_permit(options.operation)
+                .instrument(tracing::info_span!(
+                    "write.permit_acquire",
+                    turbolay.cell_id = %cell_id,
+                    error.class = tracing::field::Empty,
+                ))
+                .await?;
+            let _writer = self
+                .writer_lane(cell_id)
+                .lock()
+                .instrument(tracing::info_span!(
+                    "write.lane_lock",
+                    turbolay.cell_id = %cell_id,
+                ))
+                .await;
             for attempt in 0..GRAPH_TXN_MAX_RETRIES {
                 match self
                     .import_relationships_batch_txn(
@@ -1533,6 +1547,11 @@ impl GraphShard {
             .begin(IsolationLevel::SerializableSnapshot)
             .await?;
         self.validate_write_fence_txn(&txn, cell_id, options.operation)
+            .instrument(tracing::info_span!(
+                "write.fence_validate",
+                turbolay.cell_id = %cell_id,
+                error.class = tracing::field::Empty,
+            ))
             .await?;
         if let Some((source_label, destination_label)) = options.endpoint_labels {
             let mut required_labels = BTreeMap::<VertexId, BTreeSet<&str>>::new();
@@ -2687,8 +2706,22 @@ impl GraphShard {
         let span = write_txn_span(&mutation.cell_id, Some(&mutation.edge_type));
         async {
             let mut retries = WriteRetryCount::new();
-            let _permit = self.acquire_graph_write_permit("write_edge").await?;
-            let _writer = self.writer_lane(&mutation.cell_id).lock().await;
+            let _permit = self
+                .acquire_graph_write_permit("write_edge")
+                .instrument(tracing::info_span!(
+                    "write.permit_acquire",
+                    turbolay.cell_id = %mutation.cell_id,
+                    error.class = tracing::field::Empty,
+                ))
+                .await?;
+            let _writer = self
+                .writer_lane(&mutation.cell_id)
+                .lock()
+                .instrument(tracing::info_span!(
+                    "write.lane_lock",
+                    turbolay.cell_id = %mutation.cell_id,
+                ))
+                .await;
             for attempt in 0..GRAPH_TXN_MAX_RETRIES {
                 match self.write_edge_txn(&mutation).await {
                     Err(err)
@@ -2891,6 +2924,11 @@ impl GraphShard {
             .begin(IsolationLevel::SerializableSnapshot)
             .await?;
         self.validate_write_fence_txn(&txn, &mutation.cell_id, operation)
+            .instrument(tracing::info_span!(
+                "write.fence_validate",
+                turbolay.cell_id = %mutation.cell_id,
+                error.class = tracing::field::Empty,
+            ))
             .await?;
         let idem_key = keys::idempotency(&mutation.cell_id, "create", &mutation.idempotency_key);
 
@@ -4148,8 +4186,22 @@ impl GraphShard {
         let span = write_txn_span(cell_id, common_edge_type(&mutations));
         async {
             let mut retries = WriteRetryCount::new();
-            let _permit = self.acquire_graph_write_permit(operation).await?;
-            let _writer = self.writer_lane(cell_id).lock().await;
+            let _permit = self
+                .acquire_graph_write_permit(operation)
+                .instrument(tracing::info_span!(
+                    "write.permit_acquire",
+                    turbolay.cell_id = %cell_id,
+                    error.class = tracing::field::Empty,
+                ))
+                .await?;
+            let _writer = self
+                .writer_lane(cell_id)
+                .lock()
+                .instrument(tracing::info_span!(
+                    "write.lane_lock",
+                    turbolay.cell_id = %cell_id,
+                ))
+                .await;
             for attempt in 0..GRAPH_TXN_MAX_RETRIES {
                 match self
                     .write_edge_mutations_batch_txn(cell_id, &mutations, operation, endpoint_labels)
@@ -4282,6 +4334,11 @@ impl GraphShard {
             .begin(IsolationLevel::SerializableSnapshot)
             .await?;
         self.validate_write_fence_txn(&txn, cell_id, operation)
+            .instrument(tracing::info_span!(
+                "write.fence_validate",
+                turbolay.cell_id = %cell_id,
+                error.class = tracing::field::Empty,
+            ))
             .await?;
 
         let mut idempotency_keys = BTreeSet::new();


### PR DESCRIPTION
Three bottlenecks in the client.mutate write path were invisible in traces because they fell inside shard.write_txn with no sub-spans:

- write.permit_acquire: the graph_write_gate semaphore acquire.  Queue time here means the shard's write concurrency limit is saturated before any transaction work begins.  Without this span, a slow shard.write_txn is indistinguishable from a write that was queued.

- write.lane_lock: the per-cell mutex that serialises concurrent writes to the same cell.  Contention here does not appear in turbolay.writer.retries (which counts SlateDB conflicts, not mutex waits) and was completely invisible.  Hot cells accumulate wait time here silently.

- write.fence_validate: two remote reads on every write attempt — the cell drop marker and pending-drop marker.  These fire on retries too, so a retry-heavy workload multiplies the round-trip cost. error.class on this span pins a CellDropped failure to this specific check rather than the root.

All three spans are added at every entry point that flows through client.mutate: write_edge (scalar), import_relationships_batch and write_edge_mutations_batch (both UNWIND batch paths).

Also adds turbolay.query.kind = scalar | batch on the client.mutate root span, recorded after parse_opencypher_unwind_batch determines the shape.  Without this, a slow client.mutate trace gives no indication which execution path was taken.