### PR TITLE
ci: publish release images to GHCR

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,0 +1,90 @@
+name: Container image
+
+on:
+  pull_request:
+    paths:
+      - Dockerfile
+      - .dockerignore
+      - Cargo.lock
+      - Cargo.toml
+      - src/**
+      - crates/**
+      - .github/workflows/container.yml
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+env:
+  IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/hydradb
+
+jobs:
+  verify:
+    name: Verify production image
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build production image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          target: runtime
+          platforms: linux/amd64
+          push: false
+
+  publish:
+    name: Publish release image
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Generate image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha,prefix=sha-
+            type=raw,value=latest
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and publish image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          target: runtime
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          provenance: true
+          sbom: true

--- a/charts/hydradb/README.md
+++ b/charts/hydradb/README.md
@@ -42,32 +42,16 @@ capacity and `indexer.replicaCount` for background indexing capacity.
 ## Image Publication
 
 `.github/workflows/container.yml` builds the production Dockerfile on pull
-requests and publishes `linux/amd64` images to the regional
-`staging/hydradb` Amazon ECR repository after a push to `main`. It follows the
-HydraDB deployment convention by publishing the full commit SHA and `latest`
-tags through the shared AWS role. Every published image also has an OCI digest,
-an SBOM, and build-provenance attestation. Argo CD is pinned to the digest and
-never deploys by `latest`.
+requests and publishes `linux/amd64` images to GitHub Container Registry when a
+`v*` tag is pushed. Published images are named
+`ghcr.io/<repository-owner>/hydradb` and receive the release version, compatible
+minor and major versions, the commit SHA, and `latest` tags. Release images
+also include an OCI digest, an SBOM, and build-provenance attestation.
 
-The publisher uses GitHub OIDC to assume the organization-provided
-`AWS_ROLE_ARN` secret, matching `hydradb-application`. Do not store AWS access
-keys in GitHub. The ECR repository and role access are provisioned through the
-team's existing AWS infrastructure process.
-
-After publishing, the workflow checks out `usecortex/hydradb-argocd` with the
-existing `INFRA_REPO_TOKEN`, synchronizes this canonical chart into the infra
-repository, updates the staging tag and digest, validates the Helm release, and
-pushes the deployment commit to `main`. This is the same promotion path used by
-HydraDB application and ingestion services.
-
-Set the `HYDRADB_STAGING_DEPLOY_ENABLED` repository variable to `true` only
-after the staging ECR repository, S3 roles, certificates, and client-auth Secret
-exist. The workflow then uses the shared `ARGOCD_AUTH_TOKEN` to refresh, sync,
-and wait for the `hydradb-staging` application to become healthy.
-
-EKS nodes pull the private image through their IAM node role. Attach
-`AmazonEC2ContainerRegistryPullOnly` or equivalent repository-scoped pull
-permissions; no registry password or Kubernetes image-pull Secret is required.
+The workflow uses the repository-scoped `GITHUB_TOKEN`; no long-lived registry
+credentials are required. Grant the workflow `packages: write` permission and
+set the resulting GHCR package visibility to match the intended deployment.
+Deployment systems should pin the image digest rather than `latest`.
 
 ## Security
 


### PR DESCRIPTION
## Summary
- build the production container on pull requests without registry credentials
- publish linux/amd64 release images to GHCR when a `v*` tag is pushed
- publish semver, SHA, and latest tags with SBOM and provenance
- update chart documentation for the GHCR release flow

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/container.yml")'`\n- `git diff --check`\n\nAfter merge, create and push `v0.1.0` from `main` to publish the initial OSS image.