### PR TITLE
docs: Docker quickstart, DEVELOPMENT.md split, README cleanup

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,88 @@
+# Development
+
+Detailed build, verification, and harness surface for contributors working on
+HydraDB from source. See the [README](README.md) for a first-run walkthrough and
+[AGENTS.md](AGENTS.md) for repository conventions and failure modes.
+
+Run `just` or `just help` to list the command surface. Recipes use Bash and run
+from the repository root. The full native suite requires `libcypher-parser` and
+SuiteSparse GraphBLAS.
+
+## Verification Recipes
+
+| Recipe | Coverage |
+|---|---|
+| `just native-check` | Verifies that `cypher-parser` and GraphBLAS are discoverable |
+| `just fmt`, `just fmt-check` | Formats Rust or checks formatting without modifying files |
+| `just clippy` | Default-feature lint used by CI |
+| `just clippy-chaos`, `just clippy-opencypher` | Chaos-harness and OpenCypher lint configurations |
+| `just clippy-native`, `just clippy-client-protocols`, `just clippy-runtime` | Full native, public protocol, and production runtime lint configurations |
+| `just check` | Checks every default-feature target |
+| `just check-all-features` | Checks every target with every Cargo feature |
+| `just check-client-api`, `just check-bolt-server` | Checks shared client code and standalone Bolt independently |
+| `just check-examples`, `just check-examples-native`, `just check-examples-chaos` | Checks example targets under their supported feature sets |
+| `just test [cargo test args]` | Runs default library tests and forwards optional arguments |
+| `just test-opencypher`, `just test-native`, `just test-client-protocols`, `just test-chaos` | Runs the major library and public-protocol test matrices |
+| `just test-server-runtime`, `just test-indexer`, `just test-node-otlp` | Runs graph-node, indexer, and OTLP binary tests |
+| `just test-placement`, `just test-telemetry` | Lints and tests the two workspace crates |
+| `just ci` | Runs the complete local CI-equivalent sequence; a clean feature-matrix run can take tens of minutes (25m 41s in the verification run for this README) |
+
+`scripts/ci_local.sh` is a compatibility entry point that sets a shared Cargo
+target directory and delegates to `just ci`, so the script and Justfile cannot
+silently drift into different test matrices.
+
+## Local Harnesses
+
+| Recipe | What it runs | Output or side effect |
+|---|---|---|
+| `just smoke` | Isolated local object-store write, traversal, reopen, and verification | Temporary directory removed on exit |
+| `just smoke-graphblas` | The same smoke flow with SuiteSparse selected explicitly | Temporary directory removed on exit |
+| `just query-correctness` | Exact OpenCypher result checks | `bench-results/query_correctness.csv` and `.log` |
+| `just query-bench` | Configurable cold, hot, and concurrent query benchmark | `bench-results/query_bench_full.csv` and `.log` by default |
+| `just query-memory-profile` | Build/query memory matrix with runtime-selectable kernels | Results and logs under the configured benchmark directory |
+| `just stress` | Multiprocess writes, restart recovery, compaction, GC, and verification | Temporary local stores removed on exit |
+| `just fence` | Hard SlateDB writer-takeover proof | Temporary local stores removed on exit |
+
+The benchmark recipes intentionally use production-sized defaults and can run
+for a long time. Override their documented `GRAPH_QUERY_*` environment
+variables for a small development sample.
+
+## Docker And MinIO Harnesses
+
+| Recipe | Purpose |
+|---|---|
+| `just minio-smoke` | Runs the object-store smoke flow against an ephemeral MinIO container |
+| `just minio-query-correctness` | Runs exact query checks against MinIO |
+| `just minio-query-bench` | Runs the query benchmark against MinIO |
+| `just minio-chaos` | Pauses, restarts, and recovers MinIO during graph operations |
+| `just minio-fence` | Runs writer takeover against MinIO |
+| `just minio-mbt` | Replays the formal MBT adapters against MinIO; unavailable in this checkout because the referenced `tests/formal_mbt*.rs` targets are absent |
+
+The MinIO recipes create isolated containers, networks, buckets, and temporary
+configuration files. Their cleanup traps remove those resources unless a
+recipe-specific keep flag is set. Docker may pull pinned images on the first
+run.
+
+## Standalone Scripts
+
+The scripts below are not all exposed as Just recipes because several operate
+external infrastructure or incur cloud cost.
+
+| Script | Requirements and behavior |
+|---|---|
+| `scripts/runtime_smoke.sh` | Builds `graph-node`, checks readiness and metrics, then exercises Bolt, scoped databases, HTTP, and graceful shutdown; requires Python `neo4j` |
+| `scripts/bolt_neo4j_driver_smoke.sh` | Exercises direct and routing Bolt URIs through the official Python Neo4j driver |
+| `scripts/query_bench.sh`, `scripts/query_correctness.sh`, `scripts/query_memory_profile.sh` | Implement the corresponding local Just recipes |
+| `scripts/multiprocess_stress.sh`, `scripts/fence_takeover.sh` | Implement the local stress and fencing recipes |
+| `scripts/minio_*.sh` | MinIO smoke, correctness, benchmark, chaos, fencing, MBT, and write-profile harnesses; require Docker |
+| `scripts/multinode_k3s.sh` | Creates a disposable multi-node K3d cluster and performs disruptive failover tests; requires Docker, K3d, kubectl, and Helm |
+| `scripts/deploy_single_node_k3s.sh` | Builds and deploys to an existing K3s host using an S3 bucket; changes Kubernetes and AWS resources |
+| `scripts/ec2_graphblas_benchmark.sh` | Runs the containerized GraphBLAS benchmark against S3 on EC2; uses AWS credentials and can incur cost |
+| `scripts/run_s3_bolt_benchmark.sh` | Starts the S3-backed Bolt benchmark and optionally deletes its benchmark prefix afterward |
+| `scripts/neo4j_exact_hop_benchmark.sh` | Pulls and runs Neo4j in Docker for comparison measurements |
+| `scripts/bolt_graphblas_client.py`, `scripts/falkordb_bolt_benchmark.py`, `scripts/s3_bolt_driver_benchmark.py` | Python benchmark clients used by the shell harnesses; require the `neo4j` package |
+| `scripts/multinode_k3s_client.py` | Runs inside the disposable K3d client Pod created by `multinode_k3s.sh` |
+
+`just update-slatedb` is a maintenance command, not a verification command. It
+updates the pinned SlateDB dependency in `Cargo.lock`; review and test the
+resulting lockfile diff before committing it.

--- a/README.md
+++ b/README.md
@@ -1,24 +1,28 @@
 # HydraDB
 
-[![CI](https://github.com/hydra-db/hydradb/actions/workflows/ci.yml/badge.svg)](https://github.com/hydra-db/hydradb/actions/workflows/ci.yml)
+[![Container image](https://github.com/hydra-db/hydradb/actions/workflows/container.yml/badge.svg)](https://github.com/hydra-db/hydradb/actions/workflows/container.yml)
 [![OpenCypher TCK](https://github.com/hydra-db/hydradb/actions/workflows/opencypher-tck.yml/badge.svg)](https://github.com/hydra-db/hydradb/actions/workflows/opencypher-tck.yml)
 [![License: AGPL-3.0](https://img.shields.io/badge/license-AGPL--3.0-blue.svg)](LICENSE)
 [![Rust 1.91+](https://img.shields.io/badge/rust-1.91%2B-orange.svg)](rust-toolchain.toml)
+[![Benchmarks](https://img.shields.io/badge/benchmarks-live-brightgreen.svg)](https://hydra-db.github.io/benchmark/)
 
 HydraDB is an object-store-native distributed graph database written in Rust.
 It combines durable graph storage on SlateDB with snapshot-consistent
 OpenCypher queries, GraphBLAS traversal, Neo4j-compatible Bolt connectivity,
 and an HTTPS query API.
 
-S3-compatible object storage is the durable source of truth. Query nodes and
-indexers keep only disposable state in memory and on local SSD or NVMe, so they
-can be replaced or scaled without moving the graph itself.
+Storage and compute are fully disaggregated. S3-compatible object storage is the
+durable source of truth, and compute runs as two independent roles: **data
+nodes** (`graph-node`) serve queries and canonical mutations, while **indexers**
+(`graph-indexer`) build immutable traversal indexes in the background. Both keep
+only disposable state in memory and on local SSD or NVMe, so they can be replaced
+or scaled without moving the graph itself.
 
 ## Why HydraDB
 
 - **Object-store durability.** Graph records, WALs, manifests, and immutable
   traversal indexes live in S3-compatible storage.
-- **Independent compute.** Query nodes and indexers scale separately and can
+- **Independent compute.** Data nodes and indexers scale separately and can
   rebuild their local caches from durable state.
 - **Safe writer handoff.** Object-store CAS leases select the active writer for
   each cell, while SlateDB writer epochs fence stale writers.
@@ -36,39 +40,44 @@ can be replaced or scaled without moving the graph itself.
 ## Architecture
 
 ```mermaid
-flowchart LR
+flowchart TB
     C["Applications<br/>Neo4j drivers or HTTPS"]
     SVC["Service or load balancer"]
 
-    subgraph Q["Query tier"]
-        Q1["graph-node"]
-        Q2["graph-node"]
-        QN["graph-node"]
+    subgraph Q["Data tier — graph-node"]
+        direction LR
+        subgraph N1["graph-node"]
+            Q1["query + mutation engine"]
+            S1["local SSD / NVMe cache"]
+            Q1 <--> S1
+        end
+        subgraph N2["graph-node"]
+            Q2["query + mutation engine"]
+            S2["local SSD / NVMe cache"]
+            Q2 <--> S2
+        end
     end
 
-    subgraph I["Indexing tier"]
+    subgraph I["Indexing tier — graph-indexer"]
         IX1["graph-indexer"]
         IXN["graph-indexer"]
     end
 
-    CACHE["Disposable memory and SSD cache"]
     STORE["S3-compatible object storage<br/>WAL, SSTs, leases, CSC generations"]
 
     C --> SVC
-    SVC --> Q1
-    SVC --> Q2
-    SVC --> QN
-    Q1 <--> CACHE
-    Q2 <--> CACHE
-    QN <--> CACHE
-    Q1 <--> STORE
-    Q2 <--> STORE
-    QN <--> STORE
+    SVC --> N1
+    SVC --> N2
+    N1 <--> STORE
+    N2 <--> STORE
     IX1 <--> STORE
     IXN <--> STORE
 ```
 
-Query nodes serve reads and canonical graph mutations. Indexer workers build
+Each data node owns a private local SSD/NVMe cache; the object store is the shared
+layer beneath the whole tier and the only durable copy of the graph.
+
+Data nodes serve reads and canonical graph mutations. Indexer workers build
 immutable CSC generations asynchronously and publish them through atomic
 object-store pointers. Readers remain correct when an index is absent or behind
 because the visible WAL tail is applied to the indexed base.
@@ -78,7 +87,63 @@ writer coordination, index lifecycle, and failure semantics.
 
 ## Getting Started
 
-### Prerequisites
+There are two ways to bring up a single development node: the published **Docker
+image**, or a **build from source**. Either way, once the node is listening, use
+[Verify a running node](#verify-a-running-node) to confirm it works — a listening
+port is not proof; a round-tripped write is. TLS is required by default in
+deployed environments, so the local flows below enable plaintext explicitly.
+
+<details>
+<summary><strong>Run with Docker</strong> — fastest, no local toolchain</summary>
+
+Release images are published to
+[`ghcr.io/hydra-db/hydradb`](https://github.com/hydra-db/hydradb/pkgs/container/hydradb).
+Each `v*` release is tagged with its full version, compatible minor and major
+versions, the commit SHA, and `latest` (for example `0.1.0`, `0.1`, `0`,
+`latest`, `sha-7bf77ac`):
+
+```bash
+docker pull ghcr.io/hydra-db/hydradb:latest
+```
+
+This starts one plaintext node backed by a host directory mounted into the
+container:
+
+```bash
+mkdir -p hydradb-data/store hydradb-data/cache
+printf '%s\n' 'local-development-token-32-bytes' > hydradb-data/auth-token
+
+docker run --rm \
+  -p 7687:7687 -p 8443:8443 -p 9090:9090 \
+  -v "$PWD/hydradb-data:/data" \
+  -e CLOUD_PROVIDER=local \
+  -e LOCAL_PATH=/data/store \
+  -e GRAPH_NAMESPACE=default \
+  -e GRAPH_ID=default \
+  -e GRAPH_CELL_ID=cell-0 \
+  -e GRAPH_CELLS=cell-0 \
+  -e GRAPH_NODE_ID=node-0 \
+  -e GRAPH_BOLT_NODE_ADDRESSES=node-0=127.0.0.1:7687 \
+  -e GRAPH_ADVERTISED_BOLT_ADDR=127.0.0.1:7687 \
+  -e GRAPH_DATA_CACHE_DIR=/data/cache \
+  -e GRAPH_AUTH_TOKEN_FILE=/data/auth-token \
+  -e GRAPH_ALLOW_PLAINTEXT=true \
+  -e RUST_MIN_STACK=33554432 \
+  ghcr.io/hydra-db/hydradb:latest
+```
+
+The node runs in the foreground. `LOCAL_PATH` must point at a directory that
+already exists, which is why `hydradb-data/store` is created before the mount.
+The image entrypoint is `graph-node`; it also ships `graph-indexer`. For
+production, pin an image digest rather than `latest` — see the
+[Helm chart guide](charts/hydradb/README.md).
+
+</details>
+
+<details>
+<summary><strong>Build from source</strong> — for development and the full recipe surface</summary>
+
+#### Prerequisites
 
 HydraDB requires Rust 1.91 or newer, a C/C++ toolchain,
 `libcypher-parser`, and SuiteSparse GraphBLAS.
@@ -126,7 +191,7 @@ repository. Install it with `cargo install just --locked` when your package
 manager does not provide it. Docker is optional and is used only by MinIO,
 Neo4j comparison, image-build, and Kubernetes harnesses.
 
-### Clone and verify
+#### Clone and verify
 
 ```bash
 git clone https://github.com/hydra-db/hydradb.git
@@ -147,11 +212,10 @@ To exercise the same flow against an ephemeral MinIO instance:
 just minio-smoke
 ```
 
-### Run a local server
+#### Run a local server
 
 The following starts a single plaintext development node backed by a local
-directory. TLS is required by default in deployed environments; plaintext must
-be enabled explicitly.
+directory.
 
 ```bash
 mkdir -p .hydradb/store .hydradb/cache
@@ -185,9 +249,36 @@ cargo run --locked --features server-runtime --bin graph-node
 ```
 
 The node runs in the foreground and does not return; that is it working, not
-hanging. Run the checks below from a second shell.
+hanging. Confirm it from a second shell with
+[Verify a running node](#verify-a-running-node).
 
-The node listens on:
+For a fully scripted Bolt and HTTP round trip against a source build, install the
+Python Neo4j driver and run. Homebrew's and Debian's Python both refuse a bare
+`pip install` under PEP 668, so use a virtualenv (`apt-get install -y
+python3-venv` on Debian/Ubuntu):
+
+```bash
+python3 -m venv /tmp/hydradb-venv && /tmp/hydradb-venv/bin/pip install neo4j
+
+# macOS: this script calls cargo directly, so it does not inherit what the
+# justfile exports. Without this it fails at bindgen with
+# `'cypher-parser.h' file not found`. Linux needs neither.
+if command -v brew >/dev/null; then
+  export BINDGEN_EXTRA_CLANG_ARGS="-I$(brew --prefix)/include"
+  export LIBRARY_PATH="$(brew --prefix)/lib"
+fi
+
+PYTHON=/tmp/hydradb-venv/bin/python bash scripts/runtime_smoke.sh
+```
+
+Prints `runtime-smoke-ok`. The node's log is at
+`/tmp/sgk-runtime-smoke/node.log`; read it first if the script fails.
+
+</details>
+
+### Verify a running node
+
+However you started it, the node listens on:
 
 | Endpoint | Address | Purpose |
 |---|---|---|
@@ -217,29 +308,8 @@ The second call returns one row containing
 `{"type":"vertex_id","value":2}`. A listening port is not proof the node works;
 a round-tripped write is.
 
-For a scripted Bolt and HTTP round trip, install the Python Neo4j driver and
-run. Homebrew's and Debian's Python both refuse a bare `pip install` under
-PEP 668, so use a virtualenv (`apt-get install -y python3-venv` on
-Debian/Ubuntu):
-
-```bash
-python3 -m venv /tmp/hydradb-venv && /tmp/hydradb-venv/bin/pip install neo4j
-
-# macOS: this script calls cargo directly, so it does not inherit what the
-# justfile exports. Without this it fails at bindgen with
-# `'cypher-parser.h' file not found`. Linux needs neither.
-if command -v brew >/dev/null; then
-  export BINDGEN_EXTRA_CLANG_ARGS="-I$(brew --prefix)/include"
-  export LIBRARY_PATH="$(brew --prefix)/lib"
-fi
-
-PYTHON=/tmp/hydradb-venv/bin/python bash scripts/runtime_smoke.sh
-```
-
-Prints `runtime-smoke-ok`. The node's log is at
-`/tmp/sgk-runtime-smoke/node.log`; read it first if the script fails.
-
-### Troubleshooting local runs
+<details>
+<summary><strong>Troubleshooting local runs</strong></summary>
 
 | Symptom | Cause and fix |
 |---|---|
@@ -250,8 +320,12 @@ Prints `runtime-smoke-ok`. The node's log is at
 | Node answers `/readyz`, then aborts with `has overflowed its stack` on the first query | `RUST_MIN_STACK` unset; export `33554432` |
 | `curl: (7) Failed to connect ... port 9090` | The node is not running. `graph-node` holds the foreground, so start it in its own shell |
 
+</details>
+
 Agents working in this repository should read [AGENTS.md](AGENTS.md), which
 carries the same sequence plus repository conventions and failure modes.
+Contributors building HydraDB should also read [DEVELOPMENT.md](DEVELOPMENT.md)
+for the full recipe, harness, and script surface.
 
 ## Querying
 
@@ -356,87 +430,10 @@ before building latency dashboards or alerts.
 ## Development
 
 Run `just` or `just help` to list the command surface. Recipes use Bash and run
-from the repository root. The full native suite requires `libcypher-parser` and
-SuiteSparse GraphBLAS.
-
-### Verification Recipes
-
-| Recipe | Coverage |
-|---|---|
-| `just native-check` | Verifies that `cypher-parser` and GraphBLAS are discoverable |
-| `just fmt`, `just fmt-check` | Formats Rust or checks formatting without modifying files |
-| `just clippy` | Default-feature lint used by CI |
-| `just clippy-chaos`, `just clippy-opencypher` | Chaos-harness and OpenCypher lint configurations |
-| `just clippy-native`, `just clippy-client-protocols`, `just clippy-runtime` | Full native, public protocol, and production runtime lint configurations |
-| `just check` | Checks every default-feature target |
-| `just check-all-features` | Checks every target with every Cargo feature |
-| `just check-client-api`, `just check-bolt-server` | Checks shared client code and standalone Bolt independently |
-| `just check-examples`, `just check-examples-native`, `just check-examples-chaos` | Checks example targets under their supported feature sets |
-| `just test [cargo test args]` | Runs default library tests and forwards optional arguments |
-| `just test-opencypher`, `just test-native`, `just test-client-protocols`, `just test-chaos` | Runs the major library and public-protocol test matrices |
-| `just test-server-runtime`, `just test-indexer`, `just test-node-otlp` | Runs graph-node, indexer, and OTLP binary tests |
-| `just test-placement`, `just test-telemetry` | Lints and tests the two workspace crates |
-| `just ci` | Runs the complete local CI-equivalent sequence; a clean feature-matrix run can take tens of minutes (25m 41s in the verification run for this README) |
-
-`scripts/ci_local.sh` is a compatibility entry point that sets a shared Cargo
-target directory and delegates to `just ci`, so the script and Justfile cannot
-silently drift into different test matrices.
-
-### Local Harnesses
-
-| Recipe | What it runs | Output or side effect |
-|---|---|---|
-| `just smoke` | Isolated local object-store write, traversal, reopen, and verification | Temporary directory removed on exit |
-| `just smoke-graphblas` | The same smoke flow with SuiteSparse selected explicitly | Temporary directory removed on exit |
-| `just query-correctness` | Exact OpenCypher result checks | `bench-results/query_correctness.csv` and `.log` |
-| `just query-bench` | Configurable cold, hot, and concurrent query benchmark | `bench-results/query_bench_full.csv` and `.log` by default |
-| `just query-memory-profile` | Build/query memory matrix with runtime-selectable kernels | Results and logs under the configured benchmark directory |
-| `just stress` | Multiprocess writes, restart recovery, compaction, GC, and verification | Temporary local stores removed on exit |
-| `just fence` | Hard SlateDB writer-takeover proof | Temporary local stores removed on exit |
-
-The benchmark recipes intentionally use production-sized defaults and can run
-for a long time. Override their documented `GRAPH_QUERY_*` environment
-variables for a small development sample.
-
-### Docker And MinIO Harnesses
-
-| Recipe | Purpose |
-|---|---|
-| `just minio-smoke` | Runs the object-store smoke flow against an ephemeral MinIO container |
-| `just minio-query-correctness` | Runs exact query checks against MinIO |
-| `just minio-query-bench` | Runs the query benchmark against MinIO |
-| `just minio-chaos` | Pauses, restarts, and recovers MinIO during graph operations |
-| `just minio-fence` | Runs writer takeover against MinIO |
-| `just minio-mbt` | Replays the formal MBT adapters against MinIO; unavailable in this checkout because the referenced `tests/formal_mbt*.rs` targets are absent |
-
-The MinIO recipes create isolated containers, networks, buckets, and temporary
-configuration files. Their cleanup traps remove those resources unless a
-recipe-specific keep flag is set. Docker may pull pinned images on the first
-run.
-
-### Standalone Scripts
-
-The scripts below are not all exposed as Just recipes because several operate
-external infrastructure or incur cloud cost.
-
-| Script | Requirements and behavior |
-|---|---|
-| `scripts/runtime_smoke.sh` | Builds `graph-node`, checks readiness and metrics, then exercises Bolt, scoped databases, HTTP, and graceful shutdown; requires Python `neo4j` |
-| `scripts/bolt_neo4j_driver_smoke.sh` | Exercises direct and routing Bolt URIs through the official Python Neo4j driver |
-| `scripts/query_bench.sh`, `scripts/query_correctness.sh`, `scripts/query_memory_profile.sh` | Implement the corresponding local Just recipes |
-| `scripts/multiprocess_stress.sh`, `scripts/fence_takeover.sh` | Implement the local stress and fencing recipes |
-| `scripts/minio_*.sh` | MinIO smoke, correctness, benchmark, chaos, fencing, MBT, and write-profile harnesses; require Docker |
-| `scripts/multinode_k3s.sh` | Creates a disposable multi-node K3d cluster and performs disruptive failover tests; requires Docker, K3d, kubectl, and Helm |
-| `scripts/deploy_single_node_k3s.sh` | Builds and deploys to an existing K3s host using an S3 bucket; changes Kubernetes and AWS resources |
-| `scripts/ec2_graphblas_benchmark.sh` | Runs the containerized GraphBLAS benchmark against S3 on EC2; uses AWS credentials and can incur cost |
-| `scripts/run_s3_bolt_benchmark.sh` | Starts the S3-backed Bolt benchmark and optionally deletes its benchmark prefix afterward |
-| `scripts/neo4j_exact_hop_benchmark.sh` | Pulls and runs Neo4j in Docker for comparison measurements |
-| `scripts/bolt_graphblas_client.py`, `scripts/falkordb_bolt_benchmark.py`, `scripts/s3_bolt_driver_benchmark.py` | Python benchmark clients used by the shell harnesses; require the `neo4j` package |
-| `scripts/multinode_k3s_client.py` | Runs inside the disposable K3d client Pod created by `multinode_k3s.sh` |
-
-`just update-slatedb` is a maintenance command, not a verification command. It
-updates the pinned SlateDB dependency in `Cargo.lock`; review and test the
-resulting lockfile diff before committing it.
+from the repository root; the full native suite requires `libcypher-parser` and
+SuiteSparse GraphBLAS. [DEVELOPMENT.md](DEVELOPMENT.md) documents the complete
+surface — verification recipes, local and MinIO harnesses, and the standalone
+scripts. Run `just ci` before opening a pull request.
 
 ### Repository layout
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ mkdir -p hydradb-data/store hydradb-data/cache
 printf '%s\n' 'local-development-token-32-bytes' > hydradb-data/auth-token
 
 docker run --rm \
+  --user "$(id -u):$(id -g)" \
   -p 7687:7687 -p 8443:8443 -p 9090:9090 \
   -v "$PWD/hydradb-data:/data" \
   -e CLOUD_PROVIDER=local \
@@ -134,9 +135,13 @@ docker run --rm \
 
 The node runs in the foreground. `LOCAL_PATH` must point at a directory that
 already exists, which is why `hydradb-data/store` is created before the mount.
-The image entrypoint is `graph-node`; it also ships `graph-indexer`. For
-production, pin an image digest rather than `latest` — see the
-[Helm chart guide](charts/hydradb/README.md).
+`--user "$(id -u):$(id -g)"` is required: the image runs as UID/GID `10001`,
+but the bind-mounted `hydradb-data` is owned by the host user, so without it the
+container cannot write its store or cache and fails on the first storage
+operation. Running as the host user makes the mounted directories writable and
+keeps the created files host-owned. The image entrypoint is `graph-node`; it
+also ships `graph-indexer`. For production, pin an image digest rather than
+`latest` — see the [Helm chart guide](charts/hydradb/README.md).
 
 </details>
 


### PR DESCRIPTION
## Summary

Restructures the README around the newly published container image and splits the
deep contributor material into a dedicated `DEVELOPMENT.md`.

- **Intro** — states storage/compute disaggregation and names the two compute
  roles: **data nodes** (`graph-node`) and **indexers** (`graph-indexer`).
- **Architecture diagram** — reworked so each `graph-node` owns a **private local
  SSD/NVMe cache**, with **object storage as the shared layer beneath** the tier.
- **Getting Started** — now two collapsible paths, **Run with Docker** and **Build
  from source**, with a shared *Verify a running node* section and folded
  troubleshooting.
- **Docker** — documents the published `ghcr.io/hydra-db/hydradb` image and tag
  scheme, plus `docker pull` / `docker run` quickstart.
- **DEVELOPMENT.md** (new) — verification recipes, local + MinIO harnesses, and
  standalone scripts moved here; README keeps a short pointer and the repository
  layout.
- **Badges** — added a live-benchmarks badge; fixed the broken **CI** badge
  (`ci.yml` no longer exists) by pointing it at the `container.yml` workflow.

## Note for reviewers

The GHCR package `ghcr.io/hydra-db/hydradb` is **currently private** — an
anonymous `docker pull` returns `unauthorized`. Making it public is blocked by an
org-level policy ("Public packages disabled by organization administrators"). The
Docker quickstart will only work anonymously once an org owner enables public
packages and the package visibility is flipped to Public. If it stays private, a
`docker login ghcr.io` step should be added to the Docker section.

Docs-only change; no code paths touched.