### PR TITLE
ci: publish linux/arm64 alongside linux/amd64

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,3 +8,15 @@ target
 *.log
 *.svg
 *.txt
+
+# Prose and operator assets. None of it is compiled — nothing in the tree uses
+# include_str!/include_bytes! — but everything here lands in the build context,
+# so without these entries editing a book or a Grafana dashboard changes the
+# COPY layer and forces the application build to run again.
+books
+docs
+notes
+grafana
+interactive
+charts
+scripts

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+
+# Workflow actions are pinned to commit SHAs rather than to `@v4`-style tags, so
+# a repointed tag cannot change what runs in a job holding `packages: write`.
+# A pinned SHA does not float, which is the point, but it also means security
+# fixes never arrive on their own — this keeps the pins moving.
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: ci

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -21,10 +21,24 @@ env:
   IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/hydradb
 
 jobs:
+  # Both architectures build on a native runner rather than one runner emulating
+  # the other through QEMU. This is a `cargo build --release` of the whole graph
+  # node against GraphBLAS and libcypher-parser; it takes ~11 minutes natively,
+  # and under emulation it runs long enough to threaten the job timeout. The
+  # arm64 runners are free for public repositories, so the matrix costs wall
+  # clock time only up to the slower of the two arches.
   verify:
-    name: Verify production image
-    runs-on: ubuntu-latest
+    name: Verify production image (${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
     if: github.event_name == 'pull_request'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
     steps:
       - name: Check out source
         uses: actions/checkout@v4
@@ -38,21 +52,100 @@ jobs:
           context: .
           file: Dockerfile
           target: runtime
-          platforms: linux/amd64
+          platforms: ${{ matrix.platform }}
           push: false
 
-  publish:
-    name: Publish release image
-    runs-on: ubuntu-latest
+  # Each arch pushes an anonymous, digest-only image; the `merge` job below is
+  # what binds those digests to the release tags. Splitting it this way is what
+  # lets the two builds run on different machines — a single build-push-action
+  # step emitting both platforms would have to run them on one runner.
+  build:
+    name: Build release image (${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
     if: github.event_name == 'push'
     permissions:
       contents: read
       packages: write
       attestations: write
       id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
     steps:
       - name: Check out source
         uses: actions/checkout@v4
+
+      - name: Derive artifact-safe platform name
+        run: echo "PLATFORM_PAIR=${PLATFORM//\//-}" >> "$GITHUB_ENV"
+        env:
+          PLATFORM: ${{ matrix.platform }}
+
+      - name: Generate image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          target: runtime
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          provenance: true
+          sbom: true
+
+      - name: Export digest
+        run: |
+          mkdir -p "${{ runner.temp }}/digests"
+          digest='${{ steps.build.outputs.digest }}'
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # `imagetools create` assembles one manifest list from the per-arch digests and
+  # applies every release tag to it. Each source digest is an index carrying that
+  # arch's provenance and SBOM attestations, and imagetools copies those children
+  # across, so the published tags keep the attestations the single-arch build had.
+  merge:
+    name: Publish release image
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -76,15 +169,14 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and publish image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: Dockerfile
-          target: runtime
-          platforms: linux/amd64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          provenance: true
-          sbom: true
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect published manifest
+        run: |
+          docker buildx imagetools inspect \
+            "${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}"

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -43,13 +43,13 @@ jobs:
             pair: linux-arm64
     steps:
       - name: Check out source
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Build production image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           file: Dockerfile
@@ -84,19 +84,19 @@ jobs:
             pair: linux-arm64
     steps:
       - name: Check out source
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Generate image metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
           images: ${{ env.IMAGE_NAME }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -104,7 +104,7 @@ jobs:
 
       - name: Build and push image by digest
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           file: Dockerfile
@@ -126,7 +126,7 @@ jobs:
           touch "${{ runner.temp }}/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: digests-${{ matrix.pair }}
           path: ${{ runner.temp }}/digests/*
@@ -146,29 +146,35 @@ jobs:
       packages: write
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           path: ${{ runner.temp }}/digests
           pattern: digests-*
           merge-multiple: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Generate image metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
           images: ${{ env.IMAGE_NAME }}
+          # `latest=auto` moves the tag only for a stable semver release. The
+          # previous `type=raw,value=latest` was unconditional, and this workflow
+          # fires on every `v*` tag, so tagging a v0.2.0-rc1 would have pointed
+          # `latest` — what a bare `docker pull` resolves to — at a release
+          # candidate. The semver patterns below already skip pre-releases.
+          flavor: |
+            latest=auto
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=sha,prefix=sha-
-            type=raw,value=latest
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -37,8 +37,10 @@ jobs:
         include:
           - platform: linux/amd64
             runner: ubuntu-latest
+            pair: linux-amd64
           - platform: linux/arm64
             runner: ubuntu-24.04-arm
+            pair: linux-arm64
     steps:
       - name: Check out source
         uses: actions/checkout@v4
@@ -54,6 +56,8 @@ jobs:
           target: runtime
           platforms: ${{ matrix.platform }}
           push: false
+          cache-from: type=gha,scope=container-${{ matrix.pair }}
+          cache-to: type=gha,mode=max,scope=container-${{ matrix.pair }}
 
   # Each arch pushes an anonymous, digest-only image; the `merge` job below is
   # what binds those digests to the release tags. Splitting it this way is what
@@ -74,16 +78,13 @@ jobs:
         include:
           - platform: linux/amd64
             runner: ubuntu-latest
+            pair: linux-amd64
           - platform: linux/arm64
             runner: ubuntu-24.04-arm
+            pair: linux-arm64
     steps:
       - name: Check out source
         uses: actions/checkout@v4
-
-      - name: Derive artifact-safe platform name
-        run: echo "PLATFORM_PAIR=${PLATFORM//\//-}" >> "$GITHUB_ENV"
-        env:
-          PLATFORM: ${{ matrix.platform }}
 
       - name: Generate image metadata
         id: meta
@@ -113,6 +114,10 @@ jobs:
           outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
           provenance: true
           sbom: true
+          # Shares the scope the pull-request builds populate, so a release tag
+          # reuses the dependency layer its own PR already compiled.
+          cache-from: type=gha,scope=container-${{ matrix.pair }}
+          cache-to: type=gha,mode=max,scope=container-${{ matrix.pair }}
 
       - name: Export digest
         run: |
@@ -123,7 +128,7 @@ jobs:
       - name: Upload digest
         uses: actions/upload-artifact@v4
         with:
-          name: digests-${{ env.PLATFORM_PAIR }}
+          name: digests-${{ matrix.pair }}
           path: ${{ runner.temp }}/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -176,7 +181,24 @@ jobs:
             $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf '${{ env.IMAGE_NAME }}@sha256:%s ' *)
 
-      - name: Inspect published manifest
+      # A publish that silently loses an architecture is the exact failure this
+      # workflow exists to prevent, and it is invisible until someone pulls on
+      # the missing one. Assert the platform set rather than printing it. The
+      # provenance and SBOM manifests report `unknown/unknown` and are filtered
+      # out so they cannot be mistaken for a platform.
+      - name: Verify published manifest covers both platforms
         run: |
-          docker buildx imagetools inspect \
-            "${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}"
+          image="${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}"
+          docker buildx imagetools inspect "$image"
+
+          published=$(docker buildx imagetools inspect "$image" --format '{{json .Manifest}}' \
+            | jq -r '.manifests[].platform | select(.os != "unknown") | "\(.os)/\(.architecture)"' \
+            | sort -u)
+          echo "Published platforms: $(echo "$published" | tr '\n' ' ')"
+
+          for expected in linux/amd64 linux/arm64; do
+            if ! grep -qxF "$expected" <<<"$published"; then
+              echo "::error::$image does not include $expected"
+              exit 1
+            fi
+          done

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:24.04 AS build-base
 
 ARG RUST_VERSION=1.91.0
+ARG CARGO_CHEF_VERSION=0.1.78
 ENV DEBIAN_FRONTEND=noninteractive \
     CARGO_HOME=/usr/local/cargo \
     RUSTUP_HOME=/usr/local/rustup \
@@ -14,9 +15,32 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /workspace
+
+# cargo-chef is what lets the ~400 dependency crates cache independently of our
+# own source. It is installed in this stage, which changes only when the apt set
+# or the toolchain does, so it is paid for once and never on a source change.
+RUN cargo install cargo-chef --locked --version "${CARGO_CHEF_VERSION}"
+
+# `prepare` reduces the tree to a dependency manifest. Its output is a function
+# of Cargo.toml, Cargo.lock and the crate layout only, so editing src/ leaves
+# recipe.json byte-identical and the cook layers below stay valid. This stage
+# still re-runs on every source change; it takes seconds and produces no build.
+FROM build-base AS planner
+
 COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
 
 FROM build-base AS builder
+
+# cook must be handed the same profile and feature set as the build below it.
+# A mismatch is not an error — cargo simply rebuilds what does not match, which
+# silently undoes the dependency/application split this whole stage exists for.
+COPY --from=planner /workspace/recipe.json recipe.json
+RUN cargo chef cook --locked --release \
+      --features server-runtime,indexer-runtime,otlp \
+      --recipe-path recipe.json
+
+COPY . .
 
 # `otlp` is off by default in Cargo.toml, and every OTLP path — the trace
 # bridge, the log appender, the observable-counter registration — compiles to an
@@ -30,6 +54,13 @@ RUN cargo build --locked --release --features server-runtime,indexer-runtime,otl
 
 FROM build-base AS benchmark-builder
 
+# A different feature set to the builder stage above, so this cooks and caches
+# its own dependency layer rather than sharing one.
+COPY --from=planner /workspace/recipe.json recipe.json
+RUN cargo chef cook --locked --release --features server-runtime \
+      --recipe-path recipe.json
+
+COPY . .
 RUN cargo build --locked --release --features server-runtime \
       --example s3_bolt_benchmark_server && \
     strip target/release/examples/s3_bolt_benchmark_server

--- a/README.md
+++ b/README.md
@@ -106,6 +106,25 @@ versions, the commit SHA, and `latest` (for example `0.1.0`, `0.1`, `0`,
 docker pull ghcr.io/hydra-db/hydradb:latest
 ```
 
+Images are published for `linux/amd64` and `linux/arm64`, so Docker selects the
+right one for the host and Apple Silicon needs no extra flags. Releases up to
+and including `0.1.0` were `linux/amd64` only, and pulling one of those on an
+ARM host fails with:
+
+```
+no matching manifest for linux/arm64/v8 in the manifest list entries
+```
+
+That message means the tag predates multi-architecture publishing, not that the
+pull is misconfigured. Move to a release after `0.1.0`, or run the older tag
+under emulation with `--platform linux/amd64` — correct but slower, and it
+requires Rosetta on Apple Silicon. To see which architectures a tag actually
+carries before pulling it:
+
+```bash
+docker buildx imagetools inspect ghcr.io/hydra-db/hydradb:latest
+```
+
 This starts one plaintext node backed by a host directory mounted into the
 container:
 


### PR DESCRIPTION
## The bug

`docker pull ghcr.io/hydra-db/hydradb:latest` fails on Apple Silicon:

```
no matching manifest for linux/arm64/v8 in the manifest list entries
```

The publish job set `platforms: linux/amd64`, so the manifest list behind every published tag has exactly one entry. Nothing was failing — the v0.1.0 run succeeded — arm64 was simply never built. The `verify` job carried the same restriction, which is why no PR ever caught an arm-specific break.

## Commit 1 — multi-arch on native runners

Not by adding `linux/arm64` to the platforms line: that routes the arm build through QEMU on an amd64 runner, and this release build of the whole graph node against GraphBLAS and libcypher-parser runs long enough emulated to threaten the job timeout. Instead each arch builds natively (`ubuntu-24.04-arm` is free for public repos), pushes a digest-only image, and a `merge` job assembles the manifest list with `imagetools create` — which copies each arch's provenance and SBOM attestation children into the merged index, so published tags keep their supply-chain metadata. PR verification matrixes both arches too, so arm breaks surface on the PR rather than at tag time.

## Commit 2 — dependency caching, context hygiene, publish assertion

Nothing was cached between CI runs: every build compiled all ~400 dependency crates from scratch. A cache alone would not have fixed it, because `build-base` ran `COPY . .` before `cargo build`, so any file in the context invalidated the dependency build. Two changes together:

- **cargo-chef** (pinned 0.1.78) splits dependency compilation from application compilation. Safe here because `build.rs` reads no files — it only shells out to `pkg-config`/`brew` — and nothing in the tree uses `include_str!`/`include_bytes!`.
- **GHA cache** scoped per arch (`container-linux-amd64` / `container-linux-arm64`) so the arches cannot evict each other; release builds share the scope their own PR populated.
- **`.dockerignore`** now excludes `books/`, `docs/`, `notes/`, `grafana/`, `interactive/`, `charts/`, `scripts/` — prose and operator assets that reached the build context and churned the COPY layer.
- The merge job now **asserts** both platforms are present in the published manifest (filtering the `unknown/unknown` attestation manifests) instead of just printing it. A publish that silently drops an arch is the exact failure this workflow exists to prevent.
- README documents the multi-arch images and explains that the `no matching manifest` error on an ARM host means a tag published before this change.

**Measured on this PR** (same commit, run 31621455704): cold cache 12m24s, warm cache **15s**. Cold builds pay ~5 min over the old single-pass build (`cargo install cargo-chef` + cook); warm builds get it back many times over. A source-only change lands in between — dependencies cached, app crate recompiled.

## Commit 3 — supply-chain pins and `latest` guard

The `merge` job holds `packages: write` and feeds downloaded artifacts straight into `imagetools create`, so a repointed mutable action tag could publish attacker-controlled content under the release tags (Greptile P2). All 13 action references are pinned to commit SHAs, kept on the majors already in use — moving `checkout` v4→v7 is a behavior change, not a security fix. `.github/dependabot.yml` (weekly, `github-actions`) keeps the pins from rotting.

`type=raw,value=latest` was unconditional while the workflow fires on every `v*` tag, so tagging `v0.2.0-rc1` would have moved `latest` onto a release candidate. `latest=auto` applies it only to stable semver releases, consistent with how the `{{major}}`/`{{major}}.{{minor}}` semver patterns already skip pre-releases.

## After merge

Existing tags stay amd64-only; the manifest list is written at push time. Cutting the next `v*` tag republishes `latest` as a two-arch list. To fix `latest` without a new release, re-run the workflow on the `v0.1.0` tag.