### PR TITLE
fix: stop dropping intra-frontier edges in the WAL-overlay traversal

### DIFF
--- a/src/shard/topology_tail.rs
+++ b/src/shard/topology_tail.rs
@@ -458,6 +458,33 @@ pub(crate) fn expand_range_with_overlay(
     let mut reachable = BTreeSet::new();
     let mut edge_visits = 0_u64;
 
+    // A zero-length path is the start vertex itself, so `*0..n` includes it —
+    // and the level loop below starts at hop 1, so nothing else here can. Left
+    // out, `MATCH (a)-[:T*0..2]->(b)` silently dropped `a` from its own answer
+    // whenever a WAL overlay was active, while the non-overlay path
+    // (`expand_range_bitmap`, which seeds `result_seen` from `start_ordinals`)
+    // returned it.
+    //
+    // Membership is the same test the non-overlay path uses: the compiled
+    // dictionary is sources ∪ destinations, so a start with no incident edge is
+    // not a vertex of the graph and is not returned. The overlay clause covers
+    // a start the WAL has since given an outgoing edge to, which the compiled
+    // generation cannot know about yet.
+    //
+    // Known limit: a start that appears *only* as an overlay destination is
+    // still missed. Catching it needs a scan of the whole overlay per start,
+    // and the case is a vertex created after the last index build and reached
+    // by a zero-length path in the same query.
+    if min_hops == 0 {
+        reachable.extend(starts.iter().copied().filter(|start| {
+            crate::sparse_kernel::compiled_graphblas_contains_vertex(compiled, *start)
+                || overlay
+                    .states
+                    .get(start)
+                    .is_some_and(|destinations| destinations.values().any(|exists| *exists))
+        }));
+    }
+
     for hop in 1..=max_hops {
         if frontier.is_empty() {
             break;
@@ -585,6 +612,34 @@ mod tests {
             (2u64, BTreeSet::from([9u64])),
         ]);
         assert_overlay_walk_matches_range_expansion(&adjacency, &[0], 3, 3);
+    }
+
+    /// A zero-length path is the start vertex itself. `*0..n` must return it,
+    /// and the level loop starts at hop 1, so only an explicit seed can.
+    ///
+    /// Caught by the sweep below rather than written first: `min_hops == 0` is
+    /// reachable straight from Cypher — `lower_hop_range` accepts an explicit
+    /// `0` and `validate_reachable_hop_request` only rejects `min > max` — so
+    /// `MATCH (a)-[:T*0..2]->(b)` was dropping `a` whenever an overlay existed.
+    #[test]
+    fn a_zero_length_path_returns_the_start_vertex() {
+        let adjacency = crate::sparse_kernel::Adjacency::from([
+            (1u64, BTreeSet::from([2u64])),
+            (2u64, BTreeSet::from([3u64])),
+        ]);
+        for (min_hops, max_hops) in [(0u8, 0u8), (0, 1), (0, 2)] {
+            assert_overlay_walk_matches_range_expansion(&adjacency, &[1], min_hops, max_hops);
+        }
+    }
+
+    /// A start vertex with no incident edge is not a vertex of the graph, so
+    /// `*0..n` must not invent it. This is the same rule `start_ordinals`
+    /// applies on the non-overlay path, and getting it wrong in the other
+    /// direction would have been just as silent.
+    #[test]
+    fn a_zero_length_path_does_not_invent_an_absent_start() {
+        let adjacency = crate::sparse_kernel::Adjacency::from([(1u64, BTreeSet::from([2u64]))]);
+        assert_overlay_walk_matches_range_expansion(&adjacency, &[404], 0, 2);
     }
 
     /// The general guard, over shapes the two targeted cases do not cover:

--- a/src/shard/topology_tail.rs
+++ b/src/shard/topology_tail.rs
@@ -457,17 +457,25 @@ pub(crate) fn expand_range_with_overlay(
     let mut frontier = starts.iter().copied().collect::<BTreeSet<_>>();
     let mut reachable = BTreeSet::new();
     let mut edge_visits = 0_u64;
-    let empty = BTreeMap::new();
 
     for hop in 1..=max_hops {
         if frontier.is_empty() {
             break;
         }
-        let frontier_values = frontier.iter().copied().collect::<Vec<_>>();
-        let base =
-            crate::sparse_kernel::expand_compiled_graphblas(compiled, &empty, &frontier_values, 1)?;
-        edge_visits = edge_visits.saturating_add(base.edge_visits);
-        let mut next = base.vertices.into_iter().collect::<BTreeSet<_>>();
+        // One hop is a *neighbourhood*, not a reachability query, and the two
+        // are not interchangeable. This used to call `expand(frontier, 1)`,
+        // which seeds its `seen` set with its `starts` and then strips them
+        // from the result — so every edge between two members of the same
+        // frontier vanished, dropping rows whenever `min_hops > 1` and
+        // collapsing the frontier a hop early when the only way forward ran
+        // through such an edge. Unioning per-vertex neighbourhoods has no
+        // start set and therefore no way to express that bug.
+        let mut next = BTreeSet::new();
+        for src in &frontier {
+            let neighbors = crate::sparse_kernel::compiled_graphblas_out_neighbors(compiled, *src);
+            edge_visits = edge_visits.saturating_add(neighbors.len() as u64);
+            next.extend(neighbors);
+        }
 
         for src in &frontier {
             let Some(changes) = overlay.states.get(src) else {
@@ -510,6 +518,111 @@ pub(crate) fn expand_range_with_overlay(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// An empty overlay makes [`expand_range_with_overlay`] and
+    /// `expand_range_compiled_graphblas` the same specification, so any
+    /// disagreement between them is a bug in the overlay walk. Nothing pinned
+    /// that before, which is how the frontier defect below survived.
+    fn assert_overlay_walk_matches_range_expansion(
+        adjacency: &crate::sparse_kernel::Adjacency,
+        starts: &[VertexId],
+        min_hops: u8,
+        max_hops: u8,
+    ) {
+        let compiled = crate::sparse_kernel::compile_graphblas_matrix(
+            adjacency,
+            crate::sparse_kernel::SparseKernelBackend::CompactCsc,
+        )
+        .expect("the matrix compiles");
+
+        let with_overlay = expand_range_with_overlay(
+            &compiled,
+            &GraphTopologyOverlay::default(),
+            starts,
+            min_hops,
+            max_hops,
+        )
+        .expect("the overlay walk succeeds");
+        let without_overlay = crate::sparse_kernel::expand_range_compiled_graphblas(
+            &compiled,
+            &BTreeMap::new(),
+            starts,
+            min_hops,
+            max_hops,
+        )
+        .expect("the range expansion succeeds");
+
+        assert_eq!(
+            with_overlay.vertices, without_overlay.vertices,
+            "overlay walk disagreed for starts={starts:?} hops={min_hops}..{max_hops}"
+        );
+        assert_eq!(
+            with_overlay.edge_visits, without_overlay.edge_visits,
+            "overlay walk counted different work for starts={starts:?} hops={min_hops}..{max_hops}"
+        );
+    }
+
+    /// `0 -> 2`, `0 -> 3`, `3 -> 2`. The hop-1 frontier from `0` is `{2, 3}`,
+    /// and `3 -> 2` runs *inside* that frontier, so `2` is reachable at exactly
+    /// two hops. Expanding with `expand(frontier, 1)` hid it and returned `[]`.
+    #[test]
+    fn an_edge_between_two_frontier_members_survives_the_overlay_walk() {
+        let adjacency = crate::sparse_kernel::Adjacency::from([
+            (0u64, BTreeSet::from([2u64, 3u64])),
+            (3u64, BTreeSet::from([2u64])),
+        ]);
+        assert_overlay_walk_matches_range_expansion(&adjacency, &[0], 2, 2);
+    }
+
+    /// The same defect truncated the walk: with `2 -> 9` added, vertex `9` sits
+    /// three hops out and is reachable only through the intra-frontier edge, so
+    /// losing that edge emptied the frontier and returned `[]` instead of `[9]`.
+    #[test]
+    fn an_intra_frontier_edge_does_not_truncate_the_walk() {
+        let adjacency = crate::sparse_kernel::Adjacency::from([
+            (0u64, BTreeSet::from([2u64, 3u64])),
+            (3u64, BTreeSet::from([2u64])),
+            (2u64, BTreeSet::from([9u64])),
+        ]);
+        assert_overlay_walk_matches_range_expansion(&adjacency, &[0], 3, 3);
+    }
+
+    /// The general guard, over shapes the two targeted cases do not cover:
+    /// cycles through a start vertex, unknown starts, `min_hops == 0`, and
+    /// ranges wider than one hop.
+    #[test]
+    fn the_overlay_walk_agrees_with_range_expansion_across_hop_ranges() {
+        let graphs = [
+            // A cycle back through the start vertex.
+            crate::sparse_kernel::Adjacency::from([
+                (1u64, BTreeSet::from([2u64])),
+                (2u64, BTreeSet::from([1u64, 3u64])),
+            ]),
+            // A diamond, so a vertex is reached at two different depths.
+            crate::sparse_kernel::Adjacency::from([
+                (1u64, BTreeSet::from([2u64, 3u64])),
+                (2u64, BTreeSet::from([4u64])),
+                (3u64, BTreeSet::from([4u64])),
+                (4u64, BTreeSet::from([5u64])),
+            ]),
+            // A self-loop: the frontier contains its own neighbour.
+            crate::sparse_kernel::Adjacency::from([
+                (1u64, BTreeSet::from([1u64, 2u64])),
+                (2u64, BTreeSet::from([3u64])),
+            ]),
+        ];
+        for adjacency in &graphs {
+            for starts in [&[1u64][..], &[1, 2][..], &[404][..]] {
+                for min_hops in 0..=3u8 {
+                    for max_hops in min_hops..=3u8 {
+                        assert_overlay_walk_matches_range_expansion(
+                            adjacency, starts, min_hops, max_hops,
+                        );
+                    }
+                }
+            }
+        }
+    }
 
     #[cfg(feature = "opencypher")]
     #[test]

--- a/src/sparse_kernel/graphblas.rs
+++ b/src/sparse_kernel/graphblas.rs
@@ -295,7 +295,10 @@ impl CompiledCompactCscMatrix {
             .any(|index| self.neighbor(index) == dst_ordinal)
     }
 
-    #[cfg(feature = "opencypher")]
+    /// Ungated, unlike its `_intersecting` sibling: `shard::topology_tail`'s
+    /// overlay walk needs a one-hop neighbourhood and is not itself behind
+    /// `opencypher`, so gating this would leave the overlay path unbuildable
+    /// with `default = []`.
     fn neighbors(&self, vertex: VertexId) -> Vec<VertexId> {
         let Some(ordinal) = self.ordinal(vertex) else {
             return Vec::new();
@@ -726,7 +729,10 @@ impl CompiledGraphBlasMatrix {
             .neighbors(vertex)
     }
 
-    #[cfg(feature = "opencypher")]
+    /// The one-hop out-neighbourhood. Always served from `canonical_out`, which
+    /// both kernels populate, so this needs no replica lock and no `mxv`.
+    ///
+    /// Ungated for the reason given on [`CompiledCompactCscMatrix::neighbors`].
     pub(crate) fn out_neighbors(&self, vertex: VertexId) -> Vec<VertexId> {
         self.canonical_out.neighbors(vertex)
     }

--- a/src/sparse_kernel/graphblas.rs
+++ b/src/sparse_kernel/graphblas.rs
@@ -287,6 +287,17 @@ impl CompiledCompactCscMatrix {
         self.indices.get(index)
     }
 
+    /// Whether the vertex is in this matrix's dictionary — which is
+    /// sources ∪ destinations, so it means "has at least one incident edge in
+    /// the generation this matrix was compiled from".
+    ///
+    /// `expand_range_bitmap` decides which start vertices a `*0..n` query
+    /// returns by exactly this test (through `start_ordinals`), so the overlay
+    /// walk has to be able to ask the same question to give the same answer.
+    fn contains_vertex(&self, vertex: VertexId) -> bool {
+        self.ordinal(vertex).is_some()
+    }
+
     fn contains_edge(&self, src: VertexId, dst: VertexId) -> bool {
         let (Some(src_ordinal), Some(dst_ordinal)) = (self.ordinal(src), self.ordinal(dst)) else {
             return false;
@@ -720,6 +731,13 @@ impl CompiledGraphBlasMatrix {
 
     pub(crate) fn contains_edge(&self, src: VertexId, dst: VertexId) -> bool {
         self.canonical_out.contains_edge(src, dst)
+    }
+
+    /// Whether the vertex exists in the compiled generation. Ungated for the
+    /// same reason as [`Self::out_neighbors`]: `shard::topology_tail` needs it
+    /// and is not behind `opencypher`.
+    pub(crate) fn contains_vertex(&self, vertex: VertexId) -> bool {
+        self.canonical_out.contains_vertex(vertex)
     }
 
     #[cfg(feature = "opencypher")]

--- a/src/sparse_kernel/mod.rs
+++ b/src/sparse_kernel/mod.rs
@@ -331,6 +331,13 @@ pub(crate) fn compiled_graphblas_contains_edge(
     compiled.contains_edge(src, dst)
 }
 
+pub(crate) fn compiled_graphblas_contains_vertex(
+    compiled: &CompiledGraphBlasMatrix,
+    vertex: VertexId,
+) -> bool {
+    compiled.contains_vertex(vertex)
+}
+
 #[cfg(feature = "opencypher")]
 pub(crate) fn compiled_graphblas_in_neighbors(
     compiled: &CompiledGraphBlasMatrix,

--- a/src/sparse_kernel/mod.rs
+++ b/src/sparse_kernel/mod.rs
@@ -339,7 +339,8 @@ pub(crate) fn compiled_graphblas_in_neighbors(
     compiled.in_neighbors(vertex)
 }
 
-#[cfg(feature = "opencypher")]
+/// Ungated: `shard::topology_tail`'s overlay walk expands one hop at a time and
+/// is not behind `opencypher`. See [`CompiledGraphBlasMatrix::out_neighbors`].
 pub(crate) fn compiled_graphblas_out_neighbors(
     compiled: &CompiledGraphBlasMatrix,
     vertex: VertexId,


### PR DESCRIPTION

Closes #69.

## What's wrong

`expand_range_with_overlay` walks a hop range one level at a time and got each
level's neighbours by calling the **fixed-hop** kernel with the entire current
frontier as its `starts` argument:

```rust
let base = expand_compiled_graphblas(compiled, &empty, &frontier_values, 1)?;
````

expand is not a neighbourhood function. It seeds its seen set with starts
and strips them from the result (graphblas.rs:374-378, :405-411). Passing the
frontier as starts therefore makes every edge between two members of the
same frontier invisible. Two consequences:

1. Missing rows — with min_hops > 1, a vertex whose only path of exactly
   d hops arrives via an intra-frontier edge is never returned.
2. Early termination — a frontier whose only forward progress runs through
   such an edge collapses to empty and the walk breaks a hop early, losing
   everything downstream.

Neither surfaces as an error; the query just returns fewer rows.

## Why it matters

This path is taken exactly when the WAL-tail overlay is non-empty — i.e. when
the compiled index generation lags the read epoch, which is the normal state
between indexer cycles. The else arm (query.rs:5654) calls
expand_range_compiled_graphblas and is correct. So MATCH (a)-[:T*2..3]->(b)
returns different rows depending on how recently the indexer ran.

Reached from query.rs:5651 (Cypher variable-length match), query.rs:5730
(its count(*) form), and traversal.rs:109 (matrix_reachable).

## The fix

Union per-vertex neighbourhoods instead. There is no start set in the new form,
so the bug is unrepresentable rather than merely absent.

out_neighbors had to come out from behind `#[cfg(feature = "opencypher")],
because shard::topology_tail is not itself feature-gated and would otherwise
fail to build with default = []. It reads canonical_out, which both kernels
always populate, so the new path needs no replica lock and no mxv — it is
cheaper than the one it replaces, not just correct. edge_visits is unchanged
by construction: both forms sum the degrees of the frontier.

## Tests

Three, plus a shared helper. The helper is the durable part: with an empty
overlay, expand_range_with_overlay and expand_range_compiled_graphblas are
the same specification, so any disagreement between them is a bug in the
overlay walk. Nothing pinned that before, which is how this survived.

* an_edge_between_two_frontier_members_survives_the_overlay_walk — the
  missing row ([] → [2]).
* an_intra_frontier_edge_does_not_truncate_the_walk — the truncated walk
  ([] → [9]).
* the_overlay_walk_agrees_with_range_expansion_across_hop_ranges — sweep over
  cycles through a start vertex, unknown starts, min_hops == 0, and wider
  ranges. No existing test used a start vertex reachable from itself.

## Verification, and its limits

* cargo check --lib and cargo check --tests pass clean, no new warnings.
* The three new tests are unrun. My machine has neither libgraphblas nor
  libcypher-parser, so the test binary cannot link and --features opencypher
  cannot build. Please confirm on a SuiteSparse box before merging.
* What I did run: a standalone line-for-line transcription of the three
  routines. Both failing cases flip from [] to the correct answer and match
  the non-overlay path exactly, edge_visits included. That validates the
  algorithm, not the integration.

## Out of scope

traversal.rs:109 is one of five branches in matrix_reachable_with_kernel
that disagree about fixed-hop vs range semantics — a separate bug, filed
independently. This PR does not touch it.
