### PR TITLE
fix: give matrix_reachable one traversal specification instead of two

### DIFF
--- a/src/engine/traversal.rs
+++ b/src/engine/traversal.rs
@@ -1,5 +1,41 @@
 use super::*;
 use crate::shard::QueryBudget;
+use crate::sparse_kernel::FrontierWalk;
+
+/// The one place a [`SparseTraversal`] becomes a [`MatrixTraversalResult`], and
+/// therefore the one place `matrix_reachable`'s specification is stated.
+///
+/// That specification is [`FrontierWalk::FixedHops`]: vertices at BFS distance
+/// `1..=hops`, start vertices excluded. Most branches below reach it through
+/// `expand`, which strips its own start set. The overlay branch reaches it
+/// through a `1..=hops` range walk, which does not — so a start vertex sitting
+/// on a cycle came back from that branch and from no other, and one call
+/// answered three different ways depending on how many start ids it was handed
+/// and whether a matrix happened to be cached.
+///
+/// Normalising here rather than at each branch is the point: five call sites
+/// each remembering to strip is five chances to forget, and the last four years
+/// of this function are the evidence. For the branches that already strip, the
+/// `retain` is a no-op costing one set lookup per result vertex.
+fn matrix_traversal_result(
+    backend: TraversalBackend,
+    traversal: crate::sparse_kernel::SparseTraversal,
+    starts: &[VertexId],
+    hops: u8,
+    base_epoch: StorageSequence,
+) -> MatrixTraversalResult {
+    let start_set: BTreeSet<VertexId> = starts.iter().copied().collect();
+    let mut vertices = traversal.vertices;
+    vertices.retain(|vertex| !start_set.contains(vertex));
+    MatrixTraversalResult {
+        backend,
+        vertices,
+        hops,
+        base_epoch,
+        edge_visits: traversal.edge_visits,
+        sparse_kernel: traversal.backend,
+    }
+}
 
 impl GraphShard {
     pub async fn matrix_reachable(
@@ -76,12 +112,18 @@ impl GraphShard {
                 )
                 .await?
             else {
+                // One start walks outward from storage, touching only the
+                // reachable subgraph; anything else materialises the whole
+                // adjacency first. That is a cost decision and stays. What must
+                // not vary with it is the *answer*, so the walk is asked for
+                // fixed hops explicitly rather than being handed a `(1, hops)`
+                // pair that reads as a range.
                 let traversal = if let [start] = starts {
                     self.reachable_from_storage_frontier(
                         cell_id,
                         edge_type,
                         *start,
-                        (1, hops),
+                        FrontierWalk::FixedHops(hops),
                         read_epoch,
                         &QueryBudget::new(self.limits.max_query_runtime_ms, None),
                     )
@@ -92,14 +134,13 @@ impl GraphShard {
                         .await?;
                     expand_sparse(&adjacency, starts, hops, sparse_kernel)?
                 };
-                return Ok(MatrixTraversalResult {
-                    backend: TraversalBackend::DirectSnapshot,
-                    vertices: traversal.vertices,
+                return Ok(matrix_traversal_result(
+                    TraversalBackend::DirectSnapshot,
+                    traversal,
+                    starts,
                     hops,
                     base_epoch,
-                    edge_visits: traversal.edge_visits,
-                    sparse_kernel: traversal.backend,
-                });
+                ));
             };
             record_matrix_profile(profile, "cached_graphblas_matrix", started.elapsed(), 0);
 
@@ -124,14 +165,13 @@ impl GraphShard {
                 total_started.elapsed(),
                 0,
             );
-            return Ok(MatrixTraversalResult {
-                backend: TraversalBackend::MatrixSnapshot,
-                vertices: traversal.vertices,
+            return Ok(matrix_traversal_result(
+                TraversalBackend::MatrixSnapshot,
+                traversal,
+                starts,
                 hops,
                 base_epoch,
-                edge_visits: traversal.edge_visits,
-                sparse_kernel: traversal.backend,
-            });
+            ));
         }
 
         let started = Instant::now();
@@ -152,14 +192,13 @@ impl GraphShard {
             total_started.elapsed(),
             0,
         );
-        Ok(MatrixTraversalResult {
-            backend: TraversalBackend::MatrixSnapshot,
-            vertices: traversal.vertices,
+        Ok(matrix_traversal_result(
+            TraversalBackend::MatrixSnapshot,
+            traversal,
+            starts,
             hops,
             base_epoch,
-            edge_visits: traversal.edge_visits,
-            sparse_kernel: traversal.backend,
-        })
+        ))
     }
 
     pub async fn direct_snapshot_reachable(
@@ -181,14 +220,16 @@ impl GraphShard {
             .canonical_adjacency_at(cell_id, edge_type, read_epoch)
             .await?;
         let traversal = expand_sparse(&adjacency, starts, hops, SparseKernelBackend::Adjacency)?;
-        Ok(MatrixTraversalResult {
-            backend: TraversalBackend::DirectSnapshot,
-            vertices: traversal.vertices,
+        // `expand_sparse` already strips the start set, so this is a no-op —
+        // routed through the same helper anyway so `benchmark_hot_hops` is
+        // comparing two results built to one specification.
+        Ok(matrix_traversal_result(
+            TraversalBackend::DirectSnapshot,
+            traversal,
+            starts,
             hops,
-            base_epoch: 0,
-            edge_visits: traversal.edge_visits,
-            sparse_kernel: traversal.backend,
-        })
+            0,
+        ))
     }
 
     pub async fn benchmark_hot_hops(
@@ -211,5 +252,72 @@ impl GraphShard {
             direct,
             matrix,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sparse_kernel::{SparseKernelBackend, SparseTraversal};
+
+    fn traversal(vertices: Vec<VertexId>) -> SparseTraversal {
+        SparseTraversal {
+            vertices,
+            edge_visits: 7,
+            backend: SparseKernelBackend::Adjacency,
+        }
+    }
+
+    /// The specification, stated as a test: a start vertex never appears in its
+    /// own reachability answer, however it was reached.
+    ///
+    /// The range-backed branches return start vertices that sit on a cycle; the
+    /// `expand`-backed ones never do. This is the single point that reconciles
+    /// them, so it is the single point worth pinning.
+    #[test]
+    fn a_start_vertex_reached_around_a_cycle_is_stripped_from_the_result() {
+        let result = matrix_traversal_result(
+            TraversalBackend::MatrixSnapshot,
+            traversal(vec![1, 2, 3]),
+            &[1],
+            2,
+            0,
+        );
+        assert_eq!(result.vertices, vec![2, 3]);
+    }
+
+    /// Every start is stripped, not just the first, and a start absent from the
+    /// graph strips nothing. Both matter because the arity of `starts` used to
+    /// select the branch, and therefore the answer.
+    #[test]
+    fn stripping_covers_every_start_and_tolerates_unknown_ones() {
+        let result = matrix_traversal_result(
+            TraversalBackend::DirectSnapshot,
+            traversal(vec![1, 2, 3, 4]),
+            &[1, 3, 999],
+            3,
+            0,
+        );
+        assert_eq!(result.vertices, vec![2, 4]);
+    }
+
+    /// Idempotent, so routing the branches that already strip through it is
+    /// free of behaviour change — which is what makes it safe to apply to all
+    /// five rather than only the two that were wrong.
+    #[test]
+    fn normalising_an_already_stripped_result_changes_nothing() {
+        let already = traversal(vec![2, 3]);
+        let result = matrix_traversal_result(
+            TraversalBackend::MatrixSnapshot,
+            already.clone(),
+            &[1],
+            2,
+            9,
+        );
+        assert_eq!(result.vertices, already.vertices);
+        assert_eq!(result.edge_visits, already.edge_visits);
+        assert_eq!(result.sparse_kernel, already.backend);
+        assert_eq!(result.base_epoch, 9);
+        assert_eq!(result.hops, 2);
     }
 }

--- a/src/shard/query.rs
+++ b/src/shard/query.rs
@@ -5432,7 +5432,9 @@ impl GraphShard {
                 cell_id,
                 edge_type,
                 src,
-                (min_hops, max_hops),
+                // Cypher `*min..max` is a statement about walk lengths, so this
+                // is the range specification and must stay that way.
+                crate::sparse_kernel::FrontierWalk::HopRange(min_hops, max_hops),
                 read_epoch,
                 budget,
             )
@@ -5443,16 +5445,32 @@ impl GraphShard {
         Ok((traversal.vertices, traversal.edge_visits))
     }
 
+    /// Walk outward from `src` over storage, honouring whichever of the two
+    /// traversal specifications [`FrontierWalk`] names.
+    ///
+    /// Both callers used to pass a bare `(min, max)` pair, which cannot say
+    /// which specification the caller meant. Cypher `*min..max` wants
+    /// [`FrontierWalk::HopRange`]; `matrix_reachable` wants
+    /// [`FrontierWalk::FixedHops`] and was silently getting the range answer,
+    /// which returns start vertices reached around a cycle and re-counts the
+    /// degree of every revisited vertex.
     pub(crate) async fn reachable_from_storage_frontier(
         &self,
         cell_id: &str,
         edge_type: &str,
         src: VertexId,
-        hop_range: (u8, u8),
+        walk: crate::sparse_kernel::FrontierWalk,
         read_epoch: StorageSequence,
         budget: &QueryBudget,
     ) -> Result<crate::sparse_kernel::SparseTraversal> {
-        let (min_hops, max_hops) = hop_range;
+        let (min_hops, max_hops) = walk.bounds();
+        // `FixedHops` is BFS: a vertex is expanded at the first depth that
+        // reaches it and never again, which is what keeps `edge_visits` equal
+        // to the compiled kernels' count. `HopRange` must re-expand, because
+        // "reachable in exactly `d` hops" is a statement about walks, not
+        // about distance.
+        let dedupes = walk.dedupes_by_distance();
+        let mut seen = BTreeSet::from([src]);
         let snapshot = self.db.snapshot().await?;
         let mut frontier = BTreeSet::from([src]);
         let mut reachable = BTreeSet::new();
@@ -5475,7 +5493,15 @@ impl GraphShard {
                     edge_visits,
                     self.limits.max_query_scan_edges,
                 )?;
-                next.extend(neighbors);
+                if dedupes {
+                    next.extend(
+                        neighbors
+                            .into_iter()
+                            .filter(|neighbor| seen.insert(*neighbor)),
+                    );
+                } else {
+                    next.extend(neighbors);
+                }
             }
             ensure_limit(
                 "graph_storage_frontier_vertices",
@@ -5491,6 +5517,11 @@ impl GraphShard {
                 )?;
             }
             frontier = next;
+        }
+        if dedupes {
+            // `seen` was seeded with `src` so BFS never re-expands it; the
+            // result must exclude it too, matching `expand`.
+            reachable.remove(&src);
         }
         Ok(crate::sparse_kernel::SparseTraversal {
             vertices: reachable.into_iter().collect(),

--- a/src/shard/topology_tail.rs
+++ b/src/shard/topology_tail.rs
@@ -457,17 +457,25 @@ pub(crate) fn expand_range_with_overlay(
     let mut frontier = starts.iter().copied().collect::<BTreeSet<_>>();
     let mut reachable = BTreeSet::new();
     let mut edge_visits = 0_u64;
-    let empty = BTreeMap::new();
 
     for hop in 1..=max_hops {
         if frontier.is_empty() {
             break;
         }
-        let frontier_values = frontier.iter().copied().collect::<Vec<_>>();
-        let base =
-            crate::sparse_kernel::expand_compiled_graphblas(compiled, &empty, &frontier_values, 1)?;
-        edge_visits = edge_visits.saturating_add(base.edge_visits);
-        let mut next = base.vertices.into_iter().collect::<BTreeSet<_>>();
+        // One hop is a *neighbourhood*, not a reachability query, and the two
+        // are not interchangeable. This used to call `expand(frontier, 1)`,
+        // which seeds its `seen` set with its `starts` and then strips them
+        // from the result — so every edge between two members of the same
+        // frontier vanished, dropping rows whenever `min_hops > 1` and
+        // collapsing the frontier a hop early when the only way forward ran
+        // through such an edge. Unioning per-vertex neighbourhoods has no
+        // start set and therefore no way to express that bug.
+        let mut next = BTreeSet::new();
+        for src in &frontier {
+            let neighbors = crate::sparse_kernel::compiled_graphblas_out_neighbors(compiled, *src);
+            edge_visits = edge_visits.saturating_add(neighbors.len() as u64);
+            next.extend(neighbors);
+        }
 
         for src in &frontier {
             let Some(changes) = overlay.states.get(src) else {
@@ -510,6 +518,111 @@ pub(crate) fn expand_range_with_overlay(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// An empty overlay makes [`expand_range_with_overlay`] and
+    /// `expand_range_compiled_graphblas` the same specification, so any
+    /// disagreement between them is a bug in the overlay walk. Nothing pinned
+    /// that before, which is how the frontier defect below survived.
+    fn assert_overlay_walk_matches_range_expansion(
+        adjacency: &crate::sparse_kernel::Adjacency,
+        starts: &[VertexId],
+        min_hops: u8,
+        max_hops: u8,
+    ) {
+        let compiled = crate::sparse_kernel::compile_graphblas_matrix(
+            adjacency,
+            crate::sparse_kernel::SparseKernelBackend::CompactCsc,
+        )
+        .expect("the matrix compiles");
+
+        let with_overlay = expand_range_with_overlay(
+            &compiled,
+            &GraphTopologyOverlay::default(),
+            starts,
+            min_hops,
+            max_hops,
+        )
+        .expect("the overlay walk succeeds");
+        let without_overlay = crate::sparse_kernel::expand_range_compiled_graphblas(
+            &compiled,
+            &BTreeMap::new(),
+            starts,
+            min_hops,
+            max_hops,
+        )
+        .expect("the range expansion succeeds");
+
+        assert_eq!(
+            with_overlay.vertices, without_overlay.vertices,
+            "overlay walk disagreed for starts={starts:?} hops={min_hops}..{max_hops}"
+        );
+        assert_eq!(
+            with_overlay.edge_visits, without_overlay.edge_visits,
+            "overlay walk counted different work for starts={starts:?} hops={min_hops}..{max_hops}"
+        );
+    }
+
+    /// `0 -> 2`, `0 -> 3`, `3 -> 2`. The hop-1 frontier from `0` is `{2, 3}`,
+    /// and `3 -> 2` runs *inside* that frontier, so `2` is reachable at exactly
+    /// two hops. Expanding with `expand(frontier, 1)` hid it and returned `[]`.
+    #[test]
+    fn an_edge_between_two_frontier_members_survives_the_overlay_walk() {
+        let adjacency = crate::sparse_kernel::Adjacency::from([
+            (0u64, BTreeSet::from([2u64, 3u64])),
+            (3u64, BTreeSet::from([2u64])),
+        ]);
+        assert_overlay_walk_matches_range_expansion(&adjacency, &[0], 2, 2);
+    }
+
+    /// The same defect truncated the walk: with `2 -> 9` added, vertex `9` sits
+    /// three hops out and is reachable only through the intra-frontier edge, so
+    /// losing that edge emptied the frontier and returned `[]` instead of `[9]`.
+    #[test]
+    fn an_intra_frontier_edge_does_not_truncate_the_walk() {
+        let adjacency = crate::sparse_kernel::Adjacency::from([
+            (0u64, BTreeSet::from([2u64, 3u64])),
+            (3u64, BTreeSet::from([2u64])),
+            (2u64, BTreeSet::from([9u64])),
+        ]);
+        assert_overlay_walk_matches_range_expansion(&adjacency, &[0], 3, 3);
+    }
+
+    /// The general guard, over shapes the two targeted cases do not cover:
+    /// cycles through a start vertex, unknown starts, `min_hops == 0`, and
+    /// ranges wider than one hop.
+    #[test]
+    fn the_overlay_walk_agrees_with_range_expansion_across_hop_ranges() {
+        let graphs = [
+            // A cycle back through the start vertex.
+            crate::sparse_kernel::Adjacency::from([
+                (1u64, BTreeSet::from([2u64])),
+                (2u64, BTreeSet::from([1u64, 3u64])),
+            ]),
+            // A diamond, so a vertex is reached at two different depths.
+            crate::sparse_kernel::Adjacency::from([
+                (1u64, BTreeSet::from([2u64, 3u64])),
+                (2u64, BTreeSet::from([4u64])),
+                (3u64, BTreeSet::from([4u64])),
+                (4u64, BTreeSet::from([5u64])),
+            ]),
+            // A self-loop: the frontier contains its own neighbour.
+            crate::sparse_kernel::Adjacency::from([
+                (1u64, BTreeSet::from([1u64, 2u64])),
+                (2u64, BTreeSet::from([3u64])),
+            ]),
+        ];
+        for adjacency in &graphs {
+            for starts in [&[1u64][..], &[1, 2][..], &[404][..]] {
+                for min_hops in 0..=3u8 {
+                    for max_hops in min_hops..=3u8 {
+                        assert_overlay_walk_matches_range_expansion(
+                            adjacency, starts, min_hops, max_hops,
+                        );
+                    }
+                }
+            }
+        }
+    }
 
     #[cfg(feature = "opencypher")]
     #[test]

--- a/src/shard/topology_tail.rs
+++ b/src/shard/topology_tail.rs
@@ -458,6 +458,16 @@ pub(crate) fn expand_range_with_overlay(
     let mut reachable = BTreeSet::new();
     let mut edge_visits = 0_u64;
 
+    // Hop zero is the start set itself, and the loop below only ever reaches
+    // hop one. Both compiled kernels seed their result with the starts they
+    // find in the matrix and drop the rest, so filter the same way or
+    // `min_hops == 0` disagrees with them in both directions.
+    if min_hops == 0 {
+        reachable.extend(frontier.iter().copied().filter(|start| {
+            crate::sparse_kernel::compiled_graphblas_contains_vertex(compiled, *start)
+        }));
+    }
+
     for hop in 1..=max_hops {
         if frontier.is_empty() {
             break;

--- a/src/sparse_kernel/graphblas.rs
+++ b/src/sparse_kernel/graphblas.rs
@@ -722,6 +722,13 @@ impl CompiledGraphBlasMatrix {
         self.canonical_out.contains_edge(src, dst)
     }
 
+    /// Whether the compiled vertex set contains `vertex`. Both kernels take
+    /// their vertex set from the same CSC, so `canonical_out` answers for
+    /// either, and both drop start vertices that are missing from it.
+    pub(crate) fn contains_vertex(&self, vertex: VertexId) -> bool {
+        self.canonical_out.ordinal(vertex).is_some()
+    }
+
     #[cfg(feature = "opencypher")]
     pub(crate) fn in_neighbors(&self, vertex: VertexId) -> Vec<VertexId> {
         self.canonical_in

--- a/src/sparse_kernel/graphblas.rs
+++ b/src/sparse_kernel/graphblas.rs
@@ -295,7 +295,10 @@ impl CompiledCompactCscMatrix {
             .any(|index| self.neighbor(index) == dst_ordinal)
     }
 
-    #[cfg(feature = "opencypher")]
+    /// Ungated, unlike its `_intersecting` sibling: `shard::topology_tail`'s
+    /// overlay walk needs a one-hop neighbourhood and is not itself behind
+    /// `opencypher`, so gating this would leave the overlay path unbuildable
+    /// with `default = []`.
     fn neighbors(&self, vertex: VertexId) -> Vec<VertexId> {
         let Some(ordinal) = self.ordinal(vertex) else {
             return Vec::new();
@@ -726,7 +729,10 @@ impl CompiledGraphBlasMatrix {
             .neighbors(vertex)
     }
 
-    #[cfg(feature = "opencypher")]
+    /// The one-hop out-neighbourhood. Always served from `canonical_out`, which
+    /// both kernels populate, so this needs no replica lock and no `mxv`.
+    ///
+    /// Ungated for the reason given on [`CompiledCompactCscMatrix::neighbors`].
     pub(crate) fn out_neighbors(&self, vertex: VertexId) -> Vec<VertexId> {
         self.canonical_out.neighbors(vertex)
     }

--- a/src/sparse_kernel/mod.rs
+++ b/src/sparse_kernel/mod.rs
@@ -175,6 +175,53 @@ pub(crate) struct SparseTraversalCount {
     pub backend: SparseKernelBackend,
 }
 
+/// Which of the two traversal specifications in the capability table above a
+/// caller is asking for.
+///
+/// The distinction is not decoration. The two answers differ on exactly one
+/// class of vertex — a start that is reachable from a start — and on how much
+/// work they report, and confusing them is what made one `matrix_reachable`
+/// call return three different vertex sets depending on how many start ids it
+/// was given and whether a matrix happened to be cached.
+///
+/// Naming them is the fix: a walker that took `(min, max)` could not express
+/// which of the two its caller meant, so the caller's intent lived in a comment
+/// at the call site and drifted away from it.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum FrontierWalk {
+    /// Vertices at BFS distance `1..=hops` from the start set, **excluding the
+    /// start vertices themselves**. Each vertex is expanded at most once, so
+    /// `edge_visits` counts every edge at most once.
+    ///
+    /// This is what [`expand`] computes and what `matrix_reachable`'s `hops`
+    /// parameter means.
+    FixedHops(u8),
+    /// Vertices reachable by a walk of length exactly `d`, for some `d` in
+    /// `min..=max`. A start vertex on a cycle **is** in the answer, and a
+    /// vertex revisited at several depths is expanded once per depth, so
+    /// `edge_visits` counts repeat traversals.
+    ///
+    /// This is what [`expand_range`] computes and what Cypher `*min..max`
+    /// means — there, "reachable in exactly 3 hops" genuinely has to re-walk.
+    HopRange(u8, u8),
+}
+
+impl FrontierWalk {
+    /// The `(min, max)` hop bounds to drive the level loop with.
+    pub(crate) fn bounds(self) -> (u8, u8) {
+        match self {
+            Self::FixedHops(hops) => (1, hops),
+            Self::HopRange(min_hops, max_hops) => (min_hops, max_hops),
+        }
+    }
+
+    /// Whether a vertex already expanded at a shallower depth must be skipped.
+    /// True for [`Self::FixedHops`] only — see the variant docs.
+    pub(crate) fn dedupes_by_distance(self) -> bool {
+        matches!(self, Self::FixedHops(_))
+    }
+}
+
 /// The kernel a [`GraphCachePolicy`] starts at, resolved once per process.
 ///
 /// The legacy `GRAPH_COMPILED_KERNEL` override supplies only this *default*, so
@@ -757,6 +804,25 @@ mod tests {
 
     // The legacy `GRAPH_COMPILED_KERNEL` override is deliberately not exercised
     // here: it is process-global and would race concurrent shard tests.
+    /// `FixedHops(h)` and `HopRange(1, h)` drive the same level loop and are
+    /// distinguished only by deduplication. That is the whole difference
+    /// between the two specifications, and it is why passing a bare `(1, h)`
+    /// pair could not express which one the caller meant.
+    #[test]
+    fn the_two_frontier_walks_share_bounds_but_not_deduplication() {
+        assert_eq!(FrontierWalk::FixedHops(3).bounds(), (1, 3));
+        assert_eq!(FrontierWalk::HopRange(1, 3).bounds(), (1, 3));
+
+        assert!(FrontierWalk::FixedHops(3).dedupes_by_distance());
+        assert!(!FrontierWalk::HopRange(1, 3).dedupes_by_distance());
+    }
+
+    #[test]
+    fn a_hop_range_keeps_its_own_lower_bound() {
+        assert_eq!(FrontierWalk::HopRange(2, 5).bounds(), (2, 5));
+        assert_eq!(FrontierWalk::HopRange(0, 0).bounds(), (0, 0));
+    }
+
     #[test]
     fn a_non_default_policy_kernel_is_returned_verbatim() {
         let policy = GraphCachePolicy {

--- a/src/sparse_kernel/mod.rs
+++ b/src/sparse_kernel/mod.rs
@@ -378,6 +378,14 @@ pub(crate) fn compiled_graphblas_contains_edge(
     compiled.contains_edge(src, dst)
 }
 
+/// Ungated for the reason given on [`compiled_graphblas_out_neighbors`].
+pub(crate) fn compiled_graphblas_contains_vertex(
+    compiled: &CompiledGraphBlasMatrix,
+    vertex: VertexId,
+) -> bool {
+    compiled.contains_vertex(vertex)
+}
+
 #[cfg(feature = "opencypher")]
 pub(crate) fn compiled_graphblas_in_neighbors(
     compiled: &CompiledGraphBlasMatrix,

--- a/src/sparse_kernel/mod.rs
+++ b/src/sparse_kernel/mod.rs
@@ -339,7 +339,8 @@ pub(crate) fn compiled_graphblas_in_neighbors(
     compiled.in_neighbors(vertex)
 }
 
-#[cfg(feature = "opencypher")]
+/// Ungated: `shard::topology_tail`'s overlay walk expands one hop at a time and
+/// is not behind `opencypher`. See [`CompiledGraphBlasMatrix::out_neighbors`].
 pub(crate) fn compiled_graphblas_out_neighbors(
     compiled: &CompiledGraphBlasMatrix,
     vertex: VertexId,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1657,6 +1657,81 @@ async fn cypher_graphblas_matrix_survives_interleaved_unrelated_writes() {
     assert_eq!(shard.graphblas_cache.lock().await.len(), 1);
 }
 
+/// `matrix_reachable` must answer the same question however it is asked.
+///
+/// Two things used to change the answer that have no business doing so: the
+/// number of start ids (one start took a storage-frontier walk with range
+/// semantics, two took `expand` with fixed-hop semantics) and whether a
+/// compiled matrix happened to be cached. The graph below cycles back through
+/// the start vertex, which is the only shape on which the two specifications
+/// disagree — and the reason no existing test caught this.
+#[tokio::test]
+async fn matrix_reachable_does_not_depend_on_start_arity_or_artifact_presence() {
+    let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let shard = open_test_shard("graph/matrix-reachable-hop-semantics", object_store).await;
+
+    // 1 -> 2, 2 -> 1, 2 -> 3. Vertex 1 is reachable from itself in two hops.
+    shard.write_edge(mutation(1, 2, "cycle-1")).await.unwrap();
+    shard.write_edge(mutation(2, 1, "cycle-2")).await.unwrap();
+    shard.write_edge(mutation(2, 3, "cycle-3")).await.unwrap();
+
+    let epoch = shard.current_epoch("reddit-home").await.unwrap();
+    let reachable = |starts: Vec<VertexId>| {
+        let shard = &shard;
+        async move {
+            shard
+                .matrix_reachable(
+                    "reddit-home",
+                    "USER_SUBSCRIBED_TO_SUBREDDIT",
+                    &starts,
+                    2,
+                    epoch,
+                )
+                .await
+                .unwrap()
+        }
+    };
+
+    // No artifact yet: the single-start branch walks storage, the multi-start
+    // branch materialises the adjacency. Adding an id that is not in the graph
+    // must not change what the query means.
+    let one_start = reachable(vec![1]).await;
+    let with_absent_start = reachable(vec![1, 999]).await;
+    assert_eq!(
+        one_start.vertices, with_absent_start.vertices,
+        "start-set arity must not change the answer"
+    );
+    assert!(
+        !one_start.vertices.contains(&1),
+        "a start vertex reached around a cycle is not part of its own answer"
+    );
+    assert_eq!(one_start.vertices, vec![2, 3]);
+
+    // Now publish an artifact so the compiled branch is eligible, and ask
+    // again. Whether a matrix is cached is a cost decision, not a semantic one.
+    shard
+        .build_matrix_tiles("reddit-home", "USER_SUBSCRIBED_TO_SUBREDDIT", 2, 8)
+        .await
+        .unwrap();
+    let epoch = shard.current_epoch("reddit-home").await.unwrap();
+    let compiled = shard
+        .matrix_reachable(
+            "reddit-home",
+            "USER_SUBSCRIBED_TO_SUBREDDIT",
+            &[1],
+            2,
+            epoch,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        compiled.vertices, one_start.vertices,
+        "the presence of a compiled artifact must not change the answer"
+    );
+
+    shard.close().await.unwrap();
+}
+
 fn mutation(src: VertexId, dst: VertexId, idempotency_key: &str) -> EdgeMutation {
     EdgeMutation {
         cell_id: "reddit-home".to_string(),


### PR DESCRIPTION

Closes #71.

> **Stacked on #70.** This branch builds on `fix/overlay-frontier-edge-loss`,
> because the overlay branch touched here routes through
> `expand_range_with_overlay`, which #70 fixes. Base is set accordingly; GitHub
> will retarget to `main` once #70 merges. Review #70 first.

## What's wrong

`matrix_reachable_with_kernel` has five exit paths built on **two incompatible
traversal specifications**:

- `expand` — vertices at BFS distance `1..=hops`, **start vertices stripped**,
  each vertex expanded once (branches at `traversal.rs:93`, `:113`, `:148`).
- a `1..=hops` **range** walk — vertices reachable by a walk of length exactly
  `d` for some `d`, **start vertices kept**, revisited vertices re-expanded
  (branches at `:80`, `:109`).

They differ on exactly one class of vertex — a start reachable from a start —
and on how much work they report. So two things that have no business changing
the answer did:

1. **Start-set arity.** `starts.len() == 1` took the range branch; anything else
   took fixed-hop. Adding an id that isn't even in the graph changed the result.
2. **Whether a matrix happened to be cached.** `compiled_graphblas_query_snapshot`
   returns `None` whenever `storage_snapshot.seq() != read_epoch`, which is the
   common case — so this was routine, not exceptional.

On `1 -> 2`, `2 -> 1`, `2 -> 3` with `hops = 2`:

starts=[1]       no compiled matrix  -> [1, 2, 3]
starts=[1, 999]  no compiled matrix  -> [2, 3]
starts=[1]       compiled matrix     -> [2, 3]

`edge_visits` diverged for the same reason, which also makes
`benchmark_hot_hops`'s `matrix_wins` flag meaningless — it compares work
counters across two different walks.

## Root cause

Both range walkers took a bare `(min, max)` tuple, and **a tuple cannot say
which of the two specifications the caller meant**. Intent lived in a comment at
the call site and drifted away from it.

## The fix

**1. Name the specifications** (`sparse_kernel/mod.rs`). A `FrontierWalk` enum
with `FixedHops(u8)` and `HopRange(u8, u8)`, each documenting what it returns
and how it counts. The intent now lives in the type, where it cannot drift.

**2. The storage walk honours what it was asked for** (`shard/query.rs`).
`reachable_from_storage_frontier` takes a `FrontierWalk`; `FixedHops` adds a
`seen` set and strips `src`. This is what fixes `edge_visits` as well as the
vertex set — BFS expands each vertex once, so the count now matches the compiled
kernels exactly. Cypher's caller passes `HopRange` and is unchanged.

**3. One exit point** (`engine/traversal.rs`). All four `MatrixTraversalResult`
constructions go through `matrix_traversal_result`, which strips the start set.
It is idempotent, so applying it to the three already-correct branches costs one
set lookup per result vertex and changes nothing — which is what makes it safe
to apply to all of them rather than only the two that were wrong. Five call
sites each remembering to strip is five chances to forget.

## One option deliberately not taken

The issue suggests dropping the single-start branch entirely so both arities
fall through to `canonical_adjacency_at` + `expand_sparse`. I kept it: that
branch walks only the reachable subgraph, while the alternative materialises the
entire edge type's adjacency first. That's a real optimisation on large graphs,
and it's a cost decision, not a semantic one. Keeping it and fixing its
semantics costs ~12 lines.

## Tests

Six. Three pure unit tests on `matrix_traversal_result` (strips a cycle-reached
start; covers every start and tolerates unknown ones; idempotent), two on
`FrontierWalk` (the two walks share bounds but not deduplication), and the
arity/artifact invariance integration test the issue asks for, on the existing
`open_test_shard`/`mutation` harness.

No existing test used a start vertex reachable from itself, which is the only
shape the two specifications disagree on — that's why this survived.

## Verification, and its limits

- `cargo check --lib` and `cargo check --tests` clean, no new warnings.
- **The six new tests are unrun.** My machine has neither `libgraphblas` nor
  `libcypher-parser`, so the test binary cannot link. Please confirm on a
  SuiteSparse box before merging.
- What I did run: a standalone line-for-line transcription of the patched
  routines. All three call shapes converge on `[2, 3]` with `edge_visits = 3`.
- **The main risk in this change was breaking Cypher.** `HopRange` must keep
  walk semantics, including the start vertex on a cycle. Verified explicitly:
  `HopRange(2, 2)` from vertex `1` still returns `[1, 3]` — `1` via `1→2→1` and
  `3` via `1→2→3`. Unchanged.