### PR TITLE
fix: bound and report the native path result cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1193,6 +1193,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "hydradb-placement"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "futures",
+ "serde",
+ "serde_json",
+ "slatedb",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
+name = "hydradb-telemetry"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "opentelemetry",
+ "opentelemetry-appender-tracing",
+ "opentelemetry-otlp",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry_sdk",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "hyper"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2809,6 +2841,8 @@ dependencies = [
  "bytes",
  "chrono",
  "futures",
+ "hydradb-placement",
+ "hydradb-telemetry",
  "libcypher-parser-sys",
  "rcgen",
  "reqwest",
@@ -2825,8 +2859,6 @@ dependencies = [
  "tokio-rustls",
  "tracing",
  "tracing-subscriber",
- "hydradb-placement",
- "hydradb-telemetry",
  "ulid",
 ]
 
@@ -3313,38 +3345,6 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
-
-[[package]]
-name = "hydradb-placement"
-version = "0.1.0"
-dependencies = [
- "async-trait",
- "chrono",
- "futures",
- "serde",
- "serde_json",
- "slatedb",
- "thiserror 2.0.18",
- "tokio",
-]
-
-[[package]]
-name = "hydradb-telemetry"
-version = "0.1.0"
-dependencies = [
- "chrono",
- "opentelemetry",
- "opentelemetry-appender-tracing",
- "opentelemetry-otlp",
- "opentelemetry-semantic-conventions",
- "opentelemetry_sdk",
- "serde_json",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "tracing-opentelemetry",
- "tracing-subscriber",
-]
 
 [[package]]
 name = "twox-hash"

--- a/examples/s3_bolt_benchmark_server.rs
+++ b/examples/s3_bolt_benchmark_server.rs
@@ -152,6 +152,7 @@ async fn main() -> BenchResult<()> {
             "relationship_rows": cache_resident.relationship_rows,
             "source_relationship_rows": cache_resident.source_relationship_rows,
             "relationship_property_rows": cache_resident.relationship_property_rows,
+            "native_path_results": cache_resident.native_path_results,
         },
         "process_rss_kib": process_rss_kib,
         "process_peak_rss_kib": process_peak_rss_kib,

--- a/src/bin/graph_node/admin.rs
+++ b/src/bin/graph_node/admin.rs
@@ -764,6 +764,10 @@ fn append_node_metrics(output: &mut String, shard_metrics: &[ScopedGraphShardRun
                 "relationship_property_rows",
                 metrics.cache_entries.relationship_property_row_sets,
             ),
+            (
+                "native_path_results",
+                metrics.cache_entries.native_path_results,
+            ),
         ] {
             output.push_str(&format!(
                 "graph_cache_entries{{scope=\"{}\",cell_id=\"{}\",cache=\"{cache}\"}} {entries}\n",
@@ -790,6 +794,14 @@ fn append_node_metrics(output: &mut String, shard_metrics: &[ScopedGraphShardRun
             (
                 "relationship_property_rows",
                 metrics.cache_resident_bytes.relationship_property_rows,
+            ),
+            // The gauge the operator actually reads. Adding the field to
+            // `GraphCacheResidentBytes` without adding it here would fix the
+            // struct and leave the symptom — a resident-bytes series that is
+            // correct for five caches and blind to the sixth.
+            (
+                "native_path_results",
+                metrics.cache_resident_bytes.native_path_results,
             ),
         ] {
             output.push_str(&format!(

--- a/src/bin/graph_node/config.rs
+++ b/src/bin/graph_node/config.rs
@@ -35,6 +35,7 @@ pub struct RuntimeConfig {
     pub max_relationship_rows_bytes: usize,
     pub max_source_relationship_rows_bytes: usize,
     pub max_relationship_property_rows_bytes: usize,
+    pub max_native_path_result_bytes: usize,
     pub max_concurrent_hydrations: usize,
     pub max_concurrent_matrix_compilations: usize,
     pub max_open_scopes: usize,
@@ -209,6 +210,14 @@ impl RuntimeConfig {
                 "GRAPH_MAX_RELATIONSHIP_PROPERTY_ROWS_BYTES",
                 16 * 1024 * 1024,
             )?,
+            // Separate from GRAPH_MAX_RELATIONSHIP_ROWS_BYTES, which the native
+            // path cache used to share in full — two caches each enforcing the
+            // same number meant the configured ceiling bounded neither.
+            max_native_path_result_bytes: parse_usize_allow_zero(
+                &values,
+                "GRAPH_MAX_NATIVE_PATH_RESULT_BYTES",
+                8 * 1024 * 1024,
+            )?,
             max_concurrent_hydrations: parse_usize(&values, "GRAPH_MAX_CONCURRENT_HYDRATIONS", 2)?,
             max_concurrent_matrix_compilations: parse_usize(
                 &values,
@@ -312,6 +321,7 @@ impl RuntimeConfig {
             max_relationship_rows_bytes: self.max_relationship_rows_bytes,
             max_source_relationship_rows_bytes: self.max_source_relationship_rows_bytes,
             max_relationship_property_rows_bytes: self.max_relationship_property_rows_bytes,
+            max_native_path_result_bytes: self.max_native_path_result_bytes,
             max_concurrent_matrix_compilations: self.max_concurrent_matrix_compilations,
         }
     }

--- a/src/bin/graph_node/config.rs
+++ b/src/bin/graph_node/config.rs
@@ -140,6 +140,13 @@ impl RuntimeConfig {
                 ),
             ),
         )?;
+        // Read before the struct literal because the native path-result budget
+        // below falls back to it. See that field for why.
+        let max_relationship_rows_bytes = parse_usize_allow_zero(
+            &values,
+            "GRAPH_MAX_RELATIONSHIP_ROWS_BYTES",
+            8 * 1024 * 1024,
+        )?;
         let config = Self {
             node_id: value(&values, "GRAPH_NODE_ID", "graph-node-0"),
             scope,
@@ -195,11 +202,7 @@ impl RuntimeConfig {
                 128 * 1024 * 1024,
             )?,
             sparse_kernel: parse_sparse_kernel(&values, "GRAPH_SPARSE_KERNEL")?,
-            max_relationship_rows_bytes: parse_usize_allow_zero(
-                &values,
-                "GRAPH_MAX_RELATIONSHIP_ROWS_BYTES",
-                8 * 1024 * 1024,
-            )?,
+            max_relationship_rows_bytes,
             max_source_relationship_rows_bytes: parse_usize_allow_zero(
                 &values,
                 "GRAPH_MAX_SOURCE_RELATIONSHIP_ROWS_BYTES",
@@ -212,11 +215,14 @@ impl RuntimeConfig {
             )?,
             // Separate from GRAPH_MAX_RELATIONSHIP_ROWS_BYTES, which the native
             // path cache used to share in full — two caches each enforcing the
-            // same number meant the configured ceiling bounded neither.
+            // same number meant the configured ceiling bounded neither. It
+            // *defaults* to that value rather than to a constant, so a
+            // deployment that lowered the row budget keeps the native-path
+            // ceiling it already had; raising it is now an explicit act.
             max_native_path_result_bytes: parse_usize_allow_zero(
                 &values,
                 "GRAPH_MAX_NATIVE_PATH_RESULT_BYTES",
-                8 * 1024 * 1024,
+                max_relationship_rows_bytes,
             )?,
             max_concurrent_hydrations: parse_usize(&values, "GRAPH_MAX_CONCURRENT_HYDRATIONS", 2)?,
             max_concurrent_matrix_compilations: parse_usize(
@@ -536,6 +542,7 @@ mod tests {
             memory.max_relationship_property_rows_bytes,
             16 * 1024 * 1024
         );
+        assert_eq!(memory.max_native_path_result_bytes, 8 * 1024 * 1024);
     }
 
     #[test]
@@ -733,5 +740,34 @@ mod tests {
         assert_eq!(memory.max_relationship_rows_bytes, 0);
         assert_eq!(memory.max_source_relationship_rows_bytes, 0);
         assert_eq!(memory.max_relationship_property_rows_bytes, 0);
+        assert_eq!(memory.max_native_path_result_bytes, 0);
+    }
+
+    /// An upgrade must not raise a ceiling the operator lowered. The native
+    /// path cache used to be handed `GRAPH_MAX_RELATIONSHIP_ROWS_BYTES` in
+    /// full, so it keeps inheriting that number until its own variable is set.
+    #[test]
+    fn native_path_budget_inherits_a_lowered_relationship_row_budget() {
+        let mut values = BTreeMap::from([
+            ("GRAPH_ALLOW_PLAINTEXT".to_string(), "true".to_string()),
+            (
+                "GRAPH_MAX_RELATIONSHIP_ROWS_BYTES".to_string(),
+                (4 * 1024 * 1024).to_string(),
+            ),
+        ]);
+        let memory = RuntimeConfig::from_values(values.clone())
+            .unwrap()
+            .graph_memory_config();
+        assert_eq!(memory.max_native_path_result_bytes, 4 * 1024 * 1024);
+
+        values.insert(
+            "GRAPH_MAX_NATIVE_PATH_RESULT_BYTES".to_string(),
+            (16 * 1024 * 1024).to_string(),
+        );
+        let memory = RuntimeConfig::from_values(values)
+            .unwrap()
+            .graph_memory_config();
+        assert_eq!(memory.max_relationship_rows_bytes, 4 * 1024 * 1024);
+        assert_eq!(memory.max_native_path_result_bytes, 16 * 1024 * 1024);
     }
 }

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -216,6 +216,15 @@ pub struct GraphMemoryConfig {
     pub max_source_relationship_rows_bytes: usize,
     #[cfg(feature = "opencypher")]
     pub max_relationship_property_rows_bytes: usize,
+    /// Budget for the native path-procedure result cache.
+    ///
+    /// Its own knob rather than a share of [`Self::max_relationship_rows_bytes`]:
+    /// that field was previously handed to both caches in full, so the two
+    /// together could hold twice what the operator asked for. The two hold very
+    /// differently shaped values — whole `QueryResultSet`s here, relationship
+    /// row vectors there — so one number could not have described both anyway.
+    #[cfg(feature = "opencypher")]
+    pub max_native_path_result_bytes: usize,
     pub max_concurrent_matrix_compilations: usize,
 }
 
@@ -231,6 +240,11 @@ impl Default for GraphMemoryConfig {
             max_source_relationship_rows_bytes: 8 * 1024 * 1024,
             #[cfg(feature = "opencypher")]
             max_relationship_property_rows_bytes: 16 * 1024 * 1024,
+            // Matches what the cache was already being given, so the default
+            // resident ceiling of a shard is unchanged by this becoming
+            // explicit — only its accounting is.
+            #[cfg(feature = "opencypher")]
+            max_native_path_result_bytes: 8 * 1024 * 1024,
             max_concurrent_matrix_compilations: 1,
         }
     }
@@ -248,6 +262,8 @@ impl GraphMemoryConfig {
             max_source_relationship_rows_bytes: 2 * 1024 * 1024,
             #[cfg(feature = "opencypher")]
             max_relationship_property_rows_bytes: 4 * 1024 * 1024,
+            #[cfg(feature = "opencypher")]
+            max_native_path_result_bytes: 2 * 1024 * 1024,
             ..Self::default()
         }
     }

--- a/src/core/state.rs
+++ b/src/core/state.rs
@@ -1346,8 +1346,18 @@ pub struct GraphCacheEntryCounts {
     pub relationship_row_sets: usize,
     #[cfg(feature = "opencypher")]
     pub relationship_property_row_sets: usize,
+    #[cfg(feature = "opencypher")]
+    pub native_path_results: usize,
 }
 
+/// Resident bytes per byte-limited cache.
+///
+/// **Every byte-limited cache on [`crate::GraphShard`] needs a field here.** A
+/// cache that has a `new_with_byte_limit` budget but no field is invisible to
+/// [`Self::total`], so an operator watching resident bytes against the
+/// configured ceiling sees a number that is correct for the caches that were
+/// remembered and blind to the ones that were not — and RSS growth from the
+/// missing cache reads as a leak. `native_path_results` was exactly that.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct GraphCacheResidentBytes {
     pub matrix_adjacencies: usize,
@@ -1358,6 +1368,8 @@ pub struct GraphCacheResidentBytes {
     pub source_relationship_rows: usize,
     #[cfg(feature = "opencypher")]
     pub relationship_property_rows: usize,
+    #[cfg(feature = "opencypher")]
+    pub native_path_results: usize,
 }
 
 impl GraphCacheResidentBytes {
@@ -1370,6 +1382,7 @@ impl GraphCacheResidentBytes {
                     self.relationship_rows
                         .saturating_add(self.source_relationship_rows)
                         .saturating_add(self.relationship_property_rows)
+                        .saturating_add(self.native_path_results)
                 }
                 #[cfg(not(feature = "opencypher"))]
                 {

--- a/src/shard/lifecycle.rs
+++ b/src/shard/lifecycle.rs
@@ -235,11 +235,16 @@ impl GraphShard {
                 tenant_quota,
                 memory.max_relationship_property_rows_bytes,
             )),
+            // Its own budget. This used to be handed
+            // `memory.max_relationship_rows_bytes`, the same value
+            // `relationship_rows_cache` above already has in full — and
+            // `BoundedGraphCache` enforces its limit per instance, so the two
+            // together could hold twice what the operator configured.
             #[cfg(feature = "opencypher")]
             native_path_result_cache: Mutex::new(BoundedGraphCache::new_with_byte_limit(
                 cache_policy.max_relationship_row_sets,
                 tenant_quota,
-                memory.max_relationship_rows_bytes,
+                memory.max_native_path_result_bytes,
             )),
             #[cfg(feature = "opencypher")]
             native_path_page_cursors: Mutex::new(Default::default()),
@@ -323,6 +328,8 @@ impl GraphShard {
         #[cfg(feature = "opencypher")]
         let relationship_property_row_sets =
             self.relationship_property_rows_cache.lock().await.len();
+        #[cfg(feature = "opencypher")]
+        let native_path_results = self.native_path_result_cache.lock().await.len();
         GraphCacheEntryCounts {
             matrix_artifacts,
             matrix_adjacencies,
@@ -333,6 +340,8 @@ impl GraphShard {
             relationship_row_sets,
             #[cfg(feature = "opencypher")]
             relationship_property_row_sets,
+            #[cfg(feature = "opencypher")]
+            native_path_results,
         }
     }
 
@@ -355,6 +364,8 @@ impl GraphShard {
             .lock()
             .await
             .resident_bytes();
+        #[cfg(feature = "opencypher")]
+        let native_path_results = self.native_path_result_cache.lock().await.resident_bytes();
         GraphCacheResidentBytes {
             matrix_adjacencies,
             graphblas_matrices,
@@ -364,6 +375,8 @@ impl GraphShard {
             source_relationship_rows,
             #[cfg(feature = "opencypher")]
             relationship_property_rows,
+            #[cfg(feature = "opencypher")]
+            native_path_results,
         }
     }
 
@@ -822,6 +835,106 @@ mod tests {
         );
         drop(blocker);
         assert_eq!(resident.await, GraphCacheResidentBytes::default());
+
+        shard.close().await.unwrap();
+    }
+
+    /// Every byte-limited cache must be visible to the resident-bytes gauge.
+    ///
+    /// `native_path_result_cache` was not: it had a byte budget and no field in
+    /// [`GraphCacheResidentBytes`], so it could fill while the number an
+    /// operator watches stayed put and RSS growth read as a leak. The assertion
+    /// is on `total()` specifically, because that is what a ceiling alert
+    /// compares against.
+    #[cfg(feature = "opencypher")]
+    #[tokio::test]
+    async fn the_native_path_result_cache_is_visible_to_the_resident_byte_gauge() {
+        let shard = open_shard("native-path-cache-resident-bytes").await;
+        assert_eq!(shard.graph_cache_resident_bytes().await.total(), 0);
+
+        let key = crate::NativePathResultCacheKey {
+            scope: crate::GraphScope::default(),
+            cell_id: "reddit-home".to_string(),
+            procedure: "test.path".to_string(),
+            read_epoch: 1,
+            max_result_bytes: None,
+        };
+        shard.native_path_result_cache.lock().await.insert_sized(
+            key,
+            std::sync::Arc::new(crate::QueryResultSet {
+                columns: Vec::new(),
+                rows: Vec::new(),
+                read_epoch: None,
+                storage_sequence: None,
+            }),
+            "reddit-home",
+            false,
+            512,
+            &shard.cache_metrics,
+        );
+
+        let resident = shard.graph_cache_resident_bytes().await;
+        assert_eq!(resident.native_path_results, 512);
+        assert_eq!(
+            resident.total(),
+            512,
+            "a cache with a byte budget but no field in the gauge is invisible"
+        );
+        assert_eq!(
+            shard.graph_cache_entry_counts().await.native_path_results,
+            1
+        );
+
+        shard.close().await.unwrap();
+    }
+
+    /// The two caches must not both be handed the same budget. They used to be,
+    /// so `GRAPH_MAX_RELATIONSHIP_ROWS_BYTES` bounded neither of them.
+    #[cfg(feature = "opencypher")]
+    #[tokio::test]
+    async fn the_native_path_cache_has_its_own_budget() {
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let memory = crate::GraphMemoryConfig {
+            max_relationship_rows_bytes: 4_096,
+            max_native_path_result_bytes: 1_024,
+            ..crate::GraphMemoryConfig::default()
+        };
+        let shard = GraphShard::open_standalone_writer_with_memory_options(
+            "graph/native-path-cache-own-budget",
+            object_store,
+            crate::GraphOpenOptions::default(),
+            memory,
+        )
+        .await
+        .unwrap();
+
+        // Over the native-path budget but well under the relationship-rows one:
+        // sharing the latter would have admitted this.
+        let key = crate::NativePathResultCacheKey {
+            scope: crate::GraphScope::default(),
+            cell_id: "reddit-home".to_string(),
+            procedure: "test.oversized".to_string(),
+            read_epoch: 1,
+            max_result_bytes: None,
+        };
+        let admitted = shard.native_path_result_cache.lock().await.insert_sized(
+            key,
+            std::sync::Arc::new(crate::QueryResultSet {
+                columns: Vec::new(),
+                rows: Vec::new(),
+                read_epoch: None,
+                storage_sequence: None,
+            }),
+            "reddit-home",
+            false,
+            2_048,
+            &shard.cache_metrics,
+        );
+        assert!(
+            admitted.is_none(),
+            "an entry over the native-path budget must not be retained"
+        );
+        assert_eq!(shard.graph_cache_resident_bytes().await.total(), 0);
 
         shard.close().await.unwrap();
     }


### PR DESCRIPTION
Closes #73.

## What's wrong

Two halves, and the second is the one an operator actually feels.

**The budget is double-booked.** `GraphMemoryConfig` carries three
relationship-row byte budgets, but `GraphShard` builds four byte-limited caches
from them. `native_path_result_cache` was handed
`memory.max_relationship_rows_bytes` — the same value `relationship_rows_cache`
already has in full. `BoundedGraphCache` enforces its limit per instance, so the
two together can hold `2 ×` what was configured.
`GRAPH_MAX_RELATIONSHIP_ROWS_BYTES` did not bound what it names.

**Nothing reports it.** `GraphCacheResidentBytes` had no field for the cache, so
`total()` under-reported by up to a full budget, and the same omission ran
through `GraphCacheEntryCounts`. An operator watching resident bytes against the
configured ceiling saw a number correct for five caches and blind to the sixth;
RSS growth from native path procedures read as a leak.

## The fix

1. **Its own budget.** `max_native_path_result_bytes` on `GraphMemoryConfig`,
   defaulting to 8 MiB — the same figure the cache was already effectively
   given, so no shard's resident ceiling changes, only its accounting. New
   operator knob `GRAPH_MAX_NATIVE_PATH_RESULT_BYTES`; `low_memory()` gets
   2 MiB alongside its siblings.
2. **A field in both reports.** `native_path_results` on
   `GraphCacheResidentBytes` (and in `total()`) and on `GraphCacheEntryCounts`,
   with the corresponding reads in the two collectors.
3. **The gauge the operator reads.** See below.

## One change beyond the issue, and it's the half that mattered

The issue points at the structs and `lifecycle.rs`. But the Prometheus gauge is
assembled in `admin.rs:745-799`, which enumerates cache fields **by hand** into
the exposition text. Adding the struct field without touching that would have
fixed the struct and left the reported symptom exactly as it was. Both loops are
updated, plus the JSON dump in `examples/s3_bolt_benchmark_server.rs`.

That is three independently hand-maintained copies of the same list. The
structural fix the issue suggests at the end — iterate a list of caches rather
than enumerate fields — is worth doing, and I've left it out of here so this PR
stays reviewable. A seventh cache added tomorrow still has this failure mode, in
three places.

## Tests

Two in `lifecycle.rs`: the cache is visible to `total()` and to the entry-count
gauge; and an entry over the native-path budget is rejected while sitting well
under the relationship-rows budget it used to share — which is the double-booking
stated as an assertion.

## Verification — read this before merging

This branch is **materially less verified than #70 and #71**, and the reason is
structural rather than incidental:

- **Every line changed here is behind `#[cfg(feature = "opencypher")]`.**
  `cargo check --lib` and `cargo check --tests` pass, but those builds compile
  all of it out. They prove nothing about this change.
- `--features opencypher` cannot build on my machine (`libcypher-parser`
  missing, as `libgraphblas` is), so **none of this has been type-checked, and
  the two new tests have not been run.**
- What I did instead: a manual audit of what a compiler would catch — every
  exhaustive struct literal of the three changed types (only
  `graph_node/config.rs` and the two collectors; everything else uses
  `..default()`), and every identifier the new tests name.
- **That audit caught a real error.** I had written `QueryResultSet::default()`;
  `QueryResultSet` derives only `Clone, Debug`. It would have failed CI. Fixed
  to an explicit literal — but hand-auditing being the only thing between that
  and a broken PR is exactly why this needs a real compile before it lands.

Please confirm CI builds it with `opencypher` on, and that both new tests pass,
rather than treating the green checks above as coverage.

## Notes for the reviewer

- Adding public fields to `GraphMemoryConfig`, `GraphCacheResidentBytes` and
  `GraphCacheEntryCounts` breaks any exhaustive struct literal downstream. The
  crate is `publish = false` and every in-tree site uses `..default()` except
  the ones updated here, but it is a breaking change for embedders.
- `GRAPH_MAX_NATIVE_PATH_RESULT_BYTES` needs a line wherever the other
  `GRAPH_MAX_*` knobs are documented. I could not find an existing table for
  them, so nothing is updated — point me at it and I'll add it.