### PR TITLE
fix: count a failed query execution once, not twice

### DIFF
--- a/src/query/coordination.rs
+++ b/src/query/coordination.rs
@@ -4470,16 +4470,15 @@ where
         QueryLifecycleFinish::Cancelled => Err(cancelled_query_error()),
         QueryLifecycleFinish::NotCancelled | QueryLifecycleFinish::NotOwned => result,
     };
-    match &result {
-        Ok(_) => runtime
+    // Only successes are counted here. Every caller hands an `Err` from this
+    // function to `transport_error_response`, which owns `requests_failed`;
+    // counting failures in both places recorded each failed execution twice.
+    if result.is_ok() {
+        runtime
             .metrics
             .requests_completed
-            .fetch_add(1, Ordering::Relaxed),
-        Err(_) => runtime
-            .metrics
-            .requests_failed
-            .fetch_add(1, Ordering::Relaxed),
-    };
+            .fetch_add(1, Ordering::Relaxed);
+    }
     result
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -5948,6 +5948,72 @@ async fn tcp_query_transport_default_bind_rejects_unauthenticated_requests() {
 
 #[cfg(feature = "query-transport")]
 #[tokio::test]
+async fn tcp_query_transport_counts_a_failed_execution_once() {
+    struct FailingQueryClient;
+
+    #[async_trait::async_trait]
+    impl QueryCellClient for FailingQueryClient {
+        async fn execute_cypher_rows(
+            &self,
+            _context: QueryContext,
+            _query: &str,
+        ) -> Result<QueryResultSet> {
+            Err(GraphError::UnsupportedQuery {
+                dialect: "QueryTransport",
+                feature: "executor fails after the request is admitted".to_string(),
+            })
+        }
+
+        async fn execute_cypher_rows_page(
+            &self,
+            context: QueryContext,
+            query: &str,
+            _cursor: Option<QueryCursorToken>,
+            _page_size: usize,
+        ) -> Result<QueryResultPage> {
+            let rows = self.execute_cypher_rows(context, query).await?;
+            Ok(QueryResultPage::new(rows.columns, rows.rows, None))
+        }
+    }
+
+    let authorizer = StaticQueryTransportScopeAuthorizer::new()
+        .with_bearer_grant(
+            "metrics-reader",
+            QueryTransportScopeGrant::read_graph(GraphScope::default()),
+        )
+        .unwrap();
+    let server = TcpQueryServer::bind_with_config(
+        "127.0.0.1:0".parse().unwrap(),
+        Arc::new(FailingQueryClient),
+        QueryTransportServerConfig::default()
+            .with_required_bearer_token("metrics-reader")
+            .with_scope_authorizer(Arc::new(authorizer))
+            .insecure_allow_plaintext(),
+    )
+    .await
+    .unwrap();
+    let err = TcpQueryCellClient::new(server.local_addr())
+        .with_bearer_token("metrics-reader")
+        .insecure_allow_plaintext()
+        .execute_cypher_rows(
+            QueryContext::new("reddit-home", "query-transport-failed-once"),
+            "MATCH (u {id: 1}) RETURN u.id",
+        )
+        .await
+        .unwrap_err();
+    assert!(err.to_string().contains("executor fails"));
+
+    // One admitted request that failed in the executor must reconcile as
+    // started = completed + failed; the failure is counted exactly once.
+    let metrics = server.metrics();
+    assert_eq!(metrics.requests_started, 1);
+    assert_eq!(metrics.requests_completed, 0);
+    assert_eq!(metrics.requests_failed, 1);
+    server.stop().await.unwrap();
+}
+
+#[cfg(feature = "query-transport")]
+#[tokio::test]
 async fn tcp_query_transport_batches_page_rows_and_enforce_write_grants() {
     struct StaticBatchClient;
 


### PR DESCRIPTION
## What

Fixes hydra-db/hydradb#77.

`execute_metered_query` incremented `requests_failed` in the `Err` arm of its
final match, and every one of its call sites then handed that same `Err` to
`transport_error_response`, which increments `requests_failed` again. One
failed execution therefore left the snapshot with `requests_started = 1`,
`requests_completed = 0`, `requests_failed = 2` — the counters no longer
reconcile as `started = completed + failed`, and a failure-rate dashboard
built on them reads 200%.

## How

`transport_error_response` becomes the single owner of failure accounting —
it already sits on every error path, including the pre-execution auth and
authz rejections. `execute_metered_query` now counts only successes; its
`Err` arm is deleted.

The only path that leaves `execute_metered_query` without reaching the
deleted arm is the `?` on `begin_query_lifecycle`, and that error already
flows through `transport_error_response` exactly once at every call site, so
the change is a pure deduplication: no error path loses its count.

## Testing

New regression test `tcp_query_transport_counts_a_failed_execution_once`: a
`TcpQueryServer` over a stub `QueryCellClient` whose executor always fails
serves one authenticated Rows request, and the metrics snapshot must show
`requests_started == 1`, `requests_completed == 0`, `requests_failed == 1`.
Before this change the last assertion fails with `requests_failed == 2`.

