### PR TITLE
fix: subtract drained page bytes instead of rescanning the cursor tail

### DIFF
--- a/src/client/service.rs
+++ b/src/client/service.rs
@@ -1740,10 +1740,12 @@ impl ClientQueryService {
         let mut cursor = cursors
             .remove(&token.offset)
             .expect("cursor was checked while holding the cursor lock");
-        let previous_bytes = cursor.resident_bytes;
         let page_rows = take_cursor_rows(&mut cursor.rows, page_size);
-        cursor.resident_bytes = query_rows_resident_bytes(&cursor.rows);
-        let released_bytes = previous_bytes.saturating_sub(cursor.resident_bytes);
+        // Charge the page that was drained rather than rescanning the rows
+        // still buffered: the tail rescan made paging O(rows² / page size),
+        // paid under the cursor lock every other connection shares.
+        let released_bytes = query_rows_resident_bytes(&page_rows);
+        cursor.resident_bytes = cursor.resident_bytes.saturating_sub(released_bytes);
         self.inner
             .cursor_buffer_bytes
             .fetch_sub(released_bytes, Ordering::Relaxed);
@@ -2322,8 +2324,8 @@ fn take_cursor_rows(rows: &mut VecDeque<QueryRow>, page_size: usize) -> Vec<Quer
     rows.drain(..count).collect()
 }
 
-fn query_rows_resident_bytes(rows: &VecDeque<QueryRow>) -> u64 {
-    rows.iter().fold(0_u64, |total, row| {
+fn query_rows_resident_bytes<'a>(rows: impl IntoIterator<Item = &'a QueryRow>) -> u64 {
+    rows.into_iter().fold(0_u64, |total, row| {
         total.saturating_add(row.estimated_resident_bytes())
     })
 }

--- a/src/client/service/tests.rs
+++ b/src/client/service/tests.rs
@@ -788,6 +788,50 @@ async fn server_cursor_executes_once_and_release_invalidates_it() {
 }
 
 #[tokio::test]
+async fn server_cursor_page_accounting_stays_exact() {
+    let service = cursor_service(Arc::new(AtomicU64::new(0)), 4, 1 << 20, 1_000);
+    let session = authenticated_session(&service);
+    let request = ClientQueryRequest::new(
+        target(),
+        "query-cursor-accounting",
+        "MATCH (n {id: 1}) RETURN n.id AS value",
+    );
+
+    let mut cursor = service
+        .execute_page(&session, request.clone(), None, 1)
+        .await
+        .unwrap()
+        .page
+        .next_cursor;
+    assert!(cursor.is_some(), "four result rows leave a cursor behind");
+
+    // After every page, the cursor's own accounting and the shared gauge must
+    // both equal a fresh recount of the rows still buffered; incremental
+    // subtraction and full recomputation may never drift apart.
+    while let Some(token) = cursor {
+        {
+            let cursors = service.inner.cursors.lock().await;
+            let buffered = cursors
+                .get(&token.offset)
+                .expect("a live cursor stays registered");
+            let expected = query_rows_resident_bytes(&buffered.rows);
+            assert_eq!(buffered.resident_bytes, expected);
+            assert_eq!(
+                service.inner.cursor_buffer_bytes.load(Ordering::Relaxed),
+                expected
+            );
+        }
+        cursor = service
+            .execute_page(&session, request.clone(), Some(token), 1)
+            .await
+            .unwrap()
+            .page
+            .next_cursor;
+    }
+    assert_eq!(service.inner.cursor_buffer_bytes.load(Ordering::Relaxed), 0);
+}
+
+#[tokio::test]
 async fn server_cursor_enforces_count_and_buffer_admission() {
     let executions = Arc::new(AtomicU64::new(0));
     let service = cursor_service(Arc::clone(&executions), 1, 1 << 20, 1_000);


### PR DESCRIPTION
## What

Fixes hydra-db/hydradb#78.

`continue_server_cursor` recomputed the cursor's resident bytes with
`query_rows_resident_bytes(&cursor.rows)` after draining each page — a full
walk of every surviving row, on every continuation, under the global cursor
mutex shared by all connections. Paging N buffered rows with page size p cost
O(N²/p) row-size estimations in total; a 64 MB buffer of ~500k rows paged
1000 at a time performed ~125M estimations under the lock instead of ~500k.

## How

The metric is a saturating sum over rows, so the continuation now sums only
the rows it just drained and subtracts that from the running total:

- `query_rows_resident_bytes` is generalized from `&VecDeque<QueryRow>` to
  any `IntoIterator<Item = &QueryRow>`, so the one accounting definition
  serves both the deque and the drained page.
- `continue_server_cursor` computes `released_bytes` from the drained page
  and updates `cursor.resident_bytes` by subtraction; `released_bytes` feeds
  the existing `fetch_sub` on the shared budget unchanged.

The accounting stays exact because addition over the same rows is exactly
how the total was built. Per-page work drops to O(page_size).

## Testing

`server_cursor_page_accounting_stays_exact` pages a multi-row cursor one row
at a time and asserts after every page that the shared buffer gauge equals
the recomputed resident bytes of the rows still buffered, reaching zero when
the cursor drains. This pins the subtraction to the same value the old
rescan produced, so a future drift in either direction fails the test.

