### PR TITLE
docs(cypher-compat): record measured path-procedure and batch limits

### DIFF
--- a/cypher-compat.md
+++ b/cypher-compat.md
@@ -197,6 +197,9 @@ write one:
 - `UNWIND ... CREATE` and `UNWIND MATCH ... CREATE` cannot be followed by
   another clause, and an `UNWIND MATCH` must end in `RETURN` or `DELETE`.
 - `UNWIND MATCH` does not take `OPTIONAL`, hints, or `WHERE`.
+- A batch carries at most 1024 rows. Admission control rejects a larger one
+  with `client_query_batch_items rejected by admission control`, so a loader
+  chunks its rows rather than sending one big list.
 
 Batches run through the client service that the Bolt server uses, because a
 parameter holding a list of maps is a transport-level type. The in-process shard
@@ -231,8 +234,42 @@ Config keys include `sourceNode`, `targetNode`, `sourceLabel`, `sourceProperty`,
 optional maximum cost. Setting `targetLabel` or `targetProperty` requires
 `targetValues` as well.
 
+The keys are not interchangeable across the three procedures. How an origin is
+named differs, and using the wrong form is a parse error rather than an empty
+result:
+
+| Procedure | Origin form |
+|---|---|
+| `algo.SPpaths`, `algo.SSpaths` | a single `sourceNode`, an **integer** node id |
+| `algo.MSpaths` | a `sourceLabel` / `sourceProperty` / `sourceValues` set |
+
+Passing a `sourceValues` set to `algo.SSpaths` is rejected with `missing
+OpenCypher query parameter $sourceNode`, and a string `sourceNode` is rejected
+with `sourceNode must be an integer node id`.
+
+`sourceValues` and `targetValues` are **lists of strings**, matched against a
+string-typed property. Integer values are rejected with `sourceValues must be a
+list of strings`, and string values matched against an integer property parse
+but select nothing, so a query that looks correct returns no rows. Where node
+ids are integers, carrying a string mirror of the id as a separate property and
+pointing `sourceProperty` at that is one way to address nodes here.
+
+The two value lists must also be written as literals. Supplying them through a
+query parameter is rejected with `composite parameter $name is only supported as
+an UNWIND input`, so they are inlined into the statement text.
+
+`relDirection` accepts `'incoming'`, `'outgoing'` and `'both'`, case-insensitively;
+other spellings such as `'in'` are rejected.
+
+Without an explicit `pathCount`, `algo.SSpaths` returns only the single shortest
+path even when more exist. Counting incoming neighbours therefore needs a
+`pathCount` high enough to cover the expected degree, or the result silently
+reads as one.
+
 Yieldable columns are `path`, `pathWeight` and `pathCost`. `RETURN` may only
-name columns that were yielded.
+name columns that were yielded, and it may not aggregate over them: `RETURN
+count(path)` is rejected with `unknown path projection count`, so counting
+happens on the client.
 
 Unlike a plain `MATCH`, these are the way to get whole paths back rather than
 endpoint projections.

--- a/cypher-compat.md
+++ b/cypher-compat.md
@@ -197,9 +197,10 @@ write one:
 - `UNWIND ... CREATE` and `UNWIND MATCH ... CREATE` cannot be followed by
   another clause, and an `UNWIND MATCH` must end in `RETURN` or `DELETE`.
 - `UNWIND MATCH` does not take `OPTIONAL`, hints, or `WHERE`.
-- A batch carries at most 1024 rows. Admission control rejects a larger one
-  with `client_query_batch_items rejected by admission control`, so a loader
-  chunks its rows rather than sending one big list.
+- A batch carries at most `max_parameters` rows, 1024 by default. Admission
+  control rejects a larger one with `client_query_batch_items rejected by
+  admission control`, so a loader chunks to whatever the deployment configures
+  rather than sending one big list.
 
 Batches run through the client service that the Bolt server uses, because a
 parameter holding a list of maps is a transport-level type. The in-process shard


### PR DESCRIPTION
Building a Hack Hydra project on the open-source engine, I hit seven behaviours in the path procedures and batch loader that each cost a debugging cycle. All were straightforward once known; the reference just did not say. This records them.

The one that cost the most: the config keys are listed as a single flat set, which reads as though they apply uniformly across the three procedures. They do not — `SSpaths` wants an integer `sourceNode` and rejects a `sourceValues` set with `missing OpenCypher query parameter $sourceNode`, while `MSpaths` requires the set form. Because it surfaces as a parse error mentioning a parameter I had never written, it took a while to see that I was using the wrong origin form rather than malforming a parameter.

The subtler one worth reading twice: `sourceValues` entries are matched as **strings** against a string-typed property. Integers are rejected outright, but strings matched against an integer property **parse cleanly and select nothing** — a query that looks correct and returns no rows. That failure mode is silent, so it is the one I would most want documented.

Also recorded:

- those value lists must be inlined; passing them as a parameter is rejected with `composite parameter $name is only supported as an UNWIND input`
- `relDirection` accepts `incoming` / `outgoing` / `both`, case-insensitively (`in` is rejected)
- `algo.SSpaths` without an explicit `pathCount` returns only the single shortest path, so counting incoming neighbours silently reads as 1
- `RETURN count(path)` is rejected with `unknown path projection count`
- `UNWIND` batches cap at 1024 rows — `client_query_batch_items rejected by admission control`

Every error string is quoted verbatim from the engine. Measured against `ghcr.io/hydra-db/hydradb:latest`, revision `02a40025d2d57e97ab2754c8256219cdbfeab379` (v0.1.1).

Docs only — no code paths touched. Happy to reword anything to match house style, or to split it if you would rather these landed separately.

Separately filed #81 for a manifest-GC failure under the documented `CLOUD_PROVIDER=local` config, which is a behaviour rather than a docs gap.