### PR TITLE
fix: keep the xlog retention floor above every sequence GC deleted from

### DIFF
--- a/src/shard/xlog.rs
+++ b/src/shard/xlog.rs
@@ -17,9 +17,21 @@
 use super::*;
 use crate::shard::topology_tail::GraphTopologyOverlay;
 
-/// Cap on xlog entries deleted per GC pass so a long-idle builder's backlog
-/// cannot balloon one write transaction. A capped pass advances the low-water
-/// mark to the last sequence it touched; the next pass continues from there.
+/// Soft cap on xlog entries deleted per GC pass so a long-idle builder's
+/// backlog cannot balloon one write transaction.
+///
+/// **Soft, and it has to be.** The floor this pass publishes names a
+/// *sequence*, while the cap counts *entries*, and one sequence is one commit
+/// with one entry per changed edge — so a hard cap would routinely land inside
+/// a sequence. A pass that deleted half of sequence `S` and then published `S`
+/// as the retention floor would be claiming coverage for entries it had just
+/// removed, and the next incremental build over a range starting at `S` would
+/// take the `Complete` arm with a silently truncated delta instead of
+/// bootstrapping. So the pass stops at the first sequence *boundary* at or
+/// after the cap: a sequence is always collected whole, and the floor is
+/// always one past the last sequence that no longer exists. The overshoot is
+/// bounded by one commit's edge count, which the write path already had to
+/// hold in a single transaction.
 const XLOG_GC_MAX_DELETES: usize = 100_000;
 
 /// Outcome of deriving the delta for `(previous.base_sequence, base_sequence]`
@@ -65,6 +77,89 @@ pub(crate) fn parse_xlog_entry_key(
         return Err(corrupt("xlog key has trailing components"));
     }
     Ok((sequence, src, dst))
+}
+
+/// What one GC pass does with the entry it is looking at.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum XlogGcStep {
+    /// Add it to the delete batch.
+    Take,
+    /// End the pass without it.
+    Stop,
+}
+
+/// The retention decision a `gc_topology_changelog_to` pass makes as it walks
+/// the xlog in ascending sequence order.
+///
+/// Split out of the scan loop so both boundary rules — where the cap may stop,
+/// and what floor the pass then publishes — are exercisable from a table test
+/// instead of only through a backlog of [`XLOG_GC_MAX_DELETES`] real entries.
+/// The two are one rule seen twice, and reading them side by side is the point:
+/// the floor names a *sequence*, so the pass may only stop where a sequence
+/// ends.
+pub(crate) struct XlogGcPass {
+    gc_through: StorageSequence,
+    max_deletes: usize,
+    taken: usize,
+    last_sequence: StorageSequence,
+    capped: bool,
+}
+
+impl XlogGcPass {
+    /// A pass resuming at `low_water` and collecting entries stamped at or
+    /// below `gc_through` — the published generation's base, above which
+    /// entries are the next build's delta rather than dead weight.
+    pub(crate) fn new(
+        low_water: StorageSequence,
+        gc_through: StorageSequence,
+        max_deletes: usize,
+    ) -> Self {
+        Self {
+            gc_through,
+            max_deletes,
+            taken: 0,
+            last_sequence: low_water,
+            capped: false,
+        }
+    }
+
+    /// Offer the pass the entry stamped `sequence`. Entries must arrive in
+    /// ascending sequence order, which the key encoding's zero padding
+    /// guarantees.
+    pub(crate) fn step(&mut self, sequence: StorageSequence) -> XlogGcStep {
+        if sequence > self.gc_through {
+            return XlogGcStep::Stop;
+        }
+        // The cap is consulted before the entry is taken, and only where the
+        // sequence changes. A pass that stopped *inside* a sequence would
+        // delete part of one commit and then publish a floor claiming that
+        // commit is still retained, and the next incremental build over a
+        // range starting there would take `XlogDelta::Complete` with a
+        // silently truncated delta instead of bootstrapping.
+        if self.taken >= self.max_deletes && sequence != self.last_sequence {
+            self.capped = true;
+            return XlogGcStep::Stop;
+        }
+        self.last_sequence = sequence;
+        self.taken = self.taken.saturating_add(1);
+        XlogGcStep::Take
+    }
+
+    /// Whether the pass stopped at the cap rather than at `gc_through`.
+    pub(crate) fn capped(&self) -> bool {
+        self.capped
+    }
+
+    /// The retention floor to publish: one past the last sequence this pass
+    /// emptied, i.e. the lowest sequence whose entries still exist. Only
+    /// meaningful once at least one entry was taken.
+    pub(crate) fn next_low_water(&self) -> StorageSequence {
+        if self.capped {
+            self.last_sequence.saturating_add(1)
+        } else {
+            self.gc_through.saturating_add(1)
+        }
+    }
 }
 
 pub(crate) fn decode_xlog_exists(key: &str, value: &[u8]) -> Result<bool> {
@@ -213,19 +308,13 @@ impl GraphShard {
             )
             .await?;
         let mut dead_keys: Vec<String> = Vec::new();
-        let mut last_sequence = low_water;
-        let mut capped = false;
+        let mut pass = XlogGcPass::new(low_water, gc_through, XLOG_GC_MAX_DELETES);
         while let Some(kv) = iter.next().await? {
             let key = String::from_utf8_lossy(&kv.key).into_owned();
             let (sequence, _, _) = parse_xlog_entry_key(&prefix, &key)?;
-            if sequence > gc_through {
-                break;
-            }
-            last_sequence = sequence;
-            dead_keys.push(key);
-            if dead_keys.len() >= XLOG_GC_MAX_DELETES {
-                capped = true;
-                break;
+            match pass.step(sequence) {
+                XlogGcStep::Take => dead_keys.push(key),
+                XlogGcStep::Stop => break,
             }
         }
 
@@ -236,15 +325,8 @@ impl GraphShard {
         if dead_keys.is_empty() {
             return Ok(0);
         }
-        // A capped pass may leave entries at `last_sequence` behind, so the
-        // floor stays *at* that sequence (still retained), not past it; the
-        // next pass resumes there. An uncapped pass covered everything
-        // through `gc_through`.
-        let next_low = if capped {
-            last_sequence
-        } else {
-            gc_through.saturating_add(1)
-        };
+        let capped = pass.capped();
+        let next_low = pass.next_low_water();
         let mut batch = GraphWriteBatch::new();
         for key in &dead_keys {
             batch.delete(key.as_bytes());
@@ -264,5 +346,132 @@ impl GraphShard {
             "xlog GC advanced the low-water mark"
         );
         Ok(deleted)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Drive a pass over `sequences` and report what it collected and what
+    /// floor it would publish. One entry per element, in the order the key
+    /// encoding delivers them.
+    fn run(
+        sequences: &[StorageSequence],
+        low_water: StorageSequence,
+        gc_through: StorageSequence,
+        max_deletes: usize,
+    ) -> (Vec<StorageSequence>, StorageSequence, bool) {
+        let mut pass = XlogGcPass::new(low_water, gc_through, max_deletes);
+        let mut taken = Vec::new();
+        for sequence in sequences {
+            match pass.step(*sequence) {
+                XlogGcStep::Take => taken.push(*sequence),
+                XlogGcStep::Stop => break,
+            }
+        }
+        (taken, pass.next_low_water(), pass.capped())
+    }
+
+    /// The invariant every other test here is a corollary of, stated once:
+    /// `xlog_low_water` is the lowest sequence whose entries are *still
+    /// retained* (`keys::xlog_low_water`), so no sequence may be left
+    /// half-collected below the floor the pass publishes. `xlog_delta_since`
+    /// reads that floor and answers `Complete` for any range starting at or
+    /// above it; a half-collected sequence there is a silently truncated
+    /// delta, not an error.
+    #[test]
+    fn a_capped_pass_never_leaves_a_sequence_half_collected() {
+        // Sequence 7 is one commit that changed four edges. The cap falls in
+        // the middle of it.
+        let (taken, next_low, capped) = run(&[5, 6, 7, 7, 7, 7, 8, 9], 5, 9, 3);
+
+        assert!(capped, "the cap must have stopped this pass");
+        assert_eq!(
+            taken,
+            [5, 6, 7, 7, 7, 7],
+            "the pass must finish sequence 7 rather than stop inside it"
+        );
+        assert_eq!(
+            next_low, 8,
+            "the floor must name the lowest sequence that still exists"
+        );
+        assert!(
+            !taken.contains(&next_low),
+            "the published floor must not name a sequence this pass deleted from"
+        );
+    }
+
+    /// The regression this file's fix is for, phrased as the builder sees it:
+    /// after a capped pass, a delta whose range opens at the floor must find
+    /// every entry that floor claims is retained.
+    #[test]
+    fn the_published_floor_only_covers_sequences_that_were_left_alone() {
+        let all: Vec<StorageSequence> = vec![5, 6, 7, 7, 7, 7, 8, 9];
+        let (taken, next_low, _) = run(&all, 5, 9, 3);
+
+        let survivors: Vec<StorageSequence> = all
+            .iter()
+            .copied()
+            .skip(taken.len())
+            .filter(|sequence| *sequence <= 9)
+            .collect();
+        // Everything the next build would scan from `next_low` is still there,
+        // and nothing below `next_low` survived to be missed.
+        assert!(
+            survivors.iter().all(|sequence| *sequence >= next_low),
+            "a surviving entry sits below the published floor: {survivors:?}"
+        );
+        assert!(
+            taken.iter().all(|sequence| *sequence < next_low),
+            "a deleted entry sits at or above the published floor: {taken:?}"
+        );
+    }
+
+    /// A single commit larger than the cap must still be collected whole, or
+    /// GC would never make progress past it. The cap is a soft one precisely
+    /// so this terminates.
+    #[test]
+    fn one_commit_bigger_than_the_cap_is_still_collected_whole() {
+        let (taken, next_low, capped) = run(&[4, 4, 4, 4, 4, 4, 5], 4, 5, 2);
+
+        assert!(capped);
+        assert_eq!(taken, [4, 4, 4, 4, 4, 4], "sequence 4 must come out whole");
+        assert_eq!(next_low, 5, "and the floor must advance past it");
+    }
+
+    /// An uncapped pass covered everything through the published base, so the
+    /// floor goes one past that base and not merely past the last entry it
+    /// happened to see.
+    #[test]
+    fn an_uncapped_pass_publishes_one_past_the_generation_base() {
+        let (taken, next_low, capped) = run(&[5, 6, 7], 5, 9, 100);
+
+        assert!(!capped);
+        assert_eq!(taken, [5, 6, 7]);
+        assert_eq!(next_low, 10);
+    }
+
+    /// Entries above the published base are the *next* build's delta, not
+    /// dead weight, and the pass stops at them whatever the cap says.
+    #[test]
+    fn entries_above_the_generation_base_are_never_collected() {
+        let (taken, next_low, capped) = run(&[5, 6, 10, 11], 5, 6, 100);
+
+        assert!(!capped);
+        assert_eq!(taken, [5, 6]);
+        assert_eq!(next_low, 7);
+    }
+
+    /// The cap alone does not stop a pass: it arms it, and the next sequence
+    /// boundary fires it. A run that reaches the cap on its final sequence
+    /// finishes uncapped.
+    #[test]
+    fn reaching_the_cap_on_the_last_sequence_is_not_a_capped_pass() {
+        let (taken, next_low, capped) = run(&[5, 5, 5], 5, 5, 2);
+
+        assert!(!capped, "there was no later sequence to stop at");
+        assert_eq!(taken, [5, 5, 5]);
+        assert_eq!(next_low, 6);
     }
 }


### PR DESCRIPTION
﻿Closes #84

## The problem

`xlog_low_water` is defined by `src/keys.rs:53-58` as

> Lowest sequence whose xlog entries are still retained for the edge type â€” the
> coverage floor an incremental build checks before trusting the range scan.

and `xlog_delta_since` is written against exactly that reading: `from < low_water`
is a `CoverageGap` and everything else is `Complete`, so a range that *opens on*
the floor is treated as fully covered.

`gc_topology_changelog_to` could publish a floor for which that is false.

The floor names a **sequence**. `XLOG_GC_MAX_DELETES` counts **entries**. One
sequence is one commit with one xlog entry per changed edge, so a cap counted in
entries lands inside a sequence, and the cap check ran *after* the key was
pushed:

```rust
last_sequence = sequence;
dead_keys.push(key);                        // entry taken
if dead_keys.len() >= XLOG_GC_MAX_DELETES {
    capped = true;
    break;                                  // possibly mid-sequence
}
...
let next_low = if capped { last_sequence } else { gc_through.saturating_add(1) };
```

So a pass that stopped inside sequence `S` deleted some of `S`'s entries and
then published `S` as the lowest sequence still retained. The old comment said
"a capped pass may leave entries at `last_sequence` behind, so the floor stays
*at* that sequence (still retained)" â€” true of the survivors, and silent about
the ones the same pass had just deleted.

If a delta ever opens on that floor, `xlog_delta_since` returns `Complete` with
half a commit missing and the incremental build patches the previous generation
with a truncated delta â€” a published index that disagrees with canonical storage,
with nothing raised and nothing visible except the content-addressed generation
id no longer matching a full rebuild.

**On reachability, plainly:** I traced it and could not open that range on `main`
today. `build_graph_index_incremental` and `gc_topology_changelog` both take
their generation from `current_graph_index`, so `from = previous.base + 1` is
always above `gc_through >= last_sequence`; the floor read and the entry scan
also share one pinned snapshot, which closes the concurrent-indexer window. This
is a broken invariant rather than a live incident, and I would rather say so than
oversell it. It is still worth fixing: the invariant is what `xlog_delta_since`
is built on, the `CoverageGap` arm exists precisely to catch this class, and the
failure mode if anything later opens that range is a wrong index rather than a
refusal.

There was also a smaller, unconditional bug in the same lines: a commit larger
than the cap made no floor progress at all. The pass deleted `MAX` of its
entries, republished the same floor it started from, and the next pass rescanned
from there â€” correct in the end, but it re-read what it had already deleted on
every cycle until the commit drained.

## The change

`src/shard/xlog.rs` only.

**The cap becomes soft.** It *arms* the pass; the next sequence boundary fires
it. A sequence is therefore always collected whole, and the floor is always one
past the last sequence that no longer exists â€” which is the definition
`keys.rs` gives it.

The rule is now stated once, in a type, rather than twice in a loop:

```rust
pub(crate) struct XlogGcPass { .. }
impl XlogGcPass {
    fn step(&mut self, sequence: StorageSequence) -> XlogGcStep { .. }
    fn capped(&self) -> bool { .. }
    fn next_low_water(&self) -> StorageSequence { .. }
}
```

`gc_topology_changelog_to`'s loop keeps its shape and stays lazy â€” `step` is
consulted per entry and `Stop` still breaks out, so a capped pass reads no more
of the backlog than before. Splitting it out is what makes both boundary rules
reachable from a table test instead of only through 100 000 real entries, and it
puts the two halves of one rule next to each other: the floor names a sequence,
so the pass may only stop where a sequence ends.

Termination is preserved and improved: a single commit larger than the cap is
now collected whole and the floor advances past it, instead of being re-scanned
in slices. The overshoot is bounded by one commit's edge count â€” which the write
path already had to hold in a single transaction (`mark_topology_change_txn`),
so the batch size is bounded by something the system already sizes for.

## Tests

Six table tests in `src/shard/xlog.rs`:

- `a_capped_pass_never_leaves_a_sequence_half_collected` â€” the invariant. A cap
  that falls inside a four-entry commit must finish the commit, and the
  published floor must not name a sequence the pass deleted from.
- `the_published_floor_only_covers_sequences_that_were_left_alone` â€” the same
  thing from the builder's side: everything at or above the floor survived,
  everything below it is gone. This is the property `xlog_delta_since` relies on.
- `one_commit_bigger_than_the_cap_is_still_collected_whole` â€” termination, and
  the floor-progress bug.
- `an_uncapped_pass_publishes_one_past_the_generation_base` â€” the unchanged path.
- `entries_above_the_generation_base_are_never_collected` â€” the next build's
  delta is not dead weight, whatever the cap says.
- `reaching_the_cap_on_the_last_sequence_is_not_a_capped_pass` â€” the cap arms,
  the boundary fires.

## Verification

Built and run on Ubuntu 24.04 with `libcypher-parser` 0.6.2 and SuiteSparse
GraphBLAS 7.4.0:

```
cargo test  --locked --lib
cargo test  --locked --features opencypher --lib
cargo clippy --locked --all-targets -- -D warnings
cargo clippy --locked --all-targets --features opencypher -- -D warnings
cargo fmt --all --check
```

I also ran the three invariant tests against an unmodified `upstream/main`
worktree, with the loop and floor arithmetic from `xlog.rs:218-247` lifted into
the test module verbatim, to confirm they fail there:

```
a_capped_pass_never_leaves_a_sequence_half_collected
  the published floor 7 names a sequence this pass deleted from: [5, 6, 7]
the_published_floor_only_covers_sequences_that_were_left_alone
  a deleted entry sits at or above the published floor 7: [5, 6, 7]
one_commit_bigger_than_the_cap_is_still_collected_whole
  and the floor must advance past it: left: 4, right: 5
```

The existing xlog coverage â€” `gc_topology_changelog` in `src/tests.rs:15473`,
`:15597`, `:15653`, and the floor-repair test at `:15734` â€” exercises the
uncapped path and is unchanged by this.

