### PR TITLE
docs(readme): note that CLOUD_PROVIDER=local cannot sustain writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,17 @@ keeps the created files host-owned. The image entrypoint is `graph-node`; it
 also ships `graph-indexer`. For production, pin an image digest rather than
 `latest` — see the [Helm chart guide](charts/hydradb/README.md).
 
+> **`CLOUD_PROVIDER=local` is for smoke tests, not sustained writes.** The
+> `local` backend stores through `LocalFileSystem`, which does not implement
+> conditional puts (`put_opts` with `PutMode::Update`). Manifest garbage
+> collection needs them, so under a sustained write load GC begins failing and
+> does not recover — logged at `ERROR` as
+> `error collecting garbage [resource=Manifest, error=ObjectStoreError(NotImplemented ...)]`.
+> Reads and `/readyz` keep succeeding while this happens, so the node looks
+> healthy. For anything beyond a smoke test use an S3-compatible backend; the
+> MinIO harness below (`just minio-smoke`) is the shortest path to one. See
+> [#81](https://github.com/hydra-db/hydradb/issues/81).
+
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -169,9 +169,14 @@ also ships `graph-indexer`. For production, pin an image digest rather than
 > does not recover — logged at `ERROR` as
 > `error collecting garbage [resource=Manifest, error=ObjectStoreError(NotImplemented ...)]`.
 > Reads and `/readyz` keep succeeding while this happens, so the node looks
-> healthy. For anything beyond a smoke test use an S3-compatible backend; the
-> MinIO harness below (`just minio-smoke`) is the shortest path to one. See
-> [#81](https://github.com/hydra-db/hydradb/issues/81).
+> healthy. For anything beyond a smoke test, point the node at an S3-compatible
+> object store instead — `CLOUD_PROVIDER=aws` with `AWS_BUCKET_NAME`,
+> `AWS_DEFAULT_REGION`, and, for a local MinIO, `AWS_ENDPOINT` plus
+> `AWS_ALLOW_HTTP=true`. `CLOUD_PROVIDER` accepts `local`, `memory`, `aws`,
+> `azure` and `gcp`; `memory` is also fine for a throwaway smoke test where
+> durability does not matter. See the
+> [Helm chart guide](charts/hydradb/README.md) for the full object-store surface,
+> and [#81](https://github.com/hydra-db/hydradb/issues/81) for the reproduction.
 
 </details>
 


### PR DESCRIPTION
Documentation fix for #81 — the third of the three suggested fixes in that issue, and the only one I can make safely from outside the project.

The `local` backend stores through `LocalFileSystem`, which does not implement conditional puts (`put_opts` with `PutMode::Update`). Manifest garbage collection requires them, so under a sustained write load GC starts failing and does not recover. The failure mode is quiet: reads and `/readyz` keep succeeding throughout, so the node reads as healthy while garbage accumulates.

Reproduced on a clean container using this README's own `docker run` recipe — first GC error 6 min 21 s in, then recurring. Full reproduction and timings in #81.

This adds a short note beside the local run recipe and points at the MinIO harness (`just minio-smoke`) that the README already documents, so the reader has somewhere to go rather than just a warning.

Scope: documentation only. It deliberately does not touch the GC path or add a startup capability check — suggested fixes 1 and 2 in #81 are yours to make, and I would not want to guess at the right behaviour inside SlateDB's manifest handling. Happy to test a patch for either; the reproduction is scripted.

Related: #82 (path-procedure and batch limits in `cypher-compat.md`).