### PR TITLE
  ci: restore CI workflow and add contributor templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,156 @@
+name: Bug report
+description: Something in HydraDB behaves incorrectly — a crash, a wrong query result, or a broken deployment.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        These five have environmental causes rather than code ones. The full
+        list is in [AGENTS.md](https://github.com/hydra-db/hydradb/blob/main/AGENTS.md#failure-modes-worth-knowing-before-you-debug).
+
+        | Symptom | Cause |
+        |---|---|
+        | `invalid environment variable CLOUD_PROVIDER value` reporting `null` | `CLOUD_PROVIDER` is unset — `null` means absent, not the string. `local` also needs `LOCAL_PATH` pointing at a directory that already exists. |
+        | The node serves `/readyz`, then aborts with `has overflowed its stack` on the first query | `RUST_MIN_STACK` is unset. It looks like a query bug and is not. |
+        | `fatal error: 'cypher-parser.h' file not found` when building on macOS | `BINDGEN_EXTRA_CLANG_ARGS` is unset. Build through `just`, not bare `cargo`. |
+        | `curl: (7) Failed to connect` to the admin port | `graph-node` runs in the foreground and never returns. That is it working — start it in its own shell. |
+        | `No available formula with the name "libcypher-parser"` | Not in homebrew-core: `brew install cleishm/neo4j/libcypher-parser`. |
+
+        `Error: Slate(...)` comes from
+        [SlateDB](https://github.com/usecortex/slatedb), not from this crate.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Preflight
+      options:
+        - label: I searched existing issues and this is not a duplicate.
+          required: true
+        - label: I can reproduce this on the latest release or on current `main`.
+          required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What you observed, and what you expected instead. Paste exact error text rather than paraphrasing it.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: |
+        The smallest sequence that shows the problem. For a query bug, include the
+        Cypher that sets the data up as well as the query that misbehaves — a
+        `MATCH` cannot be run without the `CREATE` that produced the data.
+      placeholder: |
+        1. Start a node with GRAPH_ALLOW_PLAINTEXT=true against a local store
+        2. CREATE (a {id: 1})-[:FOLLOWS]->(b {id: 2})
+        3. MATCH (a {id: 1})-[:FOLLOWS]->(b) RETURN b.id AS id
+        4. Returns two rows; expected one
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Release tag, image tag, or commit SHA. "latest" is not a version — `main` is rebased frequently, so a SHA is what makes a report reproducible.
+      placeholder: "v0.1.0, or sha-7bf77ac, or commit 6a2fbb1"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Best guess is fine.
+      options:
+        - graph-node (queries, mutations, serving)
+        - graph-indexer (CSC generation building)
+        - Query planner / OpenCypher semantics
+        - Bolt protocol / Neo4j driver compatibility
+        - HTTP query API
+        - Storage, WAL, or writer fencing
+        - Sparse traversal kernel / GraphBLAS
+        - Helm chart or Kubernetes deployment
+        - Build, CI, or Docker image
+        - Documentation
+        - Not sure
+    validations:
+      required: true
+
+  - type: dropdown
+    id: install
+    attributes:
+      label: How it is running
+      options:
+        - Docker image from ghcr.io
+        - Built from source
+        - Helm chart
+        - Embedded as a library
+    validations:
+      required: true
+
+  - type: dropdown
+    id: object-store
+    attributes:
+      label: Object store backend
+      description: The `CLOUD_PROVIDER` value, or the S3-compatible service if you point `aws` at a custom endpoint.
+      options:
+        - local (filesystem)
+        - memory
+        - aws (S3)
+        - MinIO or another S3-compatible endpoint
+        - azure
+        - gcp
+    validations:
+      required: true
+
+  - type: dropdown
+    id: sparse-kernel
+    attributes:
+      label: Sparse kernel
+      description: |
+        `GRAPH_SPARSE_KERNEL`, read by the `graph-node` binary only. Worth
+        checking before reporting a wrong result: `adjacency` is a capability
+        downgrade, not merely a slower path — it has no count or window pushdown
+        and enforces scan and row limits the compiled path does not, so a
+        traversal that succeeds on `suitesparse` can fail outright on it.
+      options:
+        - suitesparse (default)
+        - compact
+        - adjacency
+        - Not applicable
+    validations:
+      required: true
+
+  - type: input
+    id: platform
+    attributes:
+      label: Platform
+      placeholder: "Ubuntu 24.04 x86_64, or macOS 15 arm64, or EKS 1.31"
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: |
+        Relevant output, ideally with `RUST_LOG=debug`. If a node failed to
+        start or died, its log is the first thing worth reading — `node.log`
+        under the run directory. Trim to the relevant portion.
+      render: shell
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Anything else
+      description: Graph size, concurrency, cell configuration, query limits you have raised or lowered, or anything that made the failure more or less likely.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: false
+
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/hydra-db/hydradb/blob/main/SECURITY.md
+    about: Do not open a public issue. Report it privately to the maintainers — SECURITY.md covers what to include.
+
+  - name: Question or usage help
+    url: https://github.com/hydra-db/hydradb/discussions
+    about: How to model something, why a query is slow, whether behaviour is intended.
+
+  - name: Build and development setup
+    url: https://github.com/hydra-db/hydradb/blob/main/DEVELOPMENT.md
+    about: Recipes and harnesses. AGENTS.md lists the failure modes that cost the most time to rediscover.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,96 @@
+name: Feature request
+description: Propose a capability HydraDB does not have, or a change to one it does.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        If you are unsure whether something is a missing feature or a bug, file
+        a bug report — it asks for the detail needed to tell the difference.
+
+        For a change large enough to need design discussion before code, open
+        the issue first and say so. Landed designs live in `docs/plans/` as
+        dated markdown; the issue is where the shape gets agreed.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Preflight
+      options:
+        - label: I searched existing issues and this is not a duplicate.
+          required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: The problem
+      description: |
+        What are you trying to do that HydraDB makes hard or impossible today?
+        Describe the situation rather than the fix; the proposed change goes in
+        the next field.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed change
+      description: What you would like to happen. Sketch the API, Cypher syntax, configuration key, or chart value if you have one in mind.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Workarounds you tried, and why they were not enough.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Query language / OpenCypher coverage
+        - Query planner or execution
+        - Bolt protocol / driver compatibility
+        - HTTP query API
+        - Storage, durability, or writer coordination
+        - Indexing (graph-indexer, CSC generations)
+        - Sparse traversal kernels
+        - Observability (metrics, traces, logs)
+        - Deployment (Helm chart, Docker, Kubernetes)
+        - Configuration and operations
+        - Documentation
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: compatibility
+    attributes:
+      label: Compatibility
+      description: |
+        Tick anything this would change. None of these disqualify a proposal —
+        they decide whether it can land in a patch release or has to wait for a
+        breaking one, so it is better to flag them now than to discover them in
+        review.
+      options:
+        - label: Changes the result of a query that works today
+        - label: Changes the Bolt or HTTP wire format
+        - label: Changes the on-disk or object-store layout
+        - label: Adds or renames configuration, environment variables, or chart values
+        - label: Adds a new third-party dependency
+        - label: None of the above, or I am not sure
+
+  - type: dropdown
+    id: contributing
+    attributes:
+      label: Would you like to implement this?
+      description: Not a commitment, and a "no" costs a proposal nothing.
+      options:
+        - "Yes, I would like to work on it"
+        - "Yes, with guidance on where to start"
+        - "No, I am proposing it for someone else to pick up"
+    validations:
+      required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,32 @@
+<!-- Delete any section that does not apply. -->
+
+## What this changes and why
+
+<!-- The reasoning that is not visible in the diff: what was broken, what else
+you considered, why this. If it closes an issue, say "Fixes #123". -->
+
+## How it was verified
+
+<!-- What you actually ran, not what you intended to run. If you ran only part
+of `just ci` — it is a long run, 25m 41s clean — say which part. -->
+
+- [ ] `just ci` passes locally (or `bash scripts/ci_local.sh`, which delegates to it)
+- [ ] New behaviour has a test that fails without the change
+- [ ] Ran `just smoke`, and `bash scripts/runtime_smoke.sh` if this touches the server runtime
+
+## Compatibility
+
+<!-- These decide whether the change can land in a patch release. If you tick
+one, describe the upgrade path for an operator on the previous release. -->
+
+- [ ] Changes the result of a query that works today
+- [ ] Changes the Bolt or HTTP wire format
+- [ ] Changes the on-disk or object-store layout, or needs a migration
+- [ ] Adds or renames configuration, environment variables, or chart values
+- [ ] Adds a third-party dependency
+- [ ] None of the above
+
+## Notes for the reviewer
+
+<!-- Where to start, what you are unsure about, what you left out of scope.
+Follow-up work belongs in an issue, linked from here. -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,10 +274,16 @@ jobs:
             echo "invalid object-store endpoint port was accepted"
             exit 1
           fi
+      # Pinned by digest, like the actions above: this image is executed on the
+      # runner and decides whether invalid manifests reach main, so a repointed
+      # tag would change the gate without review. The digest is the multi-arch
+      # index, so it resolves on both amd64 and arm64 runners.
       - name: Validate Kubernetes resources
+        env:
+          KUBECONFORM: ghcr.io/yannh/kubeconform:v0.8.0@sha256:faffaf43f95aa6425306e1ab8d6fcad72acb9049158f38e574c085ea1ec0f64e
         run: |
-          docker run --rm -i ghcr.io/yannh/kubeconform:v0.8.0 -strict -summary < /tmp/hydradb-development.yaml
-          docker run --rm -i ghcr.io/yannh/kubeconform:v0.8.0 -strict -summary -ignore-missing-schemas < /tmp/hydradb-eks.yaml
+          docker run --rm -i "$KUBECONFORM" -strict -summary < /tmp/hydradb-development.yaml
+          docker run --rm -i "$KUBECONFORM" -strict -summary -ignore-missing-schemas < /tmp/hydradb-eks.yaml
 
 
   # Each step names the `just` recipe it mirrors, in the justfile's own order.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
-      - uses: azure/setup-helm@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
         with:
           version: v3.17.3
       - name: Validate single-node deployment script
@@ -289,14 +289,18 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      # SHA-pinned like every other action here. The pin freezes the action's
+      # own code, not the compiler, so `toolchain` is stated explicitly rather
+      # than inherited from whichever branch the SHA was taken from.
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
+          toolchain: stable
           components: rustfmt, clippy
       # Without this the job rebuilds all 398 locked dependencies every run.
       # `save-if` keeps only main writing the entry, so branch-scoped caches
       # cannot accumulate and evict what the next main build needs.
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           shared-key: linux-test
           save-if: ${{ github.ref == 'refs/heads/main' }}
@@ -424,7 +428,7 @@ jobs:
       # script tears the node down on exit.
       - name: Upload runtime smoke log
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: runtime-smoke-log
           path: /tmp/sgk-runtime-smoke/node.log
@@ -444,14 +448,15 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
+          toolchain: stable
           components: clippy
       # A separate cache entry from the `test` job, and it has to be: rust-cache
       # keys on runner OS and architecture, so a macOS target directory can
       # never restore onto Linux.
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           shared-key: macos-default
           save-if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,467 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+# Cancel superseded pull-request runs, but never a `main` run: that would leave
+# no status on a commit that is already merged.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+# `RUST_MIN_STACK` matches justfile:18. OpenCypher's async query futures exceed
+# the 2 MiB default test-thread stack, and the suite then aborts with SIGABRT
+# instead of reporting the assertion that failed.
+env:
+  CARGO_INCREMENTAL: 0
+  CARGO_TERM_COLOR: always
+  RUST_MIN_STACK: 33554432
+
+jobs:
+  # Asserts the chart invariants a template cannot express: that the closed
+  # network defaults stay closed, that `templates/validate.yaml` rejects what it
+  # claims to, and that runtime integers survive Helm's YAML round-trip without
+  # turning into scientific notation.
+  helm:
+    name: Helm chart
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: azure/setup-helm@v4
+        with:
+          version: v3.17.3
+      - name: Validate single-node deployment script
+        env:
+          HYDRADB_S3_BUCKET: ci-hydradb-bucket
+          HYDRADB_PUBLIC_HOST: 203.0.113.10
+          HYDRADB_STATE_DIR: /tmp/hydradb-single-node
+        run: |
+          bash -n scripts/deploy_single_node_k3s.sh
+          bash -n scripts/ec2_graphblas_benchmark.sh
+          python3 -m py_compile scripts/bolt_graphblas_client.py
+          bash scripts/deploy_single_node_k3s.sh --render-only
+      - name: Lint Helm chart
+        run: helm lint charts/hydradb --values charts/hydradb/ci/ci-values.yaml
+      - name: Render secure EKS example
+        run: helm template hydradb charts/hydradb --namespace hydradb --values charts/hydradb/examples/values-eks.yaml > /tmp/hydradb-eks.yaml
+      - name: Render development example
+        run: helm template hydradb charts/hydradb --namespace hydradb --values charts/hydradb/examples/values-development.yaml > /tmp/hydradb-development.yaml
+      - name: Verify chart invariants
+        run: |
+          helm template hydradb charts/hydradb \
+            --namespace hydradb \
+            --values charts/hydradb/ci/ci-values.yaml \
+            --set auth.secretKey=custom-token > /tmp/hydradb-custom-auth.yaml
+          grep -q 'GRAPH_AUTH_TOKEN_FILE: "/var/run/secrets/hydradb/custom-token"' /tmp/hydradb-custom-auth.yaml
+          grep -q 'GRAPH_MAX_RELATIONSHIP_ROWS_BYTES: "8388608"' /tmp/hydradb-custom-auth.yaml
+          grep -q 'GRAPH_MAX_SOURCE_RELATIONSHIP_ROWS_BYTES: "8388608"' /tmp/hydradb-custom-auth.yaml
+          grep -q 'GRAPH_MAX_RELATIONSHIP_PROPERTY_ROWS_BYTES: "16777216"' /tmp/hydradb-custom-auth.yaml
+          grep -q 'path: custom-token' /tmp/hydradb-custom-auth.yaml
+          if grep -q '^kind: RoleBinding$' /tmp/hydradb-custom-auth.yaml; then
+            echo "controllerless chart unexpectedly rendered a RoleBinding"
+            exit 1
+          fi
+          grep -q 'name: hydradb-bolt' /tmp/hydradb-custom-auth.yaml
+          grep -q 'name: hydradb-https' /tmp/hydradb-custom-auth.yaml
+          grep -q 'app.kubernetes.io/component: node' /tmp/hydradb-custom-auth.yaml
+          grep -q 'app.kubernetes.io/component: indexer' /tmp/hydradb-custom-auth.yaml
+          grep -q 'command: \["/usr/local/bin/graph-indexer"\]' /tmp/hydradb-custom-auth.yaml
+          grep -q 'name: hydradb-indexer-metrics' /tmp/hydradb-custom-auth.yaml
+          grep -q 'GRAPH_INDEX_DISCOVERY_INTERVAL_MS: "5000"' /tmp/hydradb-custom-auth.yaml
+          grep -q 'GRAPH_INDEXER_RETAIN_PREVIOUS: "1"' /tmp/hydradb-custom-auth.yaml
+          grep -q 'GRAPH_INDEXER_BUILD_MODE: "full"' /tmp/hydradb-custom-auth.yaml
+          grep -q 'GRAPH_INDEXER_INCREMENTAL_MIN_EDGES: "250000"' /tmp/hydradb-custom-auth.yaml
+          grep -q 'GRAPH_INDEXER_SCOPE_CONCURRENCY: "8"' /tmp/hydradb-custom-auth.yaml
+          grep -q 'GRAPH_INDEXER_SCOPES_PER_CYCLE: "256"' /tmp/hydradb-custom-auth.yaml
+          grep -q 'GRAPH_INDEXER_MAX_OPEN_SCOPES: "128"' /tmp/hydradb-custom-auth.yaml
+          grep -q 'GRAPH_INDEXER_READINESS_FAILURE_THRESHOLD: "3"' /tmp/hydradb-custom-auth.yaml
+          grep -q 'GRAPH_INDEXER_MAX_TAIL_FILES: "4096"' /tmp/hydradb-custom-auth.yaml
+          grep -q 'GRAPH_WAL_TAIL_FETCH_CONCURRENCY: "16"' /tmp/hydradb-custom-auth.yaml
+          if helm template hydradb charts/hydradb \
+            --namespace hydradb \
+            --values charts/hydradb/ci/ci-values.yaml \
+            --set indexer.scopeConcurrency=64 \
+            --set indexer.maxOpenScopes=1 \
+            > /tmp/hydradb-invalid-indexer-capacity.yaml 2>&1; then
+            echo "indexer reader capacity below scope concurrency was accepted"
+            exit 1
+          fi
+          grep -q 'indexer.maxOpenScopes must be greater than or equal to indexer.scopeConcurrency' \
+            /tmp/hydradb-invalid-indexer-capacity.yaml
+          if helm template hydradb charts/hydradb \
+            --namespace hydradb \
+            --values charts/hydradb/ci/ci-values.yaml \
+            --set indexer.scopeConcurrency=16 \
+            --set indexer.scopesPerCycle=8 \
+            > /tmp/hydradb-invalid-indexer-cycle.yaml 2>&1; then
+            echo "indexer cycle budget below scope concurrency was accepted"
+            exit 1
+          fi
+          grep -q 'indexer.scopesPerCycle must be greater than or equal to indexer.scopeConcurrency' \
+            /tmp/hydradb-invalid-indexer-cycle.yaml
+          helm template hydradb charts/hydradb \
+            --namespace hydradb \
+            --values charts/hydradb/ci/ci-values.yaml \
+            --set indexer.buildMode=incremental \
+            --set indexer.incrementalMinEdges=1000000 \
+            --show-only templates/configmap.yaml > /tmp/hydradb-incremental-indexer.yaml
+          grep -q 'GRAPH_INDEXER_BUILD_MODE: "incremental"' /tmp/hydradb-incremental-indexer.yaml
+          grep -q 'GRAPH_INDEXER_INCREMENTAL_MIN_EDGES: "1000000"' /tmp/hydradb-incremental-indexer.yaml
+          if grep -q 'GRAPH_MATRIX_REFRESH_' /tmp/hydradb-custom-auth.yaml; then
+            echo "query-node matrix refresh configuration is still rendered"
+            exit 1
+          fi
+          grep -q 'Authorization: Bearer' /tmp/hydradb-custom-auth.yaml
+          grep -q 'GRAPH_DATA_CACHE_BYTES: "8589934592"' /tmp/hydradb-custom-auth.yaml
+          grep -q 'GRAPH_READER_WAL_REPLAY_CONCURRENCY: "16"' /tmp/hydradb-custom-auth.yaml
+          if grep -Eq 'GRAPH_[A-Z0-9_]+: "[0-9]+(\.[0-9]+)?e[+-][0-9]+"' /tmp/hydradb-custom-auth.yaml; then
+            echo "runtime integer was rendered in scientific notation"
+            exit 1
+          fi
+          if helm template hydradb charts/hydradb \
+            --namespace hydradb \
+            --values charts/hydradb/ci/ci-values.yaml \
+            --set-json runtime.maxConcurrentQueries=1.9 > /tmp/hydradb-fractional-runtime.yaml 2>&1; then
+            echo "fractional runtime integer was accepted"
+            exit 1
+          fi
+          helm template hydradb charts/hydradb \
+            --namespace hydradb \
+            --values charts/hydradb/ci/ci-values.yaml \
+            --set-string runtime.maxQueryRuntimeMs=18446744073709551615 \
+            > /tmp/hydradb-u64-runtime.yaml
+          grep -q 'GRAPH_MAX_QUERY_RUNTIME_MS: "18446744073709551615"' /tmp/hydradb-u64-runtime.yaml
+          if helm template hydradb charts/hydradb \
+            --namespace hydradb \
+            --values charts/hydradb/ci/ci-values.yaml \
+            --set-string runtime.maxQueryRuntimeMs=18446744073709551616 \
+            > /tmp/hydradb-u64-overflow.yaml 2>&1; then
+            echo "overflowing unsigned runtime integer was accepted"
+            exit 1
+          fi
+          if helm template hydradb charts/hydradb \
+            --namespace hydradb \
+            --values charts/hydradb/ci/ci-values.yaml \
+            --set-json 'graph.cells=["cell-0","cell-1"]' > /tmp/hydradb-multiple-cells.yaml 2>&1; then
+            echo "multiple cells in one runtime release were accepted"
+            exit 1
+          fi
+          helm template hydradb charts/hydradb \
+            --namespace hydradb \
+            --values charts/hydradb/ci/ci-values.yaml \
+            --set-string image.digest=sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa \
+            > /tmp/hydradb-digest-image.yaml
+          grep -q 'image: ghcr.io/hydra-db/hydradb@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' /tmp/hydradb-digest-image.yaml
+          helm template hydradb charts/hydradb \
+            --namespace hydradb \
+            --values charts/hydradb/ci/ci-values.yaml \
+            --set podDisruptionBudget.node.maxUnavailable=0 \
+            --set podDisruptionBudget.indexer.maxUnavailable=0 \
+            --show-only templates/poddisruptionbudgets.yaml > /tmp/hydradb-zero-disruptions.yaml
+          test "$(grep -c '^  maxUnavailable: 0$' /tmp/hydradb-zero-disruptions.yaml)" -eq 2
+          if grep -q '^  minAvailable:' /tmp/hydradb-zero-disruptions.yaml; then
+            echo "explicit zero maxUnavailable fell back to minAvailable"
+            exit 1
+          fi
+          grep -q 'port: 9000' /tmp/hydradb-development.yaml
+          grep -q 'app.kubernetes.io/component: helm-test' /tmp/hydradb-development.yaml
+          helm template hydradb charts/hydradb \
+            --namespace hydradb \
+            --values charts/hydradb/ci/ci-values.yaml \
+            --set tests.enabled=false \
+            --show-only templates/networkpolicy.yaml > /tmp/hydradb-default-policy.yaml
+          if grep -q 'cidr: 0.0.0.0/0' /tmp/hydradb-default-policy.yaml; then
+            echo "network policy unexpectedly permits universal IPv4 egress"
+            exit 1
+          fi
+          grep -q 'cidr: 10.0.0.0/8' /tmp/hydradb-default-policy.yaml
+          if awk '/^  ingress:/{ingress=1; next} /^  egress:/{ingress=0} ingress && /port: 8443/{found=1} END{exit found ? 0 : 1}' /tmp/hydradb-default-policy.yaml; then
+            echo "default client ingress unexpectedly permits HTTPS"
+            exit 1
+          fi
+          helm template hydradb charts/hydradb \
+            --namespace hydradb \
+            --values charts/hydradb/ci/ci-values.yaml \
+            --set-json 'networkPolicy.clientIngressFrom=[{"ipBlock":{"cidr":"10.20.0.0/16"}}]' > /tmp/hydradb-scoped-client.yaml
+          grep -q 'cidr: 10.20.0.0/16' /tmp/hydradb-scoped-client.yaml
+          if helm template hydradb charts/hydradb \
+            --namespace hydradb \
+            --values charts/hydradb/ci/ci-values.yaml \
+            --set-json 'networkPolicy.httpsEgressTo=[]' > /tmp/hydradb-unscoped-https.yaml 2>&1; then
+            echo "unscoped AWS HTTPS egress was accepted"
+            exit 1
+          fi
+          if helm template hydradb charts/hydradb \
+            --namespace hydradb \
+            --values charts/hydradb/ci/ci-values.yaml \
+            --set-json 'networkPolicy.httpsEgressTo=[{}]' > /tmp/hydradb-empty-https-peer.yaml 2>&1; then
+            echo "empty AWS HTTPS egress peer was accepted"
+            exit 1
+          fi
+          if helm template hydradb charts/hydradb \
+            --namespace hydradb \
+            --values charts/hydradb/ci/ci-values.yaml \
+            --set-json 'networkPolicy.httpsEgressTo=[{"ipBlock":{"cidr":"0.0.0.0/0"}}]' > /tmp/hydradb-universal-https.yaml 2>&1; then
+            echo "universal AWS HTTPS egress CIDR was accepted"
+            exit 1
+          fi
+          helm template hydradb charts/hydradb \
+            --namespace hydradb \
+            --values charts/hydradb/ci/custom-endpoint-values.yaml > /tmp/hydradb-custom-endpoint.yaml
+          grep -q 'port: 8080' /tmp/hydradb-custom-endpoint.yaml
+          grep -q 'cidr: 10.0.0.0/8' /tmp/hydradb-custom-endpoint.yaml
+          if helm template hydradb charts/hydradb \
+            --namespace hydradb \
+            --values charts/hydradb/ci/ci-values.yaml \
+            --set-string objectStore.aws.endpoint=https://object-store.example \
+            --set-json 'objectStore.aws.endpointEgressTo=[{"ipBlock":{"cidr":"10.30.0.0/16"}}]' \
+            --set-json 'networkPolicy.httpsEgressTo=[]' > /tmp/hydradb-custom-endpoint-without-sts.yaml 2>&1; then
+            echo "IRSA custom endpoint without scoped STS egress was accepted"
+            exit 1
+          fi
+          if helm template hydradb charts/hydradb \
+            --namespace hydradb \
+            --values charts/hydradb/ci/ci-values.yaml \
+            --set-string objectStore.aws.endpoint=http://object-store.example:8080 > /tmp/hydradb-unscoped-endpoint.yaml 2>&1; then
+            echo "unscoped custom object-store endpoint was accepted"
+            exit 1
+          fi
+          if helm template hydradb charts/hydradb \
+            --namespace hydradb \
+            --values charts/hydradb/ci/custom-endpoint-values.yaml \
+            --set-json 'objectStore.aws.endpointEgressTo=[{}]' > /tmp/hydradb-empty-endpoint-peer.yaml 2>&1; then
+            echo "empty custom object-store endpoint peer was accepted"
+            exit 1
+          fi
+          if helm template hydradb charts/hydradb \
+            --namespace hydradb \
+            --values charts/hydradb/ci/custom-endpoint-values.yaml \
+            --set-json 'objectStore.aws.endpointEgressTo=[{"namespaceSelector":{}}]' > /tmp/hydradb-empty-namespace-selector.yaml 2>&1; then
+            echo "empty custom object-store namespace selector was accepted"
+            exit 1
+          fi
+          if helm template hydradb charts/hydradb \
+            --namespace hydradb \
+            --values charts/hydradb/ci/custom-endpoint-values.yaml \
+            --set-json 'objectStore.aws.endpointEgressTo=[{"podSelector":{}}]' > /tmp/hydradb-empty-pod-selector.yaml 2>&1; then
+            echo "empty custom object-store Pod selector was accepted"
+            exit 1
+          fi
+          if helm template hydradb charts/hydradb \
+            --namespace hydradb \
+            --values charts/hydradb/ci/custom-endpoint-values.yaml \
+            --set-json 'objectStore.aws.endpointEgressTo=[{"ipBlock":{"cidr":"0.0.0.0/0"}}]' > /tmp/hydradb-universal-endpoint-cidr.yaml 2>&1; then
+            echo "universal custom object-store CIDR was accepted"
+            exit 1
+          fi
+          if helm template hydradb charts/hydradb \
+            --namespace hydradb \
+            --values charts/hydradb/ci/custom-endpoint-values.yaml \
+            --set-string objectStore.aws.endpoint=ftp://object-store.example > /tmp/hydradb-invalid-endpoint.yaml 2>&1; then
+            echo "unsupported object-store endpoint scheme was accepted"
+            exit 1
+          fi
+          if helm template hydradb charts/hydradb \
+            --namespace hydradb \
+            --values charts/hydradb/ci/custom-endpoint-values.yaml \
+            --set-string objectStore.aws.endpoint=http://object-store.example:70000 > /tmp/hydradb-invalid-port.yaml 2>&1; then
+            echo "invalid object-store endpoint port was accepted"
+            exit 1
+          fi
+      - name: Validate Kubernetes resources
+        run: |
+          docker run --rm -i ghcr.io/yannh/kubeconform:v0.8.0 -strict -summary < /tmp/hydradb-development.yaml
+          docker run --rm -i ghcr.io/yannh/kubeconform:v0.8.0 -strict -summary -ignore-missing-schemas < /tmp/hydradb-eks.yaml
+
+
+  # Each step names the `just` recipe it mirrors, in the justfile's own order.
+  # `scripts/ci_local.sh` promises `just ci` and this job mean the same thing,
+  # which holds only if the two lists are edited together: a new feature
+  # combination belongs in both, in the same commit.
+  test:
+    name: Linux feature matrix
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+      # Without this the job rebuilds all 398 locked dependencies every run.
+      # `save-if` keeps only main writing the entry, so branch-scoped caches
+      # cannot accumulate and evict what the next main build needs.
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: linux-test
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      # `python3-venv` is for the runtime smoke at the end of the job.
+      - name: Install native dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential clang libclang-dev cmake pkg-config \
+            libcypher-parser-dev libgraphblas-dev python3-venv
+
+      # Both are linked unconditionally, so fail here rather than ten minutes
+      # into a compile.
+      - name: Verify native dependencies             # just native-check
+        run: |
+          pkg-config --exists cypher-parser
+          ldconfig -p | grep -q libgraphblas
+
+      - name: Check formatting                       # just fmt-check
+        run: cargo fmt --all --check
+
+      # Six shipped feature combinations, none subsuming another: a lint only
+      # fires inside the cfg arms its feature set compiles. `--all-targets`
+      # covers examples and tests, which is why no `cargo check --examples`
+      # line follows.
+      - name: Clippy default feature set             # just clippy
+        run: cargo clippy --locked --all-targets -- -D warnings
+      - name: Clippy chaos harness                   # just clippy-chaos
+        run: cargo clippy --locked --all-targets --features chaos-harness -- -D warnings
+      - name: Clippy OpenCypher feature set          # just clippy-opencypher
+        run: cargo clippy --locked --all-targets --features opencypher -- -D warnings
+      - name: Clippy full native feature set         # just clippy-native
+        run: cargo clippy --locked --all-targets --features opencypher,query-transport,query-transport-tls,query-service-discovery,public-client-protocols -- -D warnings
+      - name: Clippy public client protocols         # just clippy-client-protocols
+        run: cargo clippy --locked --all-targets --features public-client-protocols -- -D warnings
+      - name: Clippy production runtime              # just clippy-runtime
+        run: cargo clippy --locked --all-targets --features server-runtime,indexer-runtime -- -D warnings
+
+      # Every other cargo line here is bare and selects the root package only;
+      # the workspace members need an explicit `-p` or they go untested.
+      - name: Lint and test placement crate          # just test-placement
+        run: |
+          cargo clippy --locked --all-targets -p hydradb-placement -- -D warnings
+          cargo test --locked -p hydradb-placement
+
+      # Without `--features otlp` the sampler, exporter wiring and log bridge
+      # are not compiled at all.
+      - name: Lint and test telemetry crate          # just test-telemetry
+        run: |
+          cargo clippy --locked --all-targets -p hydradb-telemetry --features otlp -- -D warnings
+          cargo test --locked -p hydradb-telemetry --features otlp
+
+      # `--all-features`, not an enumerated list: a list silently stops covering
+      # the next feature added to Cargo.toml. Also the only line that reaches
+      # the root `otlp` switch the binaries' cfg arms read.
+      - name: Check every feature at once            # just check-all-features
+        run: cargo check --locked --all-targets --all-features
+
+      # Nothing else builds the shared client stack without a wire protocol on
+      # top, so an item gated on Bolt or HTTP can be called from `client-api`
+      # code and still compile everywhere else.
+      #
+      # `--lib` because `src/client/mod.rs`'s `#[cfg(test)]`
+      # `ClientTestTlsBundle` names `tokio_rustls` ungated, so this
+      # configuration's lib-test target does not build. Widen once that is fixed.
+      - name: Check shared client stack              # just check-client-api
+        run: cargo check --locked --features client-api --lib
+
+      # With `http-api` also on, anything Bolt is missing gets supplied by the
+      # other protocol and the gap stays hidden.
+      - name: Check standalone Bolt server           # just check-bolt-server
+        run: cargo check --locked --all-targets --features bolt-server
+
+      - name: Test default feature set               # just test
+        run: cargo test --locked --lib
+      - name: Test OpenCypher feature set            # just test-opencypher
+        run: cargo test --locked --features opencypher --lib
+
+      # `--all-targets`, not `--lib`: `--lib` builds the client stack as a plain
+      # dependency, so `src/client/service/tests.rs` never sees `cfg(test)` and
+      # its tests silently do not exist.
+      - name: Test full native feature set           # just test-native
+        run: cargo test --locked --all-targets --features opencypher,query-transport,query-transport-tls,query-service-discovery,public-client-protocols
+
+      # Bolt and HTTP without query-service-discovery, as an embedder that
+      # brings its own routing builds them. Catches a `use reqwest::…` leaked
+      # into the shared client path, which the line above cannot.
+      - name: Test public client protocols           # just test-client-protocols
+        run: cargo test --locked --all-targets --features public-client-protocols
+
+      - name: Test chaos harness feature set         # just test-chaos
+        run: cargo test --locked --features chaos-harness --lib
+
+      - name: Test production runtime configuration  # just test-server-runtime
+        run: cargo test --locked --features server-runtime --bin graph-node
+
+      # The binary declares `required-features = ["indexer-runtime"]`, so no
+      # `--lib` or `--all-targets` line elsewhere builds its test target. This
+      # is the only step that executes indexer code.
+      - name: Test indexer runtime                   # just test-indexer
+        run: cargo test --locked --features indexer-runtime --bin graph-indexer
+
+      # The only tests proving an instrument reaches a collector rather than
+      # merely registering: an observable instrument whose callback the SDK
+      # never invokes is silent, and silence looks like a genuine zero.
+      - name: Test graph-node OTLP export            # just test-node-otlp
+        run: cargo test --locked --features server-runtime,otlp --bin graph-node
+
+      # End-to-end proof that the shipped binary serves a real Neo4j driver:
+      # builds graph-node, starts it, polls /readyz, drives it over Bolt and
+      # HTTP, then stops it. A listening port is not proof; a round-tripped
+      # write is.
+      #
+      # The virtualenv is not optional: Ubuntu's system Python is PEP 668
+      # externally-managed and refuses a bare `pip install`. The driver is held
+      # to one major series so a new major release cannot turn this job red on
+      # its own; both 5.x and 6.x speak the Bolt versions the server negotiates.
+      - name: Test production runtime lifecycle
+        run: |
+          python3 -m venv "${RUNNER_TEMP}/venv"
+          "${RUNNER_TEMP}/venv/bin/pip" install --quiet --disable-pip-version-check 'neo4j>=6,<7'
+          PYTHON="${RUNNER_TEMP}/venv/bin/python" bash scripts/runtime_smoke.sh
+
+      # The node log is the first thing worth reading on a failure, and the
+      # script tears the node down on exit.
+      - name: Upload runtime smoke log
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: runtime-smoke-log
+          path: /tmp/sgk-runtime-smoke/node.log
+          if-no-files-found: ignore
+          retention-days: 7
+
+  # macOS is a supported development platform and resolves native dependencies
+  # under Homebrew's prefix rather than the default search paths apt uses, so
+  # breakage here is invisible to the job above.
+  #
+  # Only the two feature sets that do not need libcypher-parser, to keep this a
+  # fast platform check. GraphBLAS is still linked unconditionally, but
+  # `build.rs` resolves the path itself via `brew --prefix suite-sparse`, so
+  # installing the formula is the whole setup.
+  macos-default:
+    name: macOS default features
+    runs-on: macos-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      # A separate cache entry from the `test` job, and it has to be: rust-cache
+      # keys on runner OS and architecture, so a macOS target directory can
+      # never restore onto Linux.
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: macos-default
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+      - name: Install native dependencies
+        run: brew install suite-sparse
+      - name: Clippy default feature set             # just clippy
+        run: cargo clippy --locked --all-targets -- -D warnings
+      - name: Clippy chaos harness                   # just clippy-chaos
+        run: cargo clippy --locked --all-targets --features chaos-harness -- -D warnings
+      - name: Test default feature set               # just test
+        run: cargo test --locked --lib
+      - name: Test chaos harness feature set         # just test-chaos
+        run: cargo test --locked --features chaos-harness --lib

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -14,6 +14,12 @@ on:
     tags:
       - "v*"
 
+# Never cancels a tag push: that would leave a release tag with an incomplete
+# manifest list.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 
@@ -183,6 +189,10 @@ jobs:
       - name: Create manifest list and push
         working-directory: ${{ runner.temp }}/digests
         run: |
+          # Word splitting is the mechanism here, not an accident: both
+          # substitutions expand to several arguments — one `-t` pair per tag,
+          # one reference per digest file.
+          # shellcheck disable=SC2046
           docker buildx imagetools create \
             $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf '${{ env.IMAGE_NAME }}@sha256:%s ' *)

--- a/.github/workflows/opencypher-tck.yml
+++ b/.github/workflows/opencypher-tck.yml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout kernel
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       # The kernel links libgraphblas unconditionally, so this job needs it even
       # though the report itself only exercises the parser.
@@ -28,12 +28,14 @@ jobs:
           sudo apt-get install -y libcypher-parser-dev libgraphblas-dev pkg-config
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        with:
+          toolchain: stable
 
       # This job's `cargo run` compiled the whole opencypher feature set from
       # scratch every time. `save-if` restricts writes to main for the same
       # cache-budget reason as ci.yml.
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           shared-key: opencypher-tck
           save-if: ${{ github.ref == 'refs/heads/main' }}
@@ -52,7 +54,7 @@ jobs:
             > "${RUNNER_TEMP}/opencypher-tck-compatibility.json"
 
       - name: Upload compatibility report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: opencypher-tck-compatibility
           path: ${{ runner.temp }}/opencypher-tck-compatibility.json

--- a/.github/workflows/opencypher-tck.yml
+++ b/.github/workflows/opencypher-tck.yml
@@ -5,9 +5,17 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
 jobs:
   compatibility-report:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Checkout kernel
         uses: actions/checkout@v4

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement by contacting the
+HydraDB maintainers privately. All complaints will be reviewed and investigated
+promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][mozilla].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][faq]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[mozilla]: https://github.com/mozilla/diversity
+[faq]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,154 @@
+# Contributing to HydraDB
+
+Thanks for taking the time. This file covers the process — how to get set up,
+what CI expects, and how a change gets reviewed. It deliberately does not repeat
+the build documentation:
+
+- **[DEVELOPMENT.md](DEVELOPMENT.md)** — the recipe and harness surface.
+- **[AGENTS.md](AGENTS.md)** — repository conventions, the local run-through,
+  and the failure modes that cost the most time to rediscover. Read the
+  "Failure modes worth knowing before you debug" table before debugging a build
+  or a node that will not start; it will probably save you an hour.
+- **[architecture.md](architecture.md)** — storage model, query pipeline, writer
+  coordination, index lifecycle, failure semantics.
+
+## Licensing
+
+HydraDB is licensed under the **AGPL-3.0** ([LICENSE](LICENSE)). Contributions
+are accepted under the same licence — by opening a pull request you agree that
+your work is licensed under AGPL-3.0 and that you have the right to submit it.
+There is no CLA and nothing to sign.
+
+If you are contributing on behalf of an employer, make sure you have their
+permission before you open the pull request rather than after.
+
+## Ways to contribute
+
+For a wrong query result, the `CREATE` that built the data and the `MATCH` that
+misbehaves are what make the report reproducible; without both there is nothing
+to run. Documentation corrections are welcome as ordinary pull requests with no
+issue first.
+
+For anything larger, **open an issue before writing the code.** This is a
+database: changes to query semantics, the wire protocols, or the object-store
+layout have consequences that are cheaper to argue about in an issue than in a
+review of a finished branch.
+
+## Getting set up
+
+Full instructions are in [AGENTS.md](AGENTS.md), which walks the whole sequence
+end to end. The short version:
+
+```bash
+# macOS
+brew install just cmake pkg-config llvm suite-sparse
+brew install cleishm/neo4j/libcypher-parser
+
+# Ubuntu / WSL
+sudo apt-get install -y build-essential clang libclang-dev cmake pkg-config \
+  libcypher-parser-dev libgraphblas-dev python3-venv
+cargo install just --locked
+```
+
+Then confirm the native libraries resolve before compiling anything:
+
+```bash
+just native-check   # silence and exit 0 mean both were found
+just smoke          # local object-store round trip
+```
+
+`libcypher-parser` is not in homebrew-core, hence the `cleishm/neo4j/` tap.
+SuiteSparse GraphBLAS is **not** a Cargo feature — it is linked unconditionally,
+so its headers and library are required even for a plain `cargo build`.
+
+### Build through `just`, not bare `cargo`
+
+This matters enough to state on its own. The justfile exports three variables
+that builds need:
+
+| Variable | Why |
+|---|---|
+| `BINDGEN_EXTRA_CLANG_ARGS` | macOS: bindgen must find `cypher-parser.h` |
+| `LIBRARY_PATH` | macOS: the linker must find Homebrew's libraries |
+| `RUST_MIN_STACK=33554432` | every platform: OpenCypher's async futures overflow the default test-thread stack |
+
+Without the third, a node builds fine, serves `/readyz`, and then aborts on the
+first query — which looks like a query bug and is not. CI sets these in the
+workflow environment, so a bare `cargo` line that passes in CI can still fail on
+your machine. `just --list` shows every recipe.
+
+Anything under `scripts/` invokes `cargo` directly and so does **not** inherit
+these. Export them yourself before running a script.
+
+## What CI checks
+
+`.github/workflows/ci.yml` runs three jobs on every pull request:
+
+| Job | What it covers |
+|---|---|
+| **Helm chart** | Renders the chart under every shipped values file, asserts the security defaults stay closed, and validates the output with kubeconform |
+| **Linux feature matrix** | Formatting, six clippy configurations at `-D warnings`, both workspace crates, the compile-only feature combinations, the full test matrix, and an end-to-end runtime smoke against a real Neo4j driver |
+| **macOS default features** | The default and chaos-harness feature sets, because macOS breaks in ways Linux cannot see |
+
+Two more workflows run alongside it: `container.yml` builds the production image
+for `linux/amd64` and `linux/arm64`, and `opencypher-tck.yml` regenerates the
+openCypher TCK compatibility report.
+
+**Reproduce the Linux job locally with `just ci`**, or equivalently
+`bash scripts/ci_local.sh`, which sets a shared Cargo target directory and
+delegates to it. It covers every lint, check and test step; the one thing it
+does not run is the runtime smoke, which is `bash scripts/runtime_smoke.sh` and
+needs the `neo4j` Python package on the interpreter you point `PYTHON` at.
+
+Every step in that job names the `just` recipe it mirrors, in the same order, so
+the two are meant to be edited together — if you add a feature combination, add
+it to the justfile's `ci` recipe *and* to the workflow in the same commit.
+
+It is a long run — 25m 41s for the clean run recorded in DEVELOPMENT.md. If you
+only ran part of it, say which part in the pull request rather than leaving the
+reviewer to guess.
+
+## Pull requests
+
+Work on a branch in a fork and open the pull request against `main`.
+
+**`main` is rebased and moves fast.** Before concluding that a bug exists,
+confirm you are on the current tip; before concluding a local branch has unique
+work, compare commit *subjects* against `origin/main` rather than SHAs.
+
+Commit subjects are written in the imperative mood ("Bound sparse WAL history",
+not "Bounded" or "Bounds"). An area prefix — `ci:`, `docs:`, `chore:` — is
+common and encouraged where it fits, but is not enforced. Keep the subject under
+about 72 characters and put the reasoning in the body.
+
+What review looks for, beyond correctness:
+
+- **A test that fails without the change.** For a query fix, that usually means
+  a case in the relevant test module, not a manual reproduction in the
+  description.
+- **Comments that explain why, not what.** This is the most distinctive
+  convention in the codebase — read the `[workspace.dependencies]` block in
+  `Cargo.toml` or almost any recipe in the justfile for the house style. A
+  non-obvious feature flag, a pinned version, a `--all-targets` that is
+  load-bearing: all of these get a comment saying what breaks without them.
+  A comment that restates the code is worse than none.
+- **Feature gating that holds up.** The feature matrix is large and combinations
+  do not subsume one another — a lint or a compile error only fires inside the
+  cfg arms its feature set compiles. If you add a gate, check it against the
+  configurations CI builds.
+- **Scope.** Unrelated cleanups in the same branch make a change harder to
+  review and harder to revert. Open a second pull request.
+
+Design documents for larger work go in `docs/plans/`, named
+`YYYY-MM-DD-kebab-case-title.md` and opening with a YAML frontmatter block;
+[AGENTS.md](AGENTS.md#repository-conventions) documents the format. Agree the
+shape in an issue first, then write the plan.
+
+## Reporting bugs and vulnerabilities
+
+Bugs go through the [issue templates](.github/ISSUE_TEMPLATE). The forms ask for
+a version, a platform, the object-store backend and the sparse kernel because
+those four decide which code path ran.
+
+**Security vulnerabilities do not go in issues.** Report them privately to the
+maintainers; [SECURITY.md](SECURITY.md) covers what to include.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,8 @@ version = "0.1.0"
 edition = "2021"
 rust-version = "1.91"
 description = "A SlateDB-backed object-store graph kernel"
-repository = "https://github.com/usecortex/slatedb-graph-kernel"
+repository = "https://github.com/hydra-db/hydradb"
+license = "AGPL-3.0-only"
 readme = "README.md"
 publish = false
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,60 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Report it privately to the HydraDB maintainers. **Do not open a public issue**,
+and do not describe the vulnerability in a pull request, a discussion, or a
+commit message before a fix has shipped.
+
+Include as much of the following as you have:
+
+- The version — a release tag, image tag, or commit SHA.
+- The component: `graph-node`, `graph-indexer`, the Bolt adapter, the HTTP API,
+  the Helm chart, or the object-store layer.
+- The impact, and what an attacker needs to reach it — network access to the
+  Bolt or HTTP port, a valid auth token, object-store credentials, or access to
+  the cluster.
+- A reproduction, ideally minimal.
+
+We will acknowledge within 3 working days and give an initial assessment,
+including our severity view, within 10 working days. If you have not heard back
+in that time, resend — assume the mail did not arrive rather than that it was
+ignored.
+
+We will credit you when the fix ships unless you would rather stay anonymous.
+Please give us a reasonable window to release a fix before disclosing publicly.
+
+## Supported versions
+
+HydraDB is pre-1.0. Fixes land on `main` and in the next release. There are no
+long-term support branches and older tags are not patched in place.
+
+| Version | Supported |
+|---|---|
+| Latest release | Yes |
+| `main` | Yes |
+| Anything older | No — upgrade |
+
+## Scope
+
+In scope: the `graph-node` and `graph-indexer` binaries, the Bolt and HTTP
+adapters, authentication and authorization, the query engine, the object-store
+and writer-coordination layer, the published container images, and the Helm
+chart's security defaults.
+
+Out of scope:
+
+- Vulnerabilities in dependencies, unless HydraDB's use of them is what makes
+  the issue exploitable. [SlateDB](https://github.com/usecortex/slatedb) owns
+  writer fencing, WAL durability, compaction, and object-store coordination;
+  report issues in that layer upstream.
+- Findings that require configuration the documentation warns against.
+  `GRAPH_ALLOW_PLAINTEXT=true` disables the TLS requirement on both public
+  adapters and is documented as local development only, so a report that traffic
+  is readable with it set is expected behaviour.
+- Missing hardening with no demonstrated impact, and scanner output submitted
+  without a working reproduction.
+
+The chart refuses to render unscoped network egress rather than defaulting to
+`0.0.0.0/0`, and CI asserts this on every pull request. A way to make it render
+an open default is in scope.

--- a/charts/hydradb/Chart.yaml
+++ b/charts/hydradb/Chart.yaml
@@ -5,9 +5,9 @@ type: application
 version: 0.1.0
 appVersion: "0.1.0"
 kubeVersion: ">=1.27.0-0"
-home: https://github.com/usecortex/slatedb-graph-kernel
+home: https://github.com/hydra-db/hydradb
 sources:
-  - https://github.com/usecortex/slatedb-graph-kernel
+  - https://github.com/hydra-db/hydradb
 keywords:
   - graph
   - cypher
@@ -15,4 +15,6 @@ keywords:
   - object-storage
   - graphblas
 annotations:
-  artifacthub.io/license: Apache-2.0
+  # Must match LICENSE. This read Apache-2.0 while the repository shipped
+  # AGPL-3.0, which Artifact Hub would have published as the chart's licence.
+  artifacthub.io/license: AGPL-3.0-only

--- a/charts/hydradb/values.yaml
+++ b/charts/hydradb/values.yaml
@@ -2,7 +2,14 @@ nameOverride: ""
 fullnameOverride: ""
 
 image:
-  repository: 525753068359.dkr.ecr.us-east-1.amazonaws.com/staging/hydradb
+  # The public multi-architecture image `container.yml` publishes on every `v*`
+  # tag. It has to be the default: this chart is installable from a public
+  # repository, and a default pointing at a private registry fails
+  # `helm install` for everyone outside the account that owns it.
+  #
+  # `tag` empty means the chart falls back to `.Chart.AppVersion`. Pin `digest`
+  # instead for a deployment that must not move when a tag is repointed.
+  repository: ghcr.io/hydra-db/hydradb
   tag: ""
   digest: ""
   pullPolicy: IfNotPresent

--- a/crates/telemetry/examples/smoke.rs
+++ b/crates/telemetry/examples/smoke.rs
@@ -26,8 +26,7 @@
 use hydradb_telemetry::{ServiceIdentity, TelemetryConfig};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let telemetry =
-        hydradb_telemetry::init(TelemetryConfig::from_env(ServiceIdentity::GraphNode))?;
+    let telemetry = hydradb_telemetry::init(TelemetryConfig::from_env(ServiceIdentity::GraphNode))?;
 
     tracing::info!("smoke: first line, outside any span");
 

--- a/crates/telemetry/tests/head_sampling.rs
+++ b/crates/telemetry/tests/head_sampling.rs
@@ -23,12 +23,12 @@
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
+use hydradb_telemetry::sampling::HydraDBSampler;
+use hydradb_telemetry::semconv;
 use opentelemetry::trace::TracerProvider as _;
 use opentelemetry_sdk::error::OTelSdkResult;
 use opentelemetry_sdk::trace::{SdkTracerProvider, SpanData, SpanProcessor};
 use tracing_subscriber::layer::SubscriberExt;
-use hydradb_telemetry::sampling::HydraDBSampler;
-use hydradb_telemetry::semconv;
 
 /// Collects whatever survives sampling.
 #[derive(Debug, Default, Clone)]
@@ -79,10 +79,8 @@ fn exported_spans(ratio: f64, body: impl FnOnce()) -> Vec<String> {
 #[test]
 fn a_force_recorded_after_the_span_starts_cannot_keep_the_trace() {
     let exported = exported_spans(0.0, || {
-        let span = tracing::info_span!(
-            "query.plan",
-            hydradb.sampling.force = tracing::field::Empty,
-        );
+        let span =
+            tracing::info_span!("query.plan", hydradb.sampling.force = tracing::field::Empty,);
         let entered = span.enter();
         // …the planner runs, and only now is the verdict known…
         span.record("hydradb.sampling.force", true);

--- a/crates/telemetry/tests/log_trace_ids.rs
+++ b/crates/telemetry/tests/log_trace_ids.rs
@@ -24,12 +24,12 @@
 
 use std::sync::{Arc, Mutex};
 
+use hydradb_telemetry::layers::{HydraDBJson, RedactingFields};
+use hydradb_telemetry::sampling::HydraDBSampler;
+use hydradb_telemetry::{ServiceIdentity, TelemetryConfig};
 use opentelemetry::trace::TracerProvider as _;
 use opentelemetry_sdk::trace::SdkTracerProvider;
 use tracing_subscriber::layer::SubscriberExt;
-use hydradb_telemetry::layers::{RedactingFields, HydraDBJson};
-use hydradb_telemetry::sampling::HydraDBSampler;
-use hydradb_telemetry::{ServiceIdentity, TelemetryConfig};
 
 /// Collects the rendered stdout lines.
 #[derive(Clone, Default)]

--- a/crates/telemetry/tests/meter_export.rs
+++ b/crates/telemetry/tests/meter_export.rs
@@ -40,7 +40,6 @@ use opentelemetry_sdk::metrics::data::{AggregatedMetrics, MetricData, ResourceMe
 use opentelemetry_sdk::metrics::exporter::PushMetricExporter;
 use opentelemetry_sdk::metrics::{PeriodicReader, SdkMeterProvider, Temporality};
 
-use opentelemetry::metrics::MeterProvider as _;
 use hydradb_telemetry::meter::{
     CounterSpec, CounterUnit, HistogramSpec, HistogramUnit, ObservableCounter, ObservableHistogram,
     LE_INFINITY,
@@ -50,6 +49,7 @@ use hydradb_telemetry::semconv::{
     L_DB_SYSTEM_NAME,
 };
 use hydradb_telemetry::{ServiceIdentity, TelemetryConfig};
+use opentelemetry::metrics::MeterProvider as _;
 
 /// One exported series, flattened to what the assertions are about.
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]

--- a/src/bin/graph-indexer.rs
+++ b/src/bin/graph-indexer.rs
@@ -13,6 +13,7 @@ use axum::routing::get;
 use axum::Router;
 use bytes::Bytes;
 use futures::StreamExt;
+use hydradb_telemetry::{semconv, ErrorClass, Outcome, ServiceIdentity, TelemetryConfig};
 use slatedb::object_store::path::Path;
 use slatedb::object_store::{ObjectStoreExt, PutMode, UpdateVersion};
 use slatedb_graph_kernel::{
@@ -25,7 +26,6 @@ use tokio::sync::{watch, Mutex as AsyncMutex};
 use tokio::task::JoinHandle;
 use tracing::field::Empty;
 use tracing::Instrument;
-use hydradb_telemetry::{semconv, ErrorClass, Outcome, ServiceIdentity, TelemetryConfig};
 
 type RuntimeResult<T> = Result<T, Box<dyn std::error::Error + Send + Sync>>;
 

--- a/src/bin/graph-node.rs
+++ b/src/bin/graph-node.rs
@@ -20,6 +20,9 @@ use std::time::Duration;
 use chrono::{DateTime, Utc};
 
 use config::RuntimeConfig;
+use hydradb_placement::heartbeat::{delete_heartbeat, put_heartbeat, validate_node_id, Heartbeat};
+use hydradb_placement::liveness::HeartbeatAction;
+use hydradb_telemetry::{ServiceIdentity, TelemetryConfig};
 use readiness::NodeReadiness;
 use slatedb::object_store::{path::Path, ObjectStore};
 use slatedb_graph_kernel::{
@@ -29,9 +32,6 @@ use slatedb_graph_kernel::{
     ObjectStoreNodeDirectory, PlacementConfig, PlacementView, QueryTransportAction,
     QueryTransportScopeGrant, ScopedRoutedGraphCluster, StaticQueryTransportScopeAuthorizer,
 };
-use hydradb_placement::heartbeat::{delete_heartbeat, put_heartbeat, validate_node_id, Heartbeat};
-use hydradb_placement::liveness::HeartbeatAction;
-use hydradb_telemetry::{ServiceIdentity, TelemetryConfig};
 
 type RuntimeResult<T> = Result<T, Box<dyn std::error::Error + Send + Sync>>;
 

--- a/src/bin/graph_node/otel_metrics.rs
+++ b/src/bin/graph_node/otel_metrics.rs
@@ -880,9 +880,7 @@ pub const OTEL_COUNTERS: &[OtelCounter] = &[
     OtelCounter {
         source: CounterSource::ShardCache,
         field: "relationship_property_rows_misses",
-        export: OtelCounterExport::PerCell(
-            "hydradb.shard.cache.relationship_property_rows.misses",
-        ),
+        export: OtelCounterExport::PerCell("hydradb.shard.cache.relationship_property_rows.misses"),
     },
     OtelCounter {
         source: CounterSource::ShardCache,
@@ -2189,8 +2187,9 @@ mod tests {
                 .any(|label| label.key() == "db.namespace"),
             "db.namespace became a metric label"
         );
-        assert!(hydradb_telemetry::semconv::SPAN_ONLY_KEYS
-            .contains(&hydradb_telemetry::semconv::SCOPE));
+        assert!(
+            hydradb_telemetry::semconv::SPAN_ONLY_KEYS.contains(&hydradb_telemetry::semconv::SCOPE)
+        );
     }
 
     /// `le` is the join between the two exports. The seconds rendering is the

--- a/src/bin/graph_node/otel_metrics/otlp_export_tests.rs
+++ b/src/bin/graph_node/otel_metrics/otlp_export_tests.rs
@@ -36,12 +36,12 @@ use std::net::TcpListener;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
+use hydradb_telemetry::semconv::L_CELL_ID;
+use hydradb_telemetry::{ServiceIdentity, TelemetryConfig};
 use slatedb_graph_kernel::{
     GraphCacheMetricsSnapshot, GraphId, GraphOperationalMetricsSnapshot, GraphScope,
     GraphShardRuntimeMetrics, NamespaceId, ScopedGraphShardRuntimeMetrics,
 };
-use hydradb_telemetry::semconv::L_CELL_ID;
-use hydradb_telemetry::{ServiceIdentity, TelemetryConfig};
 
 use super::{CounterSource, NodeCounters};
 

--- a/src/bin/graph_node/readiness.rs
+++ b/src/bin/graph_node/readiness.rs
@@ -34,8 +34,8 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
-use slatedb_graph_kernel::PlacementView;
 use hydradb_placement::liveness::HeartbeatAction;
+use slatedb_graph_kernel::PlacementView;
 
 /// The node's readiness, shared by the admin server and the heartbeat
 /// publisher.
@@ -98,6 +98,7 @@ mod tests {
     use async_trait::async_trait;
     use futures::stream::BoxStream;
     use futures::StreamExt;
+    use hydradb_placement::liveness::LiveView;
     use slatedb::object_store::memory::InMemory;
     use slatedb::object_store::path::Path;
     use slatedb::object_store::{
@@ -105,7 +106,6 @@ mod tests {
         ObjectMeta, ObjectStore, PutMultipartOptions, PutOptions, PutPayload, PutResult,
     };
     use slatedb_graph_kernel::PlacementConfig;
-    use hydradb_placement::liveness::LiveView;
 
     const FLEET: &[&str] = &["graph-node-0", "graph-node-1"];
 

--- a/src/core/state.rs
+++ b/src/core/state.rs
@@ -5,6 +5,7 @@ use std::sync::{
 };
 use std::time::{Duration, Instant};
 
+use hydradb_placement::cell_writer;
 use slatedb::bytes::Bytes;
 use slatedb::config::{ReadOptions, ScanOptions};
 use slatedb::object_store::{memory::InMemory, path::Path, ObjectStore};
@@ -16,7 +17,6 @@ use tokio::sync::{Mutex, OnceCell, OwnedMutexGuard, RwLock as AsyncRwLock, Semap
 #[cfg(feature = "opencypher")]
 use tokio::task::JoinHandle;
 use tracing::Instrument as _;
-use hydradb_placement::cell_writer;
 
 #[cfg(feature = "opencypher")]
 use crate::query::opencypher::ParsedRowQuery;

--- a/src/engine/cluster.rs
+++ b/src/engine/cluster.rs
@@ -2,8 +2,8 @@ use super::*;
 use crate::keys;
 
 use chrono::Utc;
-use tracing::Instrument as _;
 use hydradb_placement::cell_writer::{self, CellWriterRecord};
+use tracing::Instrument as _;
 
 /// Stamp a failure onto the span that raised it.
 ///
@@ -1883,10 +1883,10 @@ async fn close_routed_shards_best_effort(shards: BTreeMap<String, Arc<GraphShard
 
 #[cfg(all(test, feature = "query-transport"))]
 mod scoped_cluster_tests {
+    use hydradb_placement::heartbeat::{self, Heartbeat};
     use slatedb::object_store::memory::InMemory;
     use slatedb::object_store::path::Path;
     use slatedb::object_store::prefix::PrefixStore;
-    use hydradb_placement::heartbeat::{self, Heartbeat};
 
     use super::*;
     use crate::NamespaceId;
@@ -3256,13 +3256,13 @@ mod cell_writer_record_tests {
 
     use async_trait::async_trait;
     use futures::stream::BoxStream;
+    use hydradb_placement::cell_writer::{read_cell_writer, CellWriterRecord, CELL_WRITER_PREFIX};
     use slatedb::object_store::memory::InMemory;
     use slatedb::object_store::path::Path;
     use slatedb::object_store::{
         CopyOptions, GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta,
         PutMultipartOptions, PutOptions, PutPayload, PutResult,
     };
-    use hydradb_placement::cell_writer::{read_cell_writer, CellWriterRecord, CELL_WRITER_PREFIX};
 
     const CELL: &str = "cell-a";
     const FLEET: &[&str] = &["node-a", "node-b", "node-c"];

--- a/src/engine/placement.rs
+++ b/src/engine/placement.rs
@@ -48,10 +48,10 @@ use super::*;
 use std::sync::{Mutex, PoisonError, RwLock};
 
 use chrono::Utc;
-use slatedb::object_store::path::Path;
 use hydradb_placement::hash as rendezvous;
 use hydradb_placement::heartbeat::{self, HeartbeatEntry, PlacementError};
 use hydradb_placement::liveness::{HeartbeatAction, LiveNodeSet, LiveView, NodeView, ViewState};
+use slatedb::object_store::path::Path;
 
 /// The two durations placement runs on: decision 5's 5s / 15s.
 ///
@@ -594,12 +594,12 @@ mod tests {
     use async_trait::async_trait;
     use futures::stream::BoxStream;
     use futures::StreamExt;
+    use hydradb_placement::heartbeat::Heartbeat;
     use slatedb::object_store::memory::InMemory;
     use slatedb::object_store::{
         CopyOptions, GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta,
         PutMultipartOptions, PutOptions, PutPayload, PutResult,
     };
-    use hydradb_placement::heartbeat::Heartbeat;
 
     const SCOPE: &str = "acme/graphs/social";
     const CELL: &str = "cell-a";


### PR DESCRIPTION
## What this changes and why

`.github/workflows/ci.yml` was deleted in `d21f36c` on 11 Aug, so nothing has linted or tested a pull request since. Only the container build and the TCK report run today, while the justfile, `DEVELOPMENT.md`, `AGENTS.md` and `CLAUDE.md` all still cite `ci.yml` as the authority on what gets checked.

CLoses #90 
It could not be restored as it stood, for two reasons:

- It called `scripts/bolt_neo4j_driver_smoke.sh`, which has never existed in this repository. That step would have failed on the first run. Replaced with `scripts/runtime_smoke.sh`, which does exist, plus the virtualenv it needs — Ubuntu's system Python is PEP 668 externally-managed and refuses a bare `pip install`.
- It had drifted six recipes behind `just ci`: `check-all-features`, `check-client-api`, `test-telemetry`, `test-client-protocols`, `test-indexer` and `test-node-otlp`. Two of those are the gaps the justfile calls out — the `graph-indexer` binary's tests and `graph-node`'s OTLP export tests were being compiled by CI and then never run.

The restored workflow is at 21/21 parity with `just ci`, and every step names the recipe it mirrors so the two are edited together. The four `cargo check --examples` steps are gone: the `clippy --all-targets` lines subsume them feature-for-feature, which is why `just ci` omits them too.

## Also in this PR

- **Issue forms, PR template, CONTRIBUTING, SECURITY, code of conduct.** The bug form requires the four fields that decide which code path ran — version, install method, `CLOUD_PROVIDER` and `GRAPH_SPARSE_KERNEL` — and leads with the environmental failures from `AGENTS.md` rather than restating them.
- **`charts/hydradb/values.yaml`** defaulted to a private ECR repository, which answers `HTTP 401` to an unauthenticated pull, so `helm install` failed for anyone outside the account. Now `ghcr.io/hydra-db/hydradb`, which `container.yml` already publishes and the README already documents. The staging pipeline set `image.repository` explicitly with `yq`, so this does not affect deployment.
- **`Chart.yaml`** declared `artifacthub.io/license: Apache-2.0` against an AGPL-3.0 `LICENSE`, and its `home`/`sources` pointed at `usecortex/slatedb-graph-kernel`, which now 404s.
- **`container.yml` / `opencypher-tck.yml`**: `concurrency` that never cancels a tag push, explicit `permissions`, job timeouts, and a `shellcheck disable` on the `imagetools` line where the word splitting is deliberate.
- **`cargo fmt`**, as a separate commit. `cargo fmt --all --check` was already failing before this branch — the `turbolay` → `hydradb` rename lengthened the crate prefix, which moved import ordering and wrap points, and nothing re-ran the formatter with CI gone. It is the first step in the restored workflow, so without this the job is red on arrival. Import ordering and wrapping only.

## How it was verified

Run locally on macOS arm64:

| Check | Result |
|---|---|
| `just ci` | exit 0 — 22 cargo invocations, 1984 tests, 0 failed |
| `scripts/runtime_smoke.sh` | `runtime-smoke-ok` (Bolt via the Neo4j driver, and HTTP) |
| `just smoke` | passed at epoch 10 |
| `helm lint` + 221-line chart invariants | pass |
| `kubeconform -strict` | 14/14 and 15/15 resources valid |
| `actionlint` | clean across all three workflows |
