### PR TITLE
fix: refuse an unreadable namespace header instead of defaulting it

### DIFF
--- a/src/client/http.rs
+++ b/src/client/http.rs
@@ -597,18 +597,41 @@ fn http_graph_scope(
     graph_id: String,
     allow_default_namespace: bool,
 ) -> std::result::Result<GraphScope, HttpApiError> {
-    let namespace = match headers
-        .get(GRAPH_NAMESPACE_HEADER)
-        .and_then(|value| value.to_str().ok())
-    {
-        Some(namespace) => NamespacePath::new(
-            namespace
-                .split('/')
-                .map(|segment| NamespaceId::new(segment.to_string()))
-                .collect::<Result<Vec<_>>>()
-                .map_err(HttpApiError::from_graph)?,
-        )
-        .map_err(HttpApiError::from_graph)?,
+    // The namespace is the tenancy boundary for the whole request: it becomes
+    // the `NamespacePath` half of the scope and so picks the physical store
+    // path. `None` here already means "the client sent no header, and has
+    // opted into the server default", so nothing else may be allowed to
+    // collapse into it. A header that is present but unreadable — bytes
+    // outside visible ASCII, which `HeaderValue::to_str` rejects — is a client
+    // naming a namespace and failing, which is a bad request, not consent to
+    // the default. The same is true of a namespace named more than once:
+    // picking the first of several conflicting values decides tenancy by
+    // accident. Both are separated out before the match so that a request
+    // naming a namespace either reaches that namespace or is refused.
+    let sent = headers.get_all(GRAPH_NAMESPACE_HEADER);
+    let mut sent = sent.iter();
+    let header = sent.next();
+    if sent.next().is_some() {
+        return Err(invalid_namespace(format!(
+            "{GRAPH_NAMESPACE_HEADER} must be sent at most once"
+        )));
+    }
+    let namespace = match header {
+        Some(value) => {
+            let namespace = value.to_str().map_err(|_| {
+                invalid_namespace(format!(
+                    "{GRAPH_NAMESPACE_HEADER} must contain only visible ASCII characters"
+                ))
+            })?;
+            NamespacePath::new(
+                namespace
+                    .split('/')
+                    .map(|segment| NamespaceId::new(segment.to_string()))
+                    .collect::<Result<Vec<_>>>()
+                    .map_err(HttpApiError::from_graph)?,
+            )
+            .map_err(HttpApiError::from_graph)?
+        }
         None if allow_default_namespace => NamespacePath::default(),
         None => {
             return Err(HttpApiError {
@@ -624,6 +647,20 @@ fn http_graph_scope(
         namespace,
         GraphId::new(graph_id).map_err(HttpApiError::from_graph)?,
     ))
+}
+
+/// The companion to the `missing_namespace` arm above: the header was sent but
+/// cannot be turned into a namespace. Kept distinct from the generic
+/// `invalid_request` so a client can tell a rejected tenancy header from a
+/// rejected query.
+fn invalid_namespace(message: String) -> HttpApiError {
+    HttpApiError {
+        status: StatusCode::BAD_REQUEST,
+        code: "invalid_namespace",
+        message,
+        owner: None,
+        authenticate: false,
+    }
 }
 
 fn accepts_ndjson(headers: &HeaderMap) -> bool {

--- a/src/client/http/tests.rs
+++ b/src/client/http/tests.rs
@@ -171,6 +171,107 @@ fn a_routing_refusal_is_a_503_and_not_an_internal_error() {
     );
 }
 
+fn namespace_headers(values: &[&[u8]]) -> HeaderMap {
+    let mut headers = HeaderMap::new();
+    for value in values {
+        headers.append(
+            GRAPH_NAMESPACE_HEADER,
+            HeaderValue::from_bytes(value).expect("valid header bytes"),
+        );
+    }
+    headers
+}
+
+/// An absent namespace header and an unreadable one are different requests: the
+/// first has opted into the server's default, the second is naming a namespace
+/// and failing. Collapsing the second into the first sends the query to
+/// `default` — a namespace the client never asked for — whenever
+/// `allow_default_namespace` is on, which is the one configuration where the
+/// mistake is silent rather than a 400. `0xff` is a legal header byte on the
+/// wire and an illegal one for `HeaderValue::to_str`.
+#[test]
+fn an_unreadable_namespace_header_is_rejected_rather_than_defaulted() {
+    let headers = namespace_headers(&[&[0xff]]);
+
+    let error = http_graph_scope(&headers, "g".to_string(), true)
+        .expect_err("a present but unreadable namespace header must not fall back to the default");
+
+    assert_eq!(error.status, StatusCode::BAD_REQUEST);
+    assert_eq!(error.code, "invalid_namespace");
+    assert!(
+        error.message.contains(GRAPH_NAMESPACE_HEADER),
+        "the client must be told which header it got wrong: {}",
+        error.message
+    );
+}
+
+/// With the default `allow_default_namespace = false` an unreadable header was
+/// already refused, but as `missing_namespace` — the wrong diagnosis, because
+/// the client did send the header. The status was right by accident; this keeps
+/// the two answers distinguishable so a client can tell "you sent nothing" from
+/// "what you sent is unreadable".
+#[test]
+fn an_unreadable_namespace_header_is_not_reported_as_a_missing_one() {
+    let headers = namespace_headers(&[&[0xff]]);
+
+    let error = http_graph_scope(&headers, "g".to_string(), false)
+        .expect_err("an unreadable namespace header is refused however defaulting is configured");
+
+    assert_eq!(error.status, StatusCode::BAD_REQUEST);
+    assert_eq!(error.code, "invalid_namespace");
+}
+
+/// `HeaderMap::get` returns the first value of a repeated header, so a request
+/// naming two namespaces would have silently been served from whichever the
+/// client happened to send first. Tenancy is not a field to guess at: refuse.
+#[test]
+fn a_repeated_namespace_header_is_rejected_rather_than_resolved_to_the_first() {
+    let headers = namespace_headers(&[b"tenant-a", b"tenant-b"]);
+
+    let error = http_graph_scope(&headers, "g".to_string(), true)
+        .expect_err("two conflicting namespace headers must not resolve to the first");
+
+    assert_eq!(error.status, StatusCode::BAD_REQUEST);
+    assert_eq!(error.code, "invalid_namespace");
+}
+
+/// The paths that were already correct, pinned so that refusing the unreadable
+/// and the repeated header does not cost the readable, the absent, or the
+/// readable-but-invalid one their existing answers.
+#[test]
+fn readable_absent_and_invalid_namespace_headers_keep_their_answers() {
+    // `HttpApiError` is deliberately not `Debug` — it is a response, not a
+    // diagnostic — so the success arms unwrap by hand rather than with
+    // `expect`, and report the message the client would have seen.
+    let headers = namespace_headers(&[b"tenant-a/team-b"]);
+    let named = http_graph_scope(&headers, "g".to_string(), true)
+        .unwrap_or_else(|error| panic!("a readable namespace must resolve: {}", error.message));
+    assert_eq!(
+        named.namespace,
+        NamespacePath::new([
+            NamespaceId::new("tenant-a").unwrap(),
+            NamespaceId::new("team-b").unwrap(),
+        ])
+        .unwrap()
+    );
+    assert_eq!(named.graph_id, GraphId::new("g").unwrap());
+
+    let defaulted = http_graph_scope(&HeaderMap::new(), "g".to_string(), true)
+        .unwrap_or_else(|error| panic!("an absent header must still default: {}", error.message));
+    assert_eq!(defaulted.namespace, NamespacePath::default());
+
+    let missing = http_graph_scope(&HeaderMap::new(), "g".to_string(), false)
+        .expect_err("an absent header is still required when defaulting is off");
+    assert_eq!(missing.status, StatusCode::BAD_REQUEST);
+    assert_eq!(missing.code, "missing_namespace");
+
+    // Readable but not a legal component: rejected by `NamespaceId::new`, which
+    // is a path the unreadable case never reached.
+    let invalid = http_graph_scope(&namespace_headers(&[b"tenant a"]), "g".to_string(), true)
+        .expect_err("a readable namespace is still validated");
+    assert_eq!(invalid.status, StatusCode::BAD_REQUEST);
+}
+
 #[tokio::test]
 async fn http_api_enforces_auth_scope_and_returns_typed_json() {
     let backend = Arc::new(HttpTestClient {


### PR DESCRIPTION
Fixes #75.

## The defect

`http_graph_scope` (`src/client/http.rs`) read the tenancy header as

```rust
headers.get(GRAPH_NAMESPACE_HEADER).and_then(|value| value.to_str().ok())
```

`.ok()` turns `to_str`'s `Err` into `None` — the same value the match below
already uses to mean *the header was not sent at all*. The two are different
requests: an absent header is a client opting into the server's default, a
present-but-unreadable one is a client naming a namespace and failing. Under
`allow_default_namespace` the second silently became the first and the query
executed against `default`.

The namespace is the tenancy boundary — it becomes the `NamespacePath` half of
the `GraphScope` and so selects the physical store path via
`GraphScope::scoped_store_path` — so what was lost is the guarantee that a
request naming a namespace either reaches that namespace or is refused.

This was never a validation gap in `NamespaceId`: a *readable* bad namespace was
already rejected by `validate_component` and the error propagated. Only the
unreadable case escaped, and it escaped before validation ever ran.

## The change

Split "absent" from "present but unreadable" before the match. A header that is
present but not visible ASCII now returns **400 `invalid_namespace`**, kept
distinct from the generic `invalid_request` so a client can tell a rejected
tenancy header from a rejected query — matching the `missing_namespace` code
already in this function.

Two smaller things fixed alongside, both raised in the issue:

- **A repeated `x-graph-namespace` is now refused.** `HeaderMap::get` returns
  only the first value, so a request naming two namespaces was served from
  whichever arrived first — tenancy decided by accident.
- **The `allow_default_namespace = false` path reported the wrong diagnosis.**
  An unreadable header was already refused there, but as `missing_namespace`:
  right status, wrong reason, since the client *did* send the header.

## Behaviour change worth flagging

`invalid_namespace` is a new value for the JSON `error.code` field, and a
request that sends `x-graph-namespace` twice with *identical* values now gets a
400 where it previously succeeded. The issue asked for duplicates to be rejected
outright rather than compared, so that is what this does — happy to soften it to
"reject only when the values differ" if you would rather not break that case.

## Tests

Four tests in `src/client/http/tests.rs`, against the free function directly —
no server needed:

- `an_unreadable_namespace_header_is_rejected_rather_than_defaulted` — the
  headline case, with `allow_default_namespace` on. Fails on `main`, which
  returns `Ok` on namespace `default`. `0xff` is a legal header byte on the wire
  and an illegal one for `to_str`.
- `an_unreadable_namespace_header_is_not_reported_as_a_missing_one` — the same
  header with defaulting off, pinning `invalid_namespace` over the previous
  `missing_namespace`.
- `a_repeated_namespace_header_is_rejected_rather_than_resolved_to_the_first`
- `readable_absent_and_invalid_namespace_headers_keep_their_answers` — a
  regression guard holding the readable, absent, and readable-but-invalid paths
  to the answers they already gave.

## Verification status — please read

**I was not able to compile or run these tests.** My machine has no Rust
toolchain, and installing one would not be enough: `opencypher` needs
libcypher-parser and the always-linked `graphblas` needs libgraphblas, neither
of which builds on Windows. Per #90 there is also currently no CI on pull
requests, so this may reach you unbuilt.

What I did instead of running it: verified every API against the sources and the
versions in `Cargo.lock` (http 1.4.2, axum 0.8.9) rather than from memory —
including that `HttpApiError` has no `Debug` derive, so the success arms use
`unwrap_or_else` where `expect` would not compile; that `HeaderValue::from_bytes`
accepts `0xff` while `to_str` rejects it; and that `validate_component` allows
`-` but not a space, which the regression test relies on. Kept every line under
rustfmt's 100-column default since CI runs `fmt --check` and clippy with
`-D warnings`.

If it does not build, say the word and I will fix it promptly — but I did not
want to imply a green run I never saw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1mUHWQBVeoBSK7yuUFmRG
