### PR TITLE
fix: give back a writer lease whose renewal lost its scope

### DIFF
--- a/src/engine/writer_lease.rs
+++ b/src/engine/writer_lease.rs
@@ -139,6 +139,14 @@ impl ObjectStoreWriterLeaseDirectory {
         *self.scope_users().entry(key).or_default() += 1;
     }
 
+    fn scope_is_registered(&self, scope: &GraphScope, node_id: &str) -> bool {
+        let key = ScopeLeaseUserKey {
+            scope: scope.clone(),
+            node_id: node_id.to_string(),
+        };
+        self.scope_users().contains_key(&key)
+    }
+
     pub async fn current_owner(
         &self,
         scope: &GraphScope,
@@ -203,6 +211,18 @@ impl ObjectStoreWriterLeaseDirectory {
         let cache_key = path.to_string();
         let renew_margin = self.lease_duration / 3;
         if force_renew {
+            // A forced renewal writes on the authority of a live scope
+            // registration, so that registration is a precondition of the write
+            // rather than something to discover once it has landed. Checking it
+            // here means the ordinary eviction — the registration dropped
+            // before this renewal starts — issues no write at all.
+            if !self.scope_is_registered(scope, node_id) {
+                self.local().remove(&cache_key);
+                return Err(GraphError::NotCellWriter {
+                    cell_id: cell_id.to_string(),
+                    owner: None,
+                });
+            }
             let local_is_valid = self.local().get(&cache_key).is_some_and(|lease| {
                 lease.node_id == node_id && Instant::now() < lease.valid_until
             });
@@ -306,6 +326,32 @@ impl ObjectStoreWriterLeaseDirectory {
                         write_started,
                     )
                     .await;
+                    // The precondition above narrows this window but cannot
+                    // close it: the registration can still be dropped while the
+                    // write is on the wire, and a write that lands after the
+                    // release racing it reinstates a lease that nothing will
+                    // renew and nothing will release. It would hold the cell
+                    // shut for a full `lease_duration`. This is the only branch
+                    // of this function that can fail after a durable write has
+                    // succeeded, so it is the only one that has to give that
+                    // write back.
+                    //
+                    // Abandonment is the exception. `abandon_scope` drops the
+                    // registration precisely so the durable lease outlives it
+                    // and this process can resume the cell, so a record parked
+                    // there is left to expire on its own terms.
+                    if force_renew && !self.scope_is_registered(scope, node_id) {
+                        let parked = self.abandoned().contains_key(&cache_key);
+                        self.local().remove(&cache_key);
+                        if !parked {
+                            self.release_stored(scope, cell_id, node_id, generation)
+                                .await?;
+                        }
+                        return Err(GraphError::NotCellWriter {
+                            cell_id: cell_id.to_string(),
+                            owner: None,
+                        });
+                    }
                     let lease = LocalWriterLease {
                         scope: scope.clone(),
                         cell_id: cell_id.to_string(),
@@ -317,24 +363,8 @@ impl ObjectStoreWriterLeaseDirectory {
                         // object's server-timestamped expiry.
                         valid_until,
                     };
-                    if force_renew {
-                        let users = self.scope_users();
-                        let key = ScopeLeaseUserKey {
-                            scope: scope.clone(),
-                            node_id: node_id.to_string(),
-                        };
-                        if !users.contains_key(&key) {
-                            return Err(GraphError::NotCellWriter {
-                                cell_id: cell_id.to_string(),
-                                owner: Some(node_id.to_string()),
-                            });
-                        }
-                        self.abandoned().remove(&cache_key);
-                        self.local().insert(cache_key, lease);
-                    } else {
-                        self.abandoned().remove(&cache_key);
-                        self.local().insert(cache_key, lease);
-                    }
+                    self.abandoned().remove(&cache_key);
+                    self.local().insert(cache_key, lease);
                     return Ok(generation);
                 }
                 Err(
@@ -857,9 +887,136 @@ fn parse_lease_u64(path: &Path, field: &str, value: Option<&str>) -> Result<u64>
 
 #[cfg(test)]
 mod tests {
+    use std::fmt;
+
+    use async_trait::async_trait;
+    use futures::stream::BoxStream;
     use slatedb::object_store::memory::InMemory;
+    use slatedb::object_store::{
+        CopyOptions, GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta,
+        PutMultipartOptions, PutResult,
+    };
 
     use super::*;
+
+    type LeaseWriteHook = Box<dyn FnOnce() + Send>;
+
+    /// An `InMemory` store that runs one callback from inside the next
+    /// writer-lease write, before that write is applied.
+    ///
+    /// The defect under test is a lost race, and a race reproduced by sleeping
+    /// is a test that fails on a loaded machine. Firing the callback from
+    /// within the write makes "the scope registration was dropped while this
+    /// compare-and-swap was on the wire" an ordering the test states outright.
+    struct ScopeDroppingStore {
+        inner: InMemory,
+        during_lease_write: StdMutex<Option<LeaseWriteHook>>,
+    }
+
+    impl ScopeDroppingStore {
+        fn new() -> Arc<Self> {
+            Arc::new(Self {
+                inner: InMemory::new(),
+                during_lease_write: StdMutex::new(None),
+            })
+        }
+
+        fn arm(&self, hook: impl FnOnce() + Send + 'static) {
+            let hook: LeaseWriteHook = Box::new(hook);
+            let mut slot = self
+                .during_lease_write
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            *slot = Some(hook);
+        }
+
+        /// Fires for lease objects only. The clock probe writes under
+        /// `_coordination/…` and must not consume the callback.
+        fn fire_if_lease_write(&self, location: &Path) {
+            if !location.parts().any(|part| part.as_ref() == "_writer_leases") {
+                return;
+            }
+            let hook = self
+                .during_lease_write
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .take();
+            if let Some(hook) = hook {
+                hook();
+            }
+        }
+    }
+
+    impl fmt::Display for ScopeDroppingStore {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "ScopeDroppingStore({})", self.inner)
+        }
+    }
+
+    impl fmt::Debug for ScopeDroppingStore {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "ScopeDroppingStore({:?})", self.inner)
+        }
+    }
+
+    #[async_trait]
+    impl ObjectStore for ScopeDroppingStore {
+        async fn put_opts(
+            &self,
+            location: &Path,
+            payload: PutPayload,
+            opts: PutOptions,
+        ) -> slatedb::object_store::Result<PutResult> {
+            self.fire_if_lease_write(location);
+            self.inner.put_opts(location, payload, opts).await
+        }
+
+        async fn put_multipart_opts(
+            &self,
+            location: &Path,
+            opts: PutMultipartOptions,
+        ) -> slatedb::object_store::Result<Box<dyn MultipartUpload>> {
+            self.inner.put_multipart_opts(location, opts).await
+        }
+
+        async fn get_opts(
+            &self,
+            location: &Path,
+            options: GetOptions,
+        ) -> slatedb::object_store::Result<GetResult> {
+            self.inner.get_opts(location, options).await
+        }
+
+        fn delete_stream(
+            &self,
+            locations: BoxStream<'static, slatedb::object_store::Result<Path>>,
+        ) -> BoxStream<'static, slatedb::object_store::Result<Path>> {
+            self.inner.delete_stream(locations)
+        }
+
+        fn list(
+            &self,
+            prefix: Option<&Path>,
+        ) -> BoxStream<'static, slatedb::object_store::Result<ObjectMeta>> {
+            self.inner.list(prefix)
+        }
+
+        async fn list_with_delimiter(
+            &self,
+            prefix: Option<&Path>,
+        ) -> slatedb::object_store::Result<ListResult> {
+            self.inner.list_with_delimiter(prefix).await
+        }
+
+        async fn copy_opts(
+            &self,
+            from: &Path,
+            to: &Path,
+            options: CopyOptions,
+        ) -> slatedb::object_store::Result<()> {
+            self.inner.copy_opts(from, to, options).await
+        }
+    }
 
     fn directory(
         store: Arc<dyn ObjectStore>,
@@ -1059,6 +1216,112 @@ mod tests {
                 .unwrap()
                 .node_id,
             "node-0"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_renewal_that_loses_its_scope_mid_write_gives_the_lease_back() {
+        let store = ScopeDroppingStore::new();
+        let leases = directory(Arc::clone(&store), "holder-a", Duration::from_secs(30));
+        let scope = GraphScope::default();
+        leases.register_scope(&scope, "node-a");
+        leases
+            .acquire_or_renew(&scope, "cell-0", "node-a")
+            .await
+            .unwrap();
+
+        // `release_scope` drops the registration and drains the local record.
+        // Running both from inside the renewal's write puts them exactly where
+        // the outage needs them: after the renewal has proved its authority,
+        // and before the write that authority bought has landed.
+        let scope_users = Arc::clone(&leases.scope_users);
+        let local = Arc::clone(&leases.local);
+        let key = ScopeLeaseUserKey {
+            scope: scope.clone(),
+            node_id: "node-a".to_string(),
+        };
+        store.arm(move || {
+            scope_users
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .remove(&key);
+            local
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .clear();
+        });
+
+        let failures = leases.renew_local("node-a").await;
+        assert_eq!(failures.len(), 1, "the renewal reports the lost scope");
+        assert!(failures[0].ownership_lost);
+
+        // The write that landed carries a fresh window. Left standing, nothing
+        // renews it and nothing releases it, so the cell is shut for a full
+        // lease duration.
+        assert!(leases
+            .current_owner(&scope, "cell-0")
+            .await
+            .unwrap()
+            .is_none());
+        let peer = directory(store, "holder-b", Duration::from_secs(30));
+        peer.register_scope(&scope, "node-b");
+        peer.acquire_or_renew(&scope, "cell-0", "node-b")
+            .await
+            .expect("a cell whose lease was given back is acquirable");
+    }
+
+    #[tokio::test]
+    async fn a_renewal_without_a_registration_leaves_an_abandoned_lease_alone() {
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let leases = directory(store, "holder-a", Duration::from_secs(30));
+        let scope = GraphScope::default();
+        leases.register_scope(&scope, "node-a");
+        let generation = leases
+            .acquire_or_renew(&scope, "cell-0", "node-a")
+            .await
+            .unwrap();
+
+        // Abandonment drops the registration on purpose, so that the durable
+        // lease outlives the eviction and this process can resume it. Put the
+        // parked record back in `local` to stand in for a renewal that read it
+        // before the eviction ran.
+        let path = leases.lease_path(&scope, "cell-0");
+        let cache_key = path.to_string();
+        leases.abandon_scope(&scope, "node-a");
+        let parked = leases
+            .abandoned()
+            .get(&cache_key)
+            .cloned()
+            .expect("abandonment parks the local record");
+        leases.local().insert(cache_key, parked);
+        let before = leases
+            .read_stored(&path)
+            .await
+            .unwrap()
+            .expect("the lease object outlives the abandonment");
+
+        let failures = leases.renew_local("node-a").await;
+        assert_eq!(failures.len(), 1, "the renewal reports the lost scope");
+
+        let after = leases
+            .read_stored(&path)
+            .await
+            .unwrap()
+            .expect("an abandoned lease is not released");
+        assert_eq!(
+            (after.generation, after.heartbeat, after.released),
+            (before.generation, before.heartbeat, false),
+            "a renewal with no registration to write on writes nothing at all"
+        );
+
+        leases.register_scope(&scope, "node-a");
+        assert_eq!(
+            leases
+                .acquire_or_renew(&scope, "cell-0", "node-a")
+                .await
+                .unwrap(),
+            generation,
+            "the parked lease resumes at its own generation"
         );
     }
 }


### PR DESCRIPTION
Fixes #76.

## The defect

`acquire_or_renew_inner` (`src/engine/writer_lease.rs`) performed its durable
write first and validated its authority to have done so afterwards. On a forced
renewal it read `scope_users` only *after* the compare-and-swap had landed:

```rust
match write_result {
    Ok(_) => {
        ...
        if force_renew {
            let users = self.scope_users();
            if !users.contains_key(&key) {
                return Err(GraphError::NotCellWriter { .. });   // <-- write left standing
            }
```

The payload it just wrote carries a bumped `heartbeat` and a fresh
`lease_duration`, so the durable record now claims this node holds the cell for
another full window — while the in-memory record is deliberately *not*
installed, i.e. the node has just declared that it does not.

Nothing reconciles the two. `renew_local` reads the error as lost ownership and
removes the local entry, which is the correct local response and also removes
the last thing that would have driven a release. `release_scope` has already
drained `local` by then, so its `release_stored` loop has nothing left to
release for that cell. No node can take the cell until the durable lease expires
on its own, because `acquire_or_renew_inner` refuses whenever
`remaining_ms > 0 && !owned_by_this_process`. With `GRAPH_WRITER_LEASE_MS` at
its 300 s ceiling that is a five-minute write outage triggered by a routine
scope eviction.

Both writes are object-store round trips racing each other, so this is not a
narrow window. It is also worse than "the release is lost": on a store with real
conditional update the renewal's CAS is rejected by the release that beat it,
the retry loop re-reads, sees a *released* record, and writes a fresh **active**
lease at the next generation — it resurrects the lease it was racing, then bails.

## The change

The registration is a precondition of the write, not a postcondition, so it is
checked **before** the compare-and-swap. That alone only narrows the window —
the scope can still be dropped while the write is on the wire — so the check is
repeated after the write, and the branch that abandons the lease is now also the
branch that gives it back, via `release_stored` for the generation it just
wrote.

The invariant is stated where it is enforced: *this function must not return
`Err` after a successful durable write without first undoing that write.* It was
the only error path in the function that could.

**Abandonment is carved out.** `abandon_scope` drops the registration precisely
so the durable lease outlives the eviction and this process can resume the cell
(`abandoned_scope_keeps_durable_owner_and_can_resume` pins that), so a record
parked in `abandoned` is left to expire on its own terms rather than released.
Rolling it back unconditionally would trade this bug for the stale-route window
that `abandon_scope` exists to avoid.

Two smaller things fall out:

- The two arms of the old post-write `if force_renew` collapse into one. They
  were already identical once the check moved out of them.
- The error reports `owner: None` instead of naming this node as the owner of a
  cell it has just disclaimed. That matches the sibling check above it and the
  rule written down at `src/core/error.rs:136` — no hint when there is nothing
  truthful to point at.

## Behaviour change worth flagging

A forced renewal that lost its registration now issues **one extra object-store
round trip** on the racing path (the release that gives the lease back), and
**one fewer** on the ordinary path (the precondition means no write at all).
`NotCellWriter` from this path no longer carries an owner hint; nothing matches
on it — the two call sites that match `owner: Some(..)` (`src/tests.rs:4230`,
`src/tests.rs:4378`) are the remote-owner refusal, which is untouched.

## Tests

Two tests in the existing `mod tests`, plus `ScopeDroppingStore` — an `InMemory`
wrapper that runs one callback from inside the next writer-lease write. The
defect is a lost race, and a race reproduced by sleeping is a test that fails on
a loaded machine; firing the callback from within the write makes the ordering
something the test states rather than hopes for. It is modelled on the wrappers
already in this repo (`RecordStore` in `src/engine/cluster.rs`, `FaultStore` in
`crates/placement`) and implements the same seven methods they do.

- `a_renewal_that_loses_its_scope_mid_write_gives_the_lease_back` — the headline
  case. The callback runs `release_scope`'s two in-memory steps while the
  renewal's CAS is in flight. On `main` the cell is still owned by `node-a`
  afterwards and a peer is refused; the assertions are that `current_owner` is
  `None` and that the peer acquires.
- `a_renewal_without_a_registration_leaves_an_abandoned_lease_alone` — the
  precondition and the carve-out together: no durable write is issued at all
  (asserted on `generation`/`heartbeat`/`released` being identical either side
  of the renewal), the abandoned lease is not released, and it still resumes at
  its own generation. On `main` the heartbeat advances.

## Verification status — please read

**I was not able to compile or run these tests.** My machine has no Rust
toolchain, and installing one would not be enough: `opencypher` needs
libcypher-parser and the always-linked `graphblas` needs libgraphblas, neither
of which builds on Windows. Per #90 there is also currently no CI on pull
requests, so this may reach you unbuilt.

What I did instead of running it: checked every API against the sources rather
than from memory — that `object_store` is `0.14.1` in `Cargo.lock`, and that
both existing wrappers in this repo implement exactly `put_opts`,
`put_multipart_opts`, `get_opts`, `delete_stream`, `list`, `list_with_delimiter`
and `copy_opts`, so that set is complete and `delete` is not required; that
`StoredWriterLease` and `read_stored` are private but reachable from the in-file
`mod tests`; and that no `StdMutexGuard` is held across an `.await` on the new
path, which would have made the future non-`Send` at `buffer_unordered` and
tripped `clippy::await_holding_lock` under `-D warnings`. Kept every line under
rustfmt's 100-column default.

If it does not build, say the word and I will fix it promptly — but I did not
want to imply a green run I never saw.
