### PR TITLE
ci: keep root prose out of the Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -20,3 +20,17 @@ grafana
 interactive
 charts
 scripts
+
+# The same prose at the top of the tree: README.md, DEVELOPMENT.md,
+# architecture.md, cypher-compat.md and the agent guides. The directories above
+# leave these behind, so a README edit still invalidates `COPY . .` and rebuilds
+# graph-node and graph-indexer from source — the one file most likely to be
+# touched by a change that compiles to nothing.
+#
+# Root-level only, and deliberately so: `*` does not cross a path separator, so
+# this matches the six files above the source tree and nothing else. Every other
+# tracked `.md` already sits under one of the directories above; prose added
+# beside source later would need its own entry rather than silently vanishing
+# from the context. `readme = "README.md"` in Cargo.toml is packaging metadata
+# on a `publish = false` package — no build command reads the file.
+*.md


### PR DESCRIPTION
Fixes #68.

## The gap

The prose block in `.dockerignore` already carries the reasoning:

> Prose and operator assets. None of it is compiled — nothing in the tree uses
> `include_str!`/`include_bytes!` — but everything here lands in the build
> context, so without these entries editing a book or a Grafana dashboard
> changes the COPY layer and forces the application build to run again.

It just stops at the directory boundary. `README.md`, `DEVELOPMENT.md`,
`architecture.md`, `cypher-compat.md`, `AGENTS.md` and `CLAUDE.md` sit above the
source tree, so none of the existing entries reach them.

cargo-chef keeps the ~400 dependency crates cached across a source change, but
the application build sits behind `COPY . .` in both the `builder` and
`benchmark-builder` stages. Editing any of those files changes that layer, so
`cargo build --locked --release` recompiles `graph-node`, `graph-indexer` and
`s3_bolt_benchmark_server` from source for a change that compiles to nothing —
and README.md is the likeliest file in the whole tree to be edited that way.

## The change

One pattern, `*.md`, added to the block that already states the intent.

It is root-level only, which is what is wanted here: an unanchored `*` does not
cross a path separator, so it matches exactly the six files above the source
tree. That is the complete set — every other tracked `.md` already sits under
one of the ignored directories:

```
$ git ls-files '*.md' | grep -vE '^(books|docs|notes|grafana|interactive|charts|scripts)/'
AGENTS.md
CLAUDE.md
DEVELOPMENT.md
README.md
architecture.md
cypher-compat.md
```

I used `*.md` rather than `**/*.md` on purpose. Prose added *beside source* later
should have to earn its own entry rather than disappear from the build context
silently.

## Checks that nothing in the build reads them

- No `include_str!` or `include_bytes!` anywhere in the tree, which is what the
  existing comment asserts and still holds.
- `build.rs` names `docs/plans/optimisation-phases.md`, but only inside a doc
  comment describing the `GRAPHBLAS_LIB_DIR` override — it opens no file. (`docs`
  is already ignored regardless.)
- `Cargo.toml` sets `readme = "README.md"`. That key is packaging metadata,
  consumed by `cargo package`/`cargo publish` and docs.rs; the root package is
  `publish = false` and the Dockerfile only runs `cargo chef prepare`,
  `cargo chef cook` and `cargo build`, none of which read it.
- `rust-toolchain.toml` is deliberately untouched — rustup honours it inside the
  build, so it belongs in the context.

## Noticed but not changed

`justfile` and `mise.toml` are developer tooling that no image stage uses, so
they bust the same layer for the same non-reason. I left them alone: the
existing block is scoped to "prose and operator assets", and whether tooling
belongs in it is your call rather than something to fold into this issue. Happy
to add them if you want them.

## Verification status

I could not run a build to measure the cache hit: the Docker daemon is not
running on this machine, and a full image build of this tree is not something I
can complete here. What the change rests on is the pattern semantics and the
four checks above, each of which I confirmed against the tree rather than from
memory. The change is one line of pattern plus comment and removes files from a
build context, so the failure mode if I am wrong about a consumer would be a
build error rather than a silent behaviour change.
