### PR TITLE
fix: report a store that cannot conditionally put at startup

### DIFF
--- a/src/bin/graph-node.rs
+++ b/src/bin/graph-node.rs
@@ -23,11 +23,12 @@ use config::RuntimeConfig;
 use readiness::NodeReadiness;
 use slatedb::object_store::{path::Path, ObjectStore};
 use slatedb_graph_kernel::{
-    object_store_from_env, BoltServerConfig, ClientBoltServer, ClientHttpServer,
-    ClientQueryService, ClientQueryServiceConfig, ClientQueryTarget,
-    HierarchicalClientDatabaseResolver, HttpQueryServerConfig, ObjectStoreBoltRoutingTableProvider,
-    ObjectStoreNodeDirectory, PlacementConfig, PlacementView, QueryTransportAction,
-    QueryTransportScopeGrant, ScopedRoutedGraphCluster, StaticQueryTransportScopeAuthorizer,
+    object_store_from_env, probe_conditional_put, BoltServerConfig, ClientBoltServer,
+    ClientHttpServer, ClientQueryService, ClientQueryServiceConfig, ClientQueryTarget,
+    ConditionalPutSupport, HierarchicalClientDatabaseResolver, HttpQueryServerConfig,
+    ObjectStoreBoltRoutingTableProvider, ObjectStoreNodeDirectory, PlacementConfig, PlacementView,
+    QueryTransportAction, QueryTransportScopeGrant, ScopedRoutedGraphCluster,
+    StaticQueryTransportScopeAuthorizer,
 };
 use hydradb_placement::heartbeat::{delete_heartbeat, put_heartbeat, validate_node_id, Heartbeat};
 use hydradb_placement::liveness::HeartbeatAction;
@@ -133,6 +134,27 @@ async fn run_node(
     validate_node_id(&config.node_id)?;
     std::fs::create_dir_all(&config.data_cache_dir)?;
     let object_store = object_store_from_env(None)?;
+    // Asked once, here, because the answer decides whether this store can ever
+    // reclaim space. SlateDB's manifest GC is a compare-and-swap, so on a
+    // backend without conditional put every GC cycle fails and the store grows
+    // without bound — while reads, writes and /readyz all stay green. The first
+    // symptom is a per-cycle ERROR that arrives minutes into a write load, long
+    // after anyone is still reading the log, which is no warning at all.
+    match probe_conditional_put(object_store.as_ref(), &config.data_path).await {
+        Ok(ConditionalPutSupport::Supported) => {}
+        Ok(ConditionalPutSupport::Unsupported { store }) => tracing::warn!(
+            object_store = %store,
+            "object store does not implement conditional put, so SlateDB manifest \
+             garbage collection will fail on every cycle and reclaim nothing: the \
+             store grows without bound under sustained writes. Usable for smoke \
+             tests and local development, not for durable or long-running use — \
+             point CLOUD_PROVIDER at an S3-compatible backend for that"
+        ),
+        // Diagnostic only. A store that cannot answer the probe has a larger
+        // problem, and the first real write will report it with better context
+        // than a startup check can.
+        Err(error) => tracing::debug!(%error, "conditional-put probe did not complete"),
+    }
     let open_options = config.graph_open_options();
     let memory_config = config.graph_memory_config();
     let directory = ObjectStoreNodeDirectory::new(

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -221,11 +221,13 @@ impl MatrixRows {
 mod artifact_build;
 mod artifact_gc;
 mod cluster;
+mod conditional_put;
 mod index_store;
 mod placement;
 mod scope_directory;
 mod writer_lease;
 
+pub use conditional_put::{probe_conditional_put, ConditionalPutSupport};
 pub use placement::{CellOwnership, PlacementConfig, PlacementRefreshHandle, PlacementView};
 
 pub use scope_directory::ObjectStoreGraphScopeDirectory;

--- a/src/engine/conditional_put.rs
+++ b/src/engine/conditional_put.rs
@@ -1,0 +1,84 @@
+use slatedb::object_store::path::Path;
+use slatedb::object_store::{
+    Error as ObjectStoreError, ObjectStore, ObjectStoreExt, PutMode, PutOptions, PutPayload,
+    UpdateVersion,
+};
+
+use crate::Result;
+
+const PROBE_PAYLOAD: &str = "hydradb-conditional-put-probe\n";
+
+/// Whether an object store implements the conditional put that SlateDB's
+/// manifest compare-and-swap is built on.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ConditionalPutSupport {
+    /// The store evaluated `put_opts` with `PutMode::Update`.
+    Supported,
+    /// The store answered `NotImplemented`. `store` is its own description of
+    /// itself — `LocalFileSystem(file:///data/store)` and the like — taken from
+    /// the store rather than from the configuration that selected it, so the
+    /// report names what is actually mounted.
+    Unsupported { store: String },
+}
+
+impl ConditionalPutSupport {
+    pub fn is_supported(&self) -> bool {
+        matches!(self, Self::Supported)
+    }
+}
+
+/// Ask an object store whether it can perform a conditional put.
+///
+/// SlateDB updates its manifest by compare-and-swap, so a store that answers
+/// `NotImplemented` to `PutMode::Update` cannot collect its own garbage: every
+/// GC cycle fails and reclaims nothing, and the store grows without bound while
+/// reads, writes and the readiness endpoint all stay healthy. `LocalFileSystem`
+/// — the backend behind `CLOUD_PROVIDER=local` — is such a store, and its first
+/// failure arrives minutes into a write load, long after anyone is still
+/// watching the log.
+///
+/// The question is put to the store rather than inferred from a backend name,
+/// so a store that gains the capability stops being reported the day it does,
+/// and one that lacks it is caught whatever it is called.
+///
+/// The probe object is written under `_coordination/v1/`, beside the writer
+/// lease's clock probe, and deleted again. Cleanup is best-effort: the probe
+/// overwrites unconditionally, so a leftover cannot change the next answer and
+/// a failed delete is not worth failing a startup over.
+pub async fn probe_conditional_put(
+    object_store: &dyn ObjectStore,
+    base_path: &str,
+) -> Result<ConditionalPutSupport> {
+    let path = Path::from(format!(
+        "{}/_coordination/v1/conditional-put-probe",
+        base_path.trim_end_matches('/')
+    ));
+    let created = object_store
+        .put(&path, PutPayload::from(PROBE_PAYLOAD.to_string()))
+        .await?;
+    let version = UpdateVersion {
+        e_tag: created.e_tag,
+        version: created.version,
+    };
+    let conditional = object_store
+        .put_opts(
+            &path,
+            PutPayload::from(PROBE_PAYLOAD.to_string()),
+            PutOptions::from(PutMode::Update(version)),
+        )
+        .await;
+    let _ = object_store.delete(&path).await;
+    match conditional {
+        Ok(_) => Ok(ConditionalPutSupport::Supported),
+        Err(ObjectStoreError::NotImplemented { .. }) => Ok(ConditionalPutSupport::Unsupported {
+            store: object_store.to_string(),
+        }),
+        // The store weighed the precondition and refused it, which is the
+        // capability working — something else simply wrote first. Only
+        // `NotImplemented` means it cannot answer the question at all.
+        Err(ObjectStoreError::Precondition { .. } | ObjectStoreError::AlreadyExists { .. }) => {
+            Ok(ConditionalPutSupport::Supported)
+        }
+        Err(error) => Err(error.into()),
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,12 +96,12 @@ pub(crate) use core::write_batch::{GraphWriteBatch, GraphWriteGuard};
 #[cfg(feature = "query-transport")]
 pub use engine::ScopedRoutedGraphCluster;
 pub use engine::{
-    local_object_store, object_store_from_env, ArtifactGcResult, BenchmarkResult, CellOwnership,
-    GraphCluster, GraphIndexBuildPath, GraphIndexGeneration, GraphShardRuntimeMetrics,
-    MatrixArtifact, MatrixTraversalResult, ObjectStoreGraphScopeDirectory,
-    ObjectStoreNodeDirectory, ObjectStoreWriterLeaseDirectory, PlacementConfig,
-    PlacementRefreshHandle, PlacementView, RoutedGraphCluster, ScopedGraphShardRuntimeMetrics,
-    TraversalBackend, WriterLeaseOwner, WriterLeaseRenewalFailure,
+    local_object_store, object_store_from_env, probe_conditional_put, ArtifactGcResult,
+    BenchmarkResult, CellOwnership, ConditionalPutSupport, GraphCluster, GraphIndexBuildPath,
+    GraphIndexGeneration, GraphShardRuntimeMetrics, MatrixArtifact, MatrixTraversalResult,
+    ObjectStoreGraphScopeDirectory, ObjectStoreNodeDirectory, ObjectStoreWriterLeaseDirectory,
+    PlacementConfig, PlacementRefreshHandle, PlacementView, RoutedGraphCluster,
+    ScopedGraphShardRuntimeMetrics, TraversalBackend, WriterLeaseOwner, WriterLeaseRenewalFailure,
 };
 pub use locality::{
     compare_locality_layouts, locality_cell_id, locality_cell_prefix, locality_cell_prefix_len,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -3833,6 +3833,62 @@ async fn local_object_store_reopen_reads_from_remote_ground_truth() {
 }
 
 #[tokio::test]
+async fn the_local_filesystem_is_reported_as_lacking_conditional_put() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let object_store: Arc<dyn ObjectStore> =
+        Arc::new(LocalFileSystem::new_with_prefix(tempdir.path()).unwrap());
+
+    let support = probe_conditional_put(object_store.as_ref(), "graph/data")
+        .await
+        .unwrap();
+
+    assert!(!support.is_supported());
+    let ConditionalPutSupport::Unsupported { store } = support else {
+        panic!("LocalFileSystem does not implement PutMode::Update");
+    };
+    // Named by the store itself, so an operator can tell which backend the
+    // warning is about without reading it back off the configuration.
+    assert!(
+        store.contains("LocalFileSystem"),
+        "the store names itself in the report: {store}"
+    );
+}
+
+#[tokio::test]
+async fn an_in_memory_store_is_reported_as_supporting_conditional_put() {
+    let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+
+    assert_eq!(
+        probe_conditional_put(object_store.as_ref(), "graph/data")
+            .await
+            .unwrap(),
+        ConditionalPutSupport::Supported
+    );
+}
+
+#[tokio::test]
+async fn the_conditional_put_probe_answers_the_same_on_every_restart() {
+    // The probe writes an object to ask its question. A leftover from the last
+    // start must not turn the next one into an AlreadyExists, which would read
+    // as a capability the store does not have.
+    let tempdir = tempfile::tempdir().unwrap();
+    let local: Arc<dyn ObjectStore> =
+        Arc::new(LocalFileSystem::new_with_prefix(tempdir.path()).unwrap());
+    let memory: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+
+    for _ in 0..3 {
+        assert!(!probe_conditional_put(local.as_ref(), "graph/data")
+            .await
+            .unwrap()
+            .is_supported());
+        assert!(probe_conditional_put(memory.as_ref(), "graph/data")
+            .await
+            .unwrap()
+            .is_supported());
+    }
+}
+
+#[tokio::test]
 async fn second_writer_open_fences_first_writer_instance() {
     let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
     let path = "graph/writer-fence";


### PR DESCRIPTION
Refs #81. This implements suggested fix **2** — detect the missing capability at
startup and say so once. It does not implement 1, and 3 is already @areycruzer's
#87. Reasoning for that split is under *What this does not do*, and I would
rather you sanity-check the boundary than have me guess wider.

## What the probe is for

SlateDB updates its manifest by compare-and-swap, so a store that answers
`NotImplemented` to `put_opts` with `PutMode::Update` cannot collect its own
garbage. `LocalFileSystem` is such a store, so under `CLOUD_PROVIDER=local`
every manifest GC cycle fails and reclaims nothing.

The part that costs someone a day is that nothing says so. Reads, writes and
`/readyz` all stay healthy. The only signal is a per-cycle `ERROR` from inside
SlateDB that first appears **6 min 21 s** into a write load — once the manifest
has grown enough for a GC pass to run — by which point nobody is still watching
the log. Per the issue, it was only found because writes in a different workload
eventually stopped altogether.

So the node is asked the question at startup, before it has been handed any
data, and answers it once:

```
WARN object store does not implement conditional put, so SlateDB manifest garbage
     collection will fail on every cycle and reclaim nothing: the store grows
     without bound under sustained writes. Usable for smoke tests and local
     development, not for durable or long-running use — point CLOUD_PROVIDER at
     an S3-compatible backend for that
     object_store=LocalFileSystem(file:///data/store)
```

## How it decides

`probe_conditional_put` writes a small object, re-writes it with
`PutMode::Update` carrying the version the first write returned, and reads the
outcome:

- `Ok` — the store performed the conditional put.
- `Precondition` / `AlreadyExists` — the store *weighed* the condition and
  refused it. That is the capability working; something else just wrote first.
- `NotImplemented` — the store cannot answer the question at all. This is the
  only outcome that reports unsupported.

Three things worth flagging about the design:

- **Probed, not inferred.** It asks the store rather than matching on
  `CLOUD_PROVIDER` or a backend name, so a store that gains conditional put
  stops being reported the day it does, and one that lacks it is caught whatever
  it is called or however it was configured.
- **The store names itself.** `Unsupported { store }` is filled from the store's
  own `Display` — `LocalFileSystem(file:///data/store)` — so the warning names
  what is actually mounted rather than what the configuration asked for. That is
  the same string that appears in the `implementer` field of the error in the
  issue.
- **A failed probe is not fatal.** If the probe itself errors it is logged at
  `debug` and startup continues. A store that cannot service it has a larger
  problem, and the first real write reports that with better context than a
  startup check can.

The probe object sits under `_coordination/v1/`, beside the writer lease's
existing clock probe (`writer_lease.rs:618`), and is deleted afterwards. Cleanup
is best-effort on purpose: the probe's first write is unconditional, so a
leftover from a killed process cannot change the next answer. There is a test
for exactly that.

## What this does not do, and why

- **It does not make GC work on a store without compare-and-swap.** Emulating
  CAS over `LocalFileSystem` is the one change here that could corrupt a
  manifest rather than merely fail to clean one, and `NotImplemented` is that
  backend's honest answer rather than an oversight. That is not a drive-by fix.
- **It does not disable or reconfigure SlateDB's GC.** SlateDB is a pinned git
  dependency (`usecortex/slatedb`, rev `c501471`) whose source I cannot read
  from here, so anything resting on its `Settings` GC surface would be guesswork.
  If you would rather the node skip GC entirely on such a backend, that is a
  one-line follow-up for someone who can see that API — and this probe is the
  condition it would key off.
- **It warns rather than refuses.** #81 offers "refuse ... or emit a single
  prominent warning" and I took the second: `CLOUD_PROVIDER=local` is what
  `justfile:254`, `justfile:267` and `scripts/runtime_smoke.sh:27` run on, so
  refusing would break the project's own smoke recipes. If you want it fatal
  behind an opt-out, say so and I will add it — the detection is already here.
- **graph-node only.** The reproduction and the GC error are the node's.
  `graph-indexer` shares the store and I can add the same call there if you
  want it, but I would rather not widen the diff on a guess.

## Tests

Three, in `src/tests.rs` beside the existing `LocalFileSystem` coverage:

- `the_local_filesystem_is_reported_as_lacking_conditional_put` — the case from
  the issue, asserted against a real `LocalFileSystem` over a tempdir, including
  that the store names itself in the report.
- `an_in_memory_store_is_reported_as_supporting_conditional_put` — the other
  answer, so the probe is not merely always pessimistic.
- `the_conditional_put_probe_answers_the_same_on_every_restart` — runs both
  three times over. A probe that leaves an object behind and then reads
  `AlreadyExists` on the next start would report a capability the store does not
  have; this pins that it does not.

## Verification status — please read

**I could not compile or run these tests.** No Rust toolchain on this machine,
and installing one would not be enough: `opencypher` needs libcypher-parser and
the always-linked `graphblas` needs libgraphblas, neither of which builds on
Windows. Per #90 there is no CI on pull requests either, so this may reach you
unbuilt. I also could not run the reporter's Docker reproduction — the daemon is
not running here — so I have not watched the warning appear in a real container.

What I checked against the tree rather than from memory:

- The seven methods on `ObjectStore` that the repo's own store wrappers
  implement (`RecordStore`, `FaultStore`, `ListFailingStore`, `FailingStore`)
  are `put_opts`, `put_multipart_opts`, `get_opts`, `delete_stream`, `list`,
  `list_with_delimiter`, `copy_opts` — so `put` and `delete` are the
  `ObjectStoreExt` conveniences, which is why this module imports that trait
  exactly as `writer_lease.rs` and `heartbeat.rs` do.
- `PutPayload::from(String)`, `PutOptions::from(PutMode::Update(version))` and
  `UpdateVersion { e_tag, version }` are all used in `writer_lease.rs` already;
  the version here comes off `PutResult` rather than a re-read, so the probe is
  three round trips and not five.
- The probe lives in its own `engine::conditional_put` module rather than in
  `engine.rs` on purpose: `engine.rs`'s submodules pull it in with
  `use super::*`, so putting `Path`/`PutMode`/`PutOptions` at that scope would
  have pushed them into every one of them.
- Nothing in the tree lists the `_coordination/` prefix, so the extra object
  cannot perturb a scan.

If it does not build, say the word and I will fix it promptly — but I did not
want to imply a green run I never saw. And since you have the reproduction
scripted, the warning firing on a real `local` container is the one check I most
want confirmed.
