### PR TITLE
fix: refuse a retried edge write whose metadata payload changed

### DIFF
--- a/src/codec.rs
+++ b/src/codec.rs
@@ -767,11 +767,16 @@ pub(crate) fn decode_out_edge_segment(key: &str, value: &[u8]) -> Result<OutEdge
     })
 }
 
-pub(crate) fn encode_commit_idempotency(mutation: &EdgeMutation, result: &CommitResult) -> Vec<u8> {
+pub(crate) fn encode_commit_idempotency(
+    mutation: &EdgeMutation,
+    fingerprint: u64,
+    result: &CommitResult,
+) -> Vec<u8> {
     format!(
-        "graph-commit-idempotency-v1\t{}\t{}\t{}\t{}\t{}\t{}\n",
+        "graph-commit-idempotency-v1\t{}\t{}\t{}\t{}\t{}\t{}\t{}\n",
         result.epoch,
         u8::from(result.already_existed),
+        fingerprint,
         mutation.cell_id,
         mutation.edge_type,
         mutation.src,
@@ -1155,6 +1160,7 @@ pub(crate) fn decode_cell_drop_idempotency(
 pub(crate) fn decode_commit_idempotency(
     key: &str,
     mutation: &EdgeMutation,
+    fingerprint: u64,
     value: &[u8],
 ) -> Result<CommitResult> {
     let text = std::str::from_utf8(value).map_err(|err| GraphError::CorruptValue {
@@ -1162,13 +1168,20 @@ pub(crate) fn decode_commit_idempotency(
         reason: err.to_string(),
     })?;
     let parts: Vec<&str> = text.trim_end_matches('\n').split('\t').collect();
-    if parts.len() != 7 || parts[0] != "graph-commit-idempotency-v1" {
+    if parts.len() != 8 || parts[0] != "graph-commit-idempotency-v1" {
         return Err(GraphError::CorruptValue {
             key: key.to_string(),
-            reason: "expected graph-commit-idempotency-v1 record with 7 fields".to_string(),
+            reason: "expected graph-commit-idempotency-v1 record with 8 fields".to_string(),
         });
     }
-    ensure_idempotent_edge(key, "create", mutation, &parts[3..7])?;
+    ensure_idempotent_edge(key, "create", mutation, &parts[4..8])?;
+    if parse_u64(key, parts[3], "fingerprint")? != fingerprint {
+        return Err(GraphError::IdempotencyConflict {
+            operation: "create",
+            idempotency_key: mutation.idempotency_key.clone(),
+            reason: "this key already stored a result for a different payload",
+        });
+    }
     let already_existed = decode_bool_flag(key, parts[2], "already_existed")?;
     Ok(CommitResult {
         epoch: parse_u64(key, parts[1], "epoch")?,

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -1168,19 +1168,33 @@ pub(crate) fn decode_commit_idempotency(
         reason: err.to_string(),
     })?;
     let parts: Vec<&str> = text.trim_end_matches('\n').split('\t').collect();
-    if parts.len() != 8 || parts[0] != "graph-commit-idempotency-v1" {
+    if parts.first() != Some(&"graph-commit-idempotency-v1") {
         return Err(GraphError::CorruptValue {
             key: key.to_string(),
-            reason: "expected graph-commit-idempotency-v1 record with 8 fields".to_string(),
+            reason: "expected graph-commit-idempotency-v1 record".to_string(),
         });
     }
-    ensure_idempotent_edge(key, "create", mutation, &parts[4..8])?;
-    if parse_u64(key, parts[3], "fingerprint")? != fingerprint {
-        return Err(GraphError::IdempotencyConflict {
-            operation: "create",
-            idempotency_key: mutation.idempotency_key.clone(),
-            reason: "this key already stored a result for a different payload",
-        });
+    match parts.len() {
+        // Pre-fingerprint record written before payload fingerprinting shipped.
+        // No fingerprint was ever stored for it, so only identity can be checked.
+        7 => ensure_idempotent_edge(key, "create", mutation, &parts[3..7])?,
+        8 => {
+            ensure_idempotent_edge(key, "create", mutation, &parts[4..8])?;
+            if parse_u64(key, parts[3], "fingerprint")? != fingerprint {
+                return Err(GraphError::IdempotencyConflict {
+                    operation: "create",
+                    idempotency_key: mutation.idempotency_key.clone(),
+                    reason: "this key already stored a result for a different payload",
+                });
+            }
+        }
+        _ => {
+            return Err(GraphError::CorruptValue {
+                key: key.to_string(),
+                reason: "expected graph-commit-idempotency-v1 record with 7 or 8 fields"
+                    .to_string(),
+            });
+        }
     }
     let already_existed = decode_bool_flag(key, parts[2], "already_existed")?;
     Ok(CommitResult {

--- a/src/shard/write.rs
+++ b/src/shard/write.rs
@@ -2986,10 +2986,11 @@ impl GraphShard {
                 tracing::info_span!("write.fence_validate", hydradb.cell_id = %mutation.cell_id),
             )
             .await?;
+        let fingerprint = relationship_create_fingerprint(mutation, metadata_updates, edge_metadata);
         let idem_key = keys::idempotency(&mutation.cell_id, "create", &mutation.idempotency_key);
 
         if let Some(value) = read_txn_remote(&txn, &idem_key).await? {
-            return decode_commit_idempotency(&idem_key, mutation, &value);
+            return decode_commit_idempotency(&idem_key, mutation, fingerprint, &value);
         }
 
         let current_epoch = txn.seqnum();
@@ -3036,7 +3037,7 @@ impl GraphShard {
                 };
                 txn.put(
                     idem_key.as_bytes(),
-                    encode_commit_idempotency(mutation, &result),
+                    encode_commit_idempotency(mutation, fingerprint, &result),
                 )?;
                 commit_txn_traced(
                     txn,
@@ -3087,7 +3088,7 @@ impl GraphShard {
         if existing_edge_epoch.is_some() {
             txn.put(
                 idem_key.as_bytes(),
-                encode_commit_idempotency(mutation, &result),
+                encode_commit_idempotency(mutation, fingerprint, &result),
             )?;
             commit_txn_traced(
                 txn,
@@ -3154,7 +3155,7 @@ impl GraphShard {
         }
         txn.put(
             idem_key.as_bytes(),
-            encode_commit_idempotency(mutation, &result),
+            encode_commit_idempotency(mutation, fingerprint, &result),
         )?;
 
         commit_txn_traced(
@@ -4425,9 +4426,10 @@ impl GraphShard {
         let mut already_existed = 0_u64;
 
         for mutation in mutations {
+            let fingerprint = relationship_create_fingerprint(mutation, &[], &EdgeMetadata::default());
             let idem_key = keys::idempotency(cell_id, "create", &mutation.idempotency_key);
             if let Some(value) = read_txn_remote(&txn, &idem_key).await? {
-                let result = decode_commit_idempotency(&idem_key, mutation, &value)?;
+                let result = decode_commit_idempotency(&idem_key, mutation, fingerprint, &value)?;
                 if result.already_existed {
                     already_existed = already_existed.saturating_add(1);
                 } else {
@@ -4474,7 +4476,7 @@ impl GraphShard {
                 };
                 txn.put(
                     idem_key.as_bytes(),
-                    encode_commit_idempotency(mutation, &result),
+                    encode_commit_idempotency(mutation, fingerprint, &result),
                 )?;
                 already_existed = already_existed.saturating_add(1);
                 results.push(result);
@@ -4491,7 +4493,7 @@ impl GraphShard {
                 known_edges.insert(identity, current_epoch);
                 txn.put(
                     idem_key.as_bytes(),
-                    encode_commit_idempotency(mutation, &result),
+                    encode_commit_idempotency(mutation, fingerprint, &result),
                 )?;
                 already_existed = already_existed.saturating_add(1);
                 results.push(result);
@@ -4523,7 +4525,7 @@ impl GraphShard {
                 known_edges.insert(identity, epoch);
                 txn.put(
                     idem_key.as_bytes(),
-                    encode_commit_idempotency(mutation, &result),
+                    encode_commit_idempotency(mutation, fingerprint, &result),
                 )?;
                 already_existed = already_existed.saturating_add(1);
                 results.push(result);
@@ -4563,7 +4565,7 @@ impl GraphShard {
             }
             txn.put(
                 idem_key.as_bytes(),
-                encode_commit_idempotency(mutation, &result),
+                encode_commit_idempotency(mutation, fingerprint, &result),
             )?;
             known_edges.insert(identity, next_epoch);
             *out_increments

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -3470,6 +3470,83 @@ async fn idempotency_keys_are_bound_to_the_original_edge() {
 }
 
 #[tokio::test]
+async fn idempotency_keys_are_bound_to_the_original_metadata_payload() {
+    let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let shard = open_test_shard("graph/idempotency-metadata-conflict", object_store).await;
+
+    let alice = VertexMetadata::default()
+        .with_property("name", VertexPropertyValue::String("alice".to_string()));
+    let bob = VertexMetadata::default()
+        .with_property("name", VertexPropertyValue::String("bob".to_string()));
+
+    shard
+        .write_edge_with_vertex_metadata(
+            mutation(1, 2, "vertex-metadata-conflict"),
+            alice.clone(),
+            VertexMetadata::default(),
+        )
+        .await
+        .unwrap();
+    let retry_err = shard
+        .write_edge_with_vertex_metadata(
+            mutation(1, 2, "vertex-metadata-conflict"),
+            bob,
+            VertexMetadata::default(),
+        )
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        retry_err,
+        GraphError::IdempotencyConflict {
+            operation: "create",
+            ref idempotency_key,
+            reason: "this key already stored a result for a different payload"
+        } if idempotency_key == "vertex-metadata-conflict"
+    ));
+    let alice_key = keys::vertex("reddit-home", 1);
+    let stored_alice = decode_vertex_metadata(
+        &alice_key,
+        &shard.read_remote(&alice_key).await.unwrap().unwrap(),
+    )
+    .unwrap();
+    assert_eq!(stored_alice, alice);
+
+    let since = EdgeMetadata::default().with_property("since", VertexPropertyValue::Integer(2020));
+    let updated = EdgeMetadata::default().with_property("since", VertexPropertyValue::Integer(2021));
+    shard
+        .write_edge_with_full_metadata(
+            mutation(3, 4, "full-metadata-conflict"),
+            VertexMetadata::default(),
+            VertexMetadata::default(),
+            since.clone(),
+        )
+        .await
+        .unwrap();
+    let retry_err = shard
+        .write_edge_with_full_metadata(
+            mutation(3, 4, "full-metadata-conflict"),
+            VertexMetadata::default(),
+            VertexMetadata::default(),
+            updated,
+        )
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        retry_err,
+        GraphError::IdempotencyConflict {
+            operation: "create",
+            ref idempotency_key,
+            reason: "this key already stored a result for a different payload"
+        } if idempotency_key == "full-metadata-conflict"
+    ));
+    let edge_key = keys::edge_metadata("reddit-home", "USER_SUBSCRIBED_TO_SUBREDDIT", 3, 4);
+    let stored_edge =
+        decode_edge_metadata(&edge_key, &shard.read_remote(&edge_key).await.unwrap().unwrap())
+            .unwrap();
+    assert_eq!(stored_edge, since);
+}
+
+#[tokio::test]
 async fn delete_edge_updates_canonical_snapshot_idempotently() {
     let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
     let shard = open_test_shard("graph/delete-edge", object_store).await;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -3546,6 +3546,27 @@ async fn idempotency_keys_are_bound_to_the_original_metadata_payload() {
     assert_eq!(stored_edge, since);
 }
 
+#[test]
+fn decode_commit_idempotency_accepts_pre_fingerprint_records() {
+    let m = mutation(1, 2, "legacy-key");
+    let legacy_record = format!(
+        "graph-commit-idempotency-v1\t{}\t{}\t{}\t{}\t{}\t{}\n",
+        5, 1, m.cell_id, m.edge_type, m.src, m.dst
+    )
+    .into_bytes();
+
+    let result = decode_commit_idempotency("idempotency-key", &m, 0xdead_beef, &legacy_record)
+        .unwrap();
+
+    assert_eq!(
+        result,
+        CommitResult {
+            epoch: 5,
+            already_existed: true,
+        }
+    );
+}
+
 #[tokio::test]
 async fn delete_edge_updates_canonical_snapshot_idempotently() {
     let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());


### PR DESCRIPTION
write_edge_with_vertex_metadata and write_edge_with_full_metadata share the graph-commit-idempotency-v1 record with plain write_edge, which only fingerprints cell_id/edge_type/src/dst. Retrying the same idempotency_key with different vertex or edge properties hit the cached record and returned the old success silently, no error, and the new properties were never written.

create_relationship_with_full_metadata already does this right: it fingerprints the metadata with relationship_create_fingerprint and rejects a mismatched retry. This carries that same fingerprint into the commit idempotency record so all three write paths agree.

Added a regression test that retries both entry points with changed metadata under the same key and checks the original value is still what got stored.

Verified locally: cargo test --lib and --lib --features opencypher pass (204 and 326 tests), clippy clean on default and opencypher feature sets.