### PR TITLE
docs: add the RFC process, template, and contributing guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,7 @@ crates/telemetry/  tracing and OTLP export
 examples/          smoke, stress, correctness, benchmark, profiling binaries
 scripts/           local, MinIO, query, stress, and chaos harnesses
 charts/hydradb/   production Helm chart
+rfcs/              published design proposals, dated; see rfcs/README.md
 docs/plans/        design plans, dated; see conventions below
 docs/runbooks/     operational procedures
 interactive/       standalone HTML design documents
@@ -408,6 +409,16 @@ and what it holds, not just the repo, so the next session reads instead of
 re-deriving. `docs/plans/2026-07-25-sparse-kernel-backend-consolidation.md` is
 the reference example. `optimisation-phases.md` predates the convention; leave
 it unless asked, since `build.rs:10` references it by name.
+
+**RFCs are not plan documents.** `rfcs/` is tracked and public; `docs/plans/` is
+neither, and nothing under `docs/` or `interactive/` is committed. A plan says
+how we are going to do a piece of work and is disposable once the work lands. An
+RFC says why the format or the semantics are what they are and outlives every
+release that touches them. Both use the same `YYYY-MM-DD-kebab-case-title.md`
+naming so the two directories read alike. RFC status also lives in the directory
+(`rfcs/`, `rfcs/accepted/`, `rfcs/rejected/`), and where the directory and the
+frontmatter disagree, the directory wins. See [rfcs/README.md](rfcs/README.md)
+for when one is required.
 
 ## Things that will mislead you
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,159 @@
+# Contributing to HydraDB
+
+Thanks for taking the time. This file is about process: what to open, what to
+expect from us, and how a change gets reviewed. It does not repeat the build
+documentation.
+
+- **[DEVELOPMENT.md](DEVELOPMENT.md)** — recipes and the test harness.
+- **[AGENTS.md](AGENTS.md)** — repository conventions and the local run-through.
+  Read the failure-modes table before debugging a build or a node that will not
+  start; it will probably save you an hour.
+- **[architecture.md](architecture.md)** — storage model, query pipeline, writer
+  coordination, index lifecycle, failure semantics.
+- **[rfcs/](rfcs/README.md)** — the design process, for the small set of changes
+  that need one.
+
+## Licensing
+
+HydraDB is licensed under **AGPL-3.0** ([LICENSE](LICENSE)). Contributions are
+accepted under the same licence: by opening a pull request you agree that your
+work is licensed under AGPL-3.0 and that you have the right to submit it. There
+is no CLA and nothing to sign.
+
+If you are contributing on behalf of an employer, confirm you have their
+permission before you open the pull request rather than after.
+
+## Start with an issue
+
+Everything starts as an issue, including changes from maintainers. It costs you
+one issue instead of one weekend to find out that something is already being
+worked on, already rejected, or blocked behind something else.
+
+Most work stops there and goes straight to a pull request. A few things need a
+design document first:
+
+| You want to | Do this | RFC? |
+|---|---|---|
+| Fix a typo or a documentation error | Pull request, no issue needed | No |
+| Report a wrong query result | Issue with the `CREATE` **and** the `MATCH` | No |
+| Fix a bug | Issue, then a pull request referencing it | No |
+| Improve performance | Issue with a benchmark number, then a pull request | No |
+| Add a Cypher function or clause | Issue first; we will say if it needs more | Maybe |
+| Change the on-disk or wire format | Issue, then an [RFC](rfcs/README.md) | **Yes** |
+| Change query semantics, or remove anything user-visible | Issue, then an [RFC](rfcs/README.md) | **Yes** |
+| Anything over a week, or spanning multiple components | Issue, then an [RFC](rfcs/README.md) | **Yes** |
+
+For a wrong query result, the `CREATE` that built the data and the `MATCH` that
+misbehaves are what make the report reproducible. Without both there is nothing
+for us to run.
+
+For performance work, bring a measurement rather than a design document. The
+[benchmark site](https://hydra-db.github.io/benchmark/) publishes the current
+numbers and `scripts/` has the harnesses.
+
+This is a database, and the three RFC rows are there for one reason: changes to
+query semantics, the wire protocols, or the object-store layout have
+consequences that outlive the release, and they are much cheaper to argue about
+in an issue than in a review of a finished branch.
+
+## Claiming an issue
+
+Comment on it. That holds it for a week, after which it is fair game again. If
+you need longer, say so on the issue; nobody will take it from you for being
+slow, only for being silent.
+
+Please check for an open pull request before starting. Duplicate work on the
+same issue is the most expensive thing that happens in this repository, because
+it costs two contributors' time and two reviews.
+
+## Building and testing
+
+Full instructions are in [AGENTS.md](AGENTS.md). Two things matter enough to
+repeat here.
+
+**Build through `just`, not bare `cargo`.** The justfile exports three variables
+that builds require: `BINDGEN_EXTRA_CLANG_ARGS` and `LIBRARY_PATH` so bindgen
+and the linker find Homebrew's `libcypher-parser` on macOS, and
+`RUST_MIN_STACK=33554432` on every platform, without which OpenCypher's async
+futures overflow the default test-thread stack. Missing the third gives you a
+node that builds, serves `/readyz`, and then aborts on the first query, which
+looks like a query bug and is not. Anything under `scripts/` invokes `cargo`
+directly and does not inherit these; export them yourself.
+
+**Run CI on your fork before opening the pull request.** `just ci` reproduces
+the checks locally, and GitHub Actions is free for public forks. The full run
+takes about 25 minutes and there is a review queue, so a pull request that
+arrives already green gets looked at sooner. If you only ran part of it, say
+which part rather than leaving the reviewer to guess.
+
+Do not open draft pull requests. Some checks do not run on drafts, so a draft
+is a pull request nobody can evaluate. Open it when it is ready, or say
+"please don't merge yet" in the description.
+
+## Pull requests
+
+Work on a branch in a fork and open the pull request against `main`.
+
+**Keep them small.** A large pull request is not more impressive, it is less
+likely to be merged, because it is harder to review and a reviewer who cannot
+hold it in their head will not approve it. If the work is genuinely large,
+split it into a sequence that each land on their own, and say in the first one
+where the sequence is going.
+
+**Add coverage for behavioural changes.** Changes to storage, fencing,
+snapshots, routing, or index publication should state the invariant they
+preserve and include a test that fails without the fix.
+
+**Explain why, not just what.** The diff shows what changed. The description
+should say what was wrong and why this is the right repair.
+
+We reserve full and final discretion over what we merge. Following this guide
+makes a pull request likely to land; it does not guarantee it. Where we say no,
+we will say why.
+
+## AI-assisted contributions
+
+Welcome, with conditions. This repository ships `AGENTS.md` and `CLAUDE.md`, so
+we are not going to pretend otherwise. What we ask:
+
+- Say that the change is largely AI-generated, and which tool and model.
+- Understand the change. You will be asked about it in review, and "the model
+  wrote it" is not an answer we can act on.
+- Review it yourself before submitting, and run `just ci` on your fork.
+- Write the pull request description and the review replies yourself.
+
+The reason for the disclosure is practical rather than ideological. It tells the
+reviewer which question to ask first, and it is the difference between a
+generated patch that gets merged and one that stalls.
+
+## What we will not merge
+
+Saying this once is cheaper than saying it per pull request.
+
+- Pull requests that only reformat code, rename things for taste, or fix a
+  single typo. Bundle typo fixes into a documentation pull request instead.
+- Dependency bumps outside Dependabot.
+- New dependencies without a justification in the description. This binary
+  links GraphBLAS and `libcypher-parser` already; every addition is a build
+  someone has to make work on two platforms.
+- Changes to the workspace dependency table in `Cargo.toml` that do not engage
+  with the comments already there. They record why specific versions and
+  features are pinned, and each one is load-bearing.
+- Large pull requests, as above.
+
+## What you can expect from us
+
+- A first response within two weeks. If we are going to say no, we would rather
+  say it early than leave you waiting.
+- A reason when we close something.
+- A pull request with no linked issue that changes query semantics, the wire
+  protocols, or the object-store layout will be closed with a pointer to the
+  table above. That is not a judgement on the code.
+
+If a pull request of yours has gone quiet past that window, comment on it. That
+is a reasonable thing to do and not a nuisance.
+
+## Code of conduct
+
+Be straightforward and assume good faith. Report anything that falls short to
+the maintainers.

--- a/README.md
+++ b/README.md
@@ -472,6 +472,7 @@ crates/             placement and telemetry workspace crates
 charts/hydradb/    Kubernetes Helm chart
 examples/           smoke, import, benchmark, and correctness programs
 scripts/            local, MinIO, stress, fencing, and deployment harnesses
+rfcs/               design proposals for format and semantics changes
 docs/               architecture notes, runbooks, benchmarks, and verification
 ```
 
@@ -489,6 +490,8 @@ documented above.
 |---|---|
 | [Architecture](architecture.md) | End-to-end design, snapshots, writer ownership, query execution, and indexing |
 | [Helm chart guide](charts/hydradb/README.md) | Kubernetes configuration, TLS, authentication, upgrades, and verification |
+| [Contributing](CONTRIBUTING.md) | How a change gets proposed, reviewed, and merged |
+| [RFC process](rfcs/README.md) | When a design document is required, and its lifecycle |
 | [Duration histograms](docs/runbooks/duration-histograms.md) | Correct latency units, PromQL, aggregation, and alerting |
 | [Correctness casebook](docs/bugs-found-fixed/README.md) | Reproduced storage and query invariants with regression evidence |
 | [Formal verification](docs/formal-methods/0003-hydradb-quint-verification-evidence.md) | Quint and model-based testing evidence |
@@ -496,10 +499,16 @@ documented above.
 
 ## Contributing
 
-Issues and pull requests are welcome. Keep changes focused, add regression
-coverage for behavioral changes, and run `just ci` before opening a pull
-request. Changes to storage, fencing, snapshots, routing, or index publication
-should state the invariant they preserve and include a failure-oriented test.
+Issues and pull requests are welcome. See
+[CONTRIBUTING.md](CONTRIBUTING.md) for the full process; the short version is
+that everything starts as an issue, changes stay small, and `just ci` should be
+green on your fork before you open a pull request.
+
+Keep changes focused and add regression coverage for behavioral changes.
+Changes to storage, fencing, snapshots, routing, or index publication should
+state the invariant they preserve and include a failure-oriented test. Changes
+to the on-disk or wire format, or to query semantics, need an
+[RFC](rfcs/README.md) before the code.
 
 ## License
 

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -1,0 +1,108 @@
+# RFCs
+
+An RFC is a short design document, written before the code, for the small set
+of changes whose consequences outlive the release that ships them.
+
+HydraDB's durable state lives in someone else's object store. Manifest layout,
+WAL format, index generations, writer-lease semantics: those decisions survive
+every release and every one of us. This directory is where the reasoning behind
+them is written down, so the next person reads it instead of re-deriving it
+from the code.
+
+Most contributions need nothing here. Read "When an RFC is required" and, if
+you are still unsure, open an issue and ask. That answer is free and fast.
+
+## When an RFC is required
+
+Three categories:
+
+1. **The on-disk or wire format changes.** Manifests, the WAL, CSC index
+   generations, lease records, the Bolt surface, the HTTP query API.
+2. **Query semantics change, or anything user-visible is removed.** A `MATCH`
+   that returns different rows than it did last release is a format change by
+   another name.
+3. **The work takes more than a week, or spans multiple components and the way
+   they interact.** Both halves of that test are things you can assess yourself
+   before writing any code.
+
+## When an RFC is not required
+
+Bug fixes. Documentation. Refactoring that does not change behaviour.
+Performance work: bring a benchmark number rather than a design document; the
+[benchmark site](https://hydra-db.github.io/benchmark/) is the bar. New Cypher
+functions that fit the existing evaluation model. Anything you could describe
+completely in the pull request body.
+
+Being on this list is not a judgement about how valuable the work is. It is a
+statement that a written design would not have changed what you built.
+
+## Process
+
+1. **Open an issue.** Always, including for maintainers. The issue is where the
+   problem gets argued and where you find out whether an RFC is wanted at all.
+   If the answer is no, you have spent one issue instead of one weekend.
+2. **Write the RFC.** Copy [`TEMPLATE.md`](TEMPLATE.md) to
+   `rfcs/YYYY-MM-DD-kebab-case-title.md`, dated the day you started it. Open a
+   pull request. Reference the issue with `see #NNN`, never `closes #NNN`: the
+   issue outlives the RFC and tracks the implementation.
+3. **Review.** Two maintainer approvals and a seven-day comment window, so that
+   people in other time zones get a real chance to object. Discussion happens
+   in inline comments on the pull request, which is why the template asks you
+   to keep each heading to one point.
+4. **Merge as proposed.** The file lands loose in `rfcs/`. This means the design
+   was reviewed and is worth building. It does not mean it exists.
+5. **Build it.** Incrementally, in small pull requests, against the tracking
+   issue. Until the RFC is accepted, keep the code behind a feature flag or a
+   name marked unstable, so nobody's data depends on a design that may still
+   move.
+6. **Move it to `accepted/`.** In the pull request that finishes the work, once
+   there is a tested implementation on `main`.
+
+If a proposal is turned down, it moves to `rejected/` with a paragraph
+explaining why. Rejected RFCs stay. The next person to have the same idea
+deserves to find the reasoning rather than repeat the argument.
+
+## Status is the directory
+
+```text
+rfcs/
+  2026-08-17-manifest-format-versioning.md   proposed
+  accepted/                                  built, tested, on main
+  rejected/                                  considered and turned down
+```
+
+The frontmatter carries the detail (dates, tracking issue, which release it
+landed in). The directory carries the truth. Where the two disagree, the
+directory wins, because moving the file is the status change and a field is
+only a promise to remember.
+
+**Accepted means shipped, not agreed.** This is deliberate and it is the one
+rule worth defending. Projects that mark an RFC accepted at the end of the
+discussion accumulate documents describing a database that does not exist, and
+readers cannot tell which is which without reading the source. Here, agreement
+gets you into `rfcs/`; a working implementation gets you into `accepted/`.
+
+## The document is alive
+
+An RFC is not frozen when it merges. Implementation teaches you things the
+design got wrong, and the correction belongs in the document, in the same pull
+request as the code that taught you. That is the whole reason these live in
+this repository instead of a separate one.
+
+What should not change quietly is the decision. If the design moves far enough
+that a reviewer of the original would not recognise it, that is a new RFC
+superseding the old one, not an edit.
+
+## Naming
+
+`YYYY-MM-DD-kebab-case-title.md`, dated when the RFC was written. The directory
+sorts chronologically and staleness is visible at a glance, which matters more
+for design documents than sequential numbering does. This matches the
+convention already used for plan documents in `docs/plans/` (see `AGENTS.md`).
+
+## Expected volume
+
+Roughly half a dozen a year. Comparable projects run at that rate for years:
+GreptimeDB has about twenty RFCs across three and a half years. If this
+directory is growing much faster, the gate above is too wide and we should fix
+the gate rather than the documents.

--- a/rfcs/TEMPLATE.md
+++ b/rfcs/TEMPLATE.md
@@ -1,0 +1,164 @@
+---
+title: <One line, no trailing punctuation>
+status: proposed          # proposed | accepted | rejected | superseded
+date: 2026-01-01          # the day the RFC was written
+issue: 000                # the tracking issue; "see #NNN", never "closes #NNN"
+authors:
+  - <github-handle>
+implemented_in:           # release tag, added when the file moves to accepted/
+supersedes:               # path to an earlier RFC, if any
+---
+
+<!--
+Copy this file to rfcs/YYYY-MM-DD-kebab-case-title.md and delete the comments
+as you fill each section in.
+
+Two rules that make review work:
+
+  Keep each heading to one point. Review happens through inline comments on the
+  pull request, and a heading covering three ideas gets one comment covering
+  none of them.
+
+  Propose a single solution. Your job is to navigate the problem and come back
+  with a recommendation you believe in. List what you rejected under
+  Alternatives. A document that presents four options and asks the reader to
+  choose moves the design work onto the reviewer.
+
+Sections you genuinely do not need can be dropped, but say so rather than
+leaving the heading empty. "Format compatibility: none, this is read-path only"
+is a sentence a reviewer needs; a blank section is one they have to chase.
+-->
+
+## Summary
+
+<!--
+Three to six sentences. What changes, and why it is worth doing. Someone should
+be able to read only this section and know whether the rest concerns them.
+-->
+
+## Motivation
+
+<!--
+The problem, concretely. A query that returns the wrong rows, an operation that
+cannot be performed, a failure mode observed in practice, a benchmark number.
+Point at issues, traces, or measurements rather than describing the problem in
+the abstract.
+
+Then: what happens if we do nothing? Sometimes that is an acceptable answer and
+it is better to find that out here.
+-->
+
+## Goals and non-goals
+
+<!--
+Two short lists. Non-goals are the more useful half: they tell the reviewer
+what not to raise, and they keep the implementation from growing while nobody
+is watching.
+-->
+
+## Design
+
+<!--
+The proposal itself, in enough detail that someone else could build it.
+
+Name the types, modules and files you expect to touch. Diagrams and pseudocode
+where they carry more than prose would. If the design turns on an invariant,
+state the invariant explicitly: this codebase's hardest bugs have been cases
+where two components disagreed about one.
+-->
+
+## Format compatibility
+
+<!--
+Required for anything that touches durable state or a wire protocol. This is
+the section that decides whether an operator can upgrade.
+
+  - Which formats change: manifest, WAL, CSC index generation, lease record,
+    Bolt, HTTP API.
+  - Which format version this bumps, and what a node at the new version does
+    when it reads the old one.
+  - Whether a node at the old version can read what the new one writes.
+  - Whether downgrade is possible, and if not, from exactly which point it
+    stops being possible.
+  - What happens during a rolling upgrade, while both versions are serving.
+
+"No format change" is a complete and welcome answer. Say it explicitly.
+-->
+
+## openCypher and Bolt conformance
+
+<!--
+Does this change TCK results? Which scenarios, and in which direction? The
+opencypher-tck workflow publishes the current report; name the delta you
+expect so the reviewer can check it against what actually lands.
+
+Does it change anything a Neo4j driver observes? Bolt is a compatibility
+promise to clients we do not control.
+-->
+
+## Operations
+
+<!--
+  - Performance: expected effect on query latency, write throughput, index
+    build time, memory. Measured if you have a prototype, estimated if not.
+    Say which.
+  - Memory budgets: anything added to a cache or resident-byte report needs to
+    appear in that report.
+  - Observability: new metrics, spans, or log fields, and what an operator is
+    meant to do when one of them moves.
+  - Configuration: new settings, their defaults, and why those defaults are
+    safe for someone who never reads this document.
+-->
+
+## Testing
+
+<!--
+How we will know it works, and how we will know when it stops working.
+
+  - Unit and integration coverage.
+  - Failure-oriented tests: the test that fails today because of the bug, or
+    that would fail if the invariant broke.
+  - Chaos or fencing harnesses where the change touches writer ownership,
+    leases, or snapshot visibility.
+  - Benchmarks, where the motivation was performance.
+-->
+
+## Rollout
+
+<!--
+How this reaches users without breaking anyone.
+
+Phases, feature flags, and the name the feature carries while it is unstable.
+Mark experimental surfaces in the name itself rather than only in
+documentation, so someone who never reads the release notes still sees it.
+
+If the change is not reversible once data has been written under it, say so
+here in as many words.
+-->
+
+## Alternatives
+
+<!--
+What else was considered, and the specific reason each was rejected. Include
+the option of doing nothing.
+
+This is the section that pays for itself. It is what stops the same idea being
+re-proposed in a year, and it is the first thing to read when the chosen design
+turns out to be wrong.
+-->
+
+## Open questions
+
+<!--
+What is genuinely unresolved, and who or what would resolve it. An RFC can
+merge with open questions; it cannot merge with open questions in the Design
+section.
+-->
+
+## Updates
+
+<!--
+Append as the implementation teaches you things. Date each entry.
+
+  - 2026-01-15: overlay merge was O(frontier^2) as specified; revised to ...
+-->

--- a/rfcs/accepted/README.md
+++ b/rfcs/accepted/README.md
@@ -1,0 +1,2 @@
+RFCs that have a tested implementation on `main`. Getting here requires
+working code, not agreement. See [../README.md](../README.md).

--- a/rfcs/rejected/README.md
+++ b/rfcs/rejected/README.md
@@ -1,0 +1,2 @@
+RFCs that were considered and turned down, kept so the reasoning outlives the
+argument. Each states why. See [../README.md](../README.md).


### PR DESCRIPTION
## What this adds

A written design process scoped to the decisions that outlive the release that ships them, plus the contributing guide that routes work into it.

- `rfcs/README.md` — when an RFC is required, the lifecycle, and why status lives in the directory
- `rfcs/TEMPLATE.md` — the template, with `Format compatibility` and `openCypher and Bolt conformance` as first-class sections
- `rfcs/accepted/`, `rfcs/rejected/` — the two status directories
- `CONTRIBUTING.md` — routing table, claiming, PR rules, AI-assisted contribution policy, what we will not merge, what we owe contributors
- `README.md`, `AGENTS.md` — wired into the existing layout blocks and documentation table

## The gate is narrow on purpose

Three categories need an RFC: the on-disk or wire format changes; query semantics change or something user-visible is removed; the work runs past a week or spans multiple components and their interaction.

Everything else goes straight to a pull request as it does today. Bug fixes, docs, refactors. Performance work brings a benchmark number rather than a design document.

Expected volume is roughly six documents a year. If `rfcs/` grows much faster than that, the gate is too wide and the gate is what should change.

## Two choices worth reviewing closely

**Status is the directory, not a frontmatter field.** Loose in `rfcs/` is proposed. `accepted/` means there is a tested implementation on `main`. `rejected/` keeps the reasoning so the next person with the same idea finds it instead of repeating the argument. Moving the file is the status change, so a document cannot go stale about its own state.

**Accepted means shipped, not agreed.** Agreement gets a design into `rfcs/`; working code gets it into `accepted/`. This is the rule that keeps us from accumulating documents describing a database that does not exist, which is the most common way a design archive stops being trustworthy.

Naming is `YYYY-MM-DD-kebab-case-title.md`, matching the plan-document convention already in `AGENTS.md`. That file gains a paragraph on the difference between the two: plans say how we will do a piece of work and are disposable and untracked, RFCs say why the format is what it is and are published.

## Overlap with #89

**#89 also adds `CONTRIBUTING.md`**, along with restoring CI, `CODE_OF_CONDUCT.md`, `SECURITY.md` and the issue templates. The two files will conflict.

They do not overlap much in substance. #89's is the better half on setup and what CI checks; this one is about process — the routing table, triage, and the design gate. My suggestion is to **merge #89 first**, since it also brings CI back, and I will rebase this onto it and keep its build and CI sections. If this lands first instead, #89 should keep those sections and drop the process paragraph.

Happy to do that merge either way round; say which you prefer.

## Notes

- Documentation only. No Rust touched, so `just ci` was not run.
- Every relative link in the added and edited files resolves.
- Unrelated and pre-existing: four rows in the README documentation table link to `docs/runbooks/`, `docs/bugs-found-fixed/`, `docs/formal-methods/` and `docs/jepsen/` files that are not tracked in this repository, so they are broken on GitHub today. Left alone here; worth a separate fix, either committing those docs or dropping the rows.
- `CONTRIBUTING.md` promises a first response within two weeks. That is the one line here with a real recurring cost. Change the number to whatever we will actually hit, or cut it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)