### PR TITLE
fix(bolt): map 3 reachable freshness errors to retryable transient codes

### DIFF
--- a/src/client/bolt/tests.rs
+++ b/src/client/bolt/tests.rs
@@ -1659,6 +1659,92 @@ fn a_write_to_a_non_owner_maps_to_the_not_a_leader_code_with_the_owner_hint() {
     }
 }
 
+/// Freshness-family probe: `graph_error_to_bolt` maps `SnapshotAhead`,
+/// `SnapshotChanged`, `QueryStatsSnapshotChanged` and `SnapshotExpired` to
+/// distinct `Neo.TransientError` codes so drivers retry them, while
+/// `ControlWatermarkRegression` -- ungrounded in any observed retry-safe
+/// behavior and never constructed anywhere in this codebase -- still falls
+/// through to the opaque, non-retryable `BoltError::Backend` catch-all, even
+/// though `GraphError::error_class` groups all five into the same
+/// `CLASS_FRESHNESS` bucket (error.rs).
+#[test]
+fn graph_error_to_bolt_freshness() {
+    // (variant name, error, expected BoltError::Query code substring; None means BoltError::Backend)
+    let cases: Vec<(&str, GraphError, Option<&str>)> = vec![
+        (
+            "SnapshotAhead",
+            GraphError::SnapshotAhead {
+                cell_id: "cell-a".to_string(),
+                read_epoch: 10,
+                current_epoch: 20,
+            },
+            Some("Neo.TransientError.Transaction.BookmarkTimeout"),
+        ),
+        (
+            "SnapshotExpired",
+            GraphError::SnapshotExpired {
+                cell_id: "cell-a".to_string(),
+                edge_type: "KNOWS".to_string(),
+                read_epoch: 5,
+                min_epoch: 15,
+            },
+            Some("Neo.TransientError.Transaction.LeaseExpired"),
+        ),
+        (
+            "SnapshotChanged",
+            GraphError::SnapshotChanged {
+                operation: "artifact-build",
+                cell_id: "cell-a".to_string(),
+                edge_type: "KNOWS".to_string(),
+                read_epoch: 5,
+                current_epoch: 15,
+            },
+            Some("Neo.TransientError.Transaction.Outdated"),
+        ),
+        (
+            "QueryStatsSnapshotChanged",
+            GraphError::QueryStatsSnapshotChanged {
+                operation: "stats-refresh",
+                cell_id: "cell-a".to_string(),
+                read_epoch: 5,
+                current_epoch: 15,
+            },
+            Some("Neo.TransientError.Transaction.Outdated"),
+        ),
+        (
+            "ControlWatermarkRegression",
+            GraphError::ControlWatermarkRegression {
+                cell_id: "cell-a".to_string(),
+                field: "compacted_watermark",
+                requested_epoch: 5,
+                current_epoch: 15,
+            },
+            None,
+        ),
+    ];
+
+    let mut table = String::from("variant -> BoltError variant -> code\n");
+    for (name, error, expected_code) in cases {
+        let bolt = graph_error_to_bolt(error);
+        match (&bolt, expected_code) {
+            (BoltError::Query { code, .. }, Some(expected)) => {
+                table.push_str(&format!("{name} -> Query -> {code}\n"));
+                assert_eq!(
+                    code, expected,
+                    "{name} should map to {expected}, got {code}"
+                );
+            }
+            (BoltError::Backend(_), None) => {
+                table.push_str(&format!("{name} -> Backend -> (opaque, non-retryable)\n"));
+            }
+            (other, _) => panic!(
+                "{name}: expected {expected_code:?}, got {other:?}"
+            ),
+        }
+    }
+    eprintln!("{table}");
+}
+
 #[test]
 fn an_idempotency_conflict_is_visible_and_non_retryable_to_bolt_clients() {
     let error = graph_error_to_bolt(GraphError::IdempotencyConflict {

--- a/src/client/bolt/values.rs
+++ b/src/client/bolt/values.rs
@@ -229,6 +229,25 @@ pub(super) fn graph_error_to_bolt(error: GraphError) -> BoltError {
             code: "Neo.TransientError.Transaction.BookmarkTimeout".to_string(),
             message: error.to_string(),
         },
+        // "Outdated" is Neo4j's real code for 'transaction has seen state
+        // invalidated by a concurrent update, retrying will very likely
+        // succeed' -- an exact semantic match for an epoch that moved
+        // mid-read. "LeaseExpired" (below) fits SnapshotExpired specifically
+        // because the requested epoch has been compacted away entirely --
+        // retrying the identical request with the same stale epoch cannot
+        // succeed, but a managed-transaction retry (which neo4j drivers run
+        // as a fresh transaction function, not a resubmission of the same
+        // parameters) naturally acquires a new epoch and can.
+        GraphError::SnapshotChanged { .. } | GraphError::QueryStatsSnapshotChanged { .. } => {
+            BoltError::Query {
+                code: "Neo.TransientError.Transaction.Outdated".to_string(),
+                message: error.to_string(),
+            }
+        }
+        GraphError::SnapshotExpired { .. } => BoltError::Query {
+            code: "Neo.TransientError.Transaction.LeaseExpired".to_string(),
+            message: error.to_string(),
+        },
         GraphError::InvalidKeyComponent { .. }
         | GraphError::MissingQueryParameter { .. }
         | GraphError::QueryParse { .. }
@@ -266,6 +285,14 @@ pub(super) fn graph_error_to_bolt(error: GraphError) -> BoltError {
             code: "Neo.TransientError.General.DatabaseUnavailable".to_string(),
             message: error.to_string(),
         },
+        // ControlWatermarkRegression is grouped into CLASS_FRESHNESS for
+        // telemetry purposes but is currently unreachable (never constructed
+        // anywhere in this codebase -- confirmed via grep across src/ and
+        // crates/) and describes a control-plane metadata anomaly, not a
+        // routine concurrent-write race like its siblings; mapping it to a
+        // retryable code without evidence it shares the same safe-retry
+        // semantics would be premature. It falls through here with the rest
+        // of the catch-all.
         _ => {
             tracing::warn!(target: "slatedb_graph_kernel", error = %error, "Bolt suppressed internal graph error");
             BoltError::Backend("internal query execution error".to_string())


### PR DESCRIPTION
Closes #105

graph_error_to_bolt() only mapped SnapshotAhead to a retryable 
Neo.TransientError code. class_index() groups it with SnapshotExpired, 
SnapshotChanged, QueryStatsSnapshotChanged, and ControlWatermarkRegression 
under CLASS_FRESHNESS, but the other 4 fell through to an opaque, 
non-retryable BoltError::Backend.

SnapshotChanged and QueryStatsSnapshotChanged -> Neo.TransientError.Transaction.Outdated
SnapshotExpired -> Neo.TransientError.Transaction.LeaseExpired (not Outdated -- 
retrying the same stale epoch can't succeed, but a managed-transaction 
retry acquires a fresh one and can)
ControlWatermarkRegression -> left on the catch-all deliberately. It's 
currently unreachable (never constructed anywhere in src/ or crates/, 
confirmed via grep) and describes a control-plane anomaly, not a routine 
concurrent-write race like its siblings. Full reasoning is in the commit 
message.

Test output:
SnapshotAhead -> BookmarkTimeout (unchanged)
SnapshotExpired -> LeaseExpired
SnapshotChanged -> Outdated
QueryStatsSnapshotChanged -> Outdated
ControlWatermarkRegression -> Backend (unchanged)

40/40 client::bolt tests pass. clippy-client-protocols clean.