### PR TITLE
fix(client): surface error class on suppressed query errors

### DIFF
--- a/src/client/bolt/tests.rs
+++ b/src/client/bolt/tests.rs
@@ -1890,6 +1890,30 @@ async fn object_store_routing_advertises_nothing_when_no_live_node_is_addressabl
     }
 }
 
+/// The catch-all arm withholds the error detail but must still name the
+/// coarse class (issue #107) so a client can tell a storage failure from a
+/// query bug without an operator pulling server logs.
+#[test]
+fn unclassified_graph_error_names_its_class_without_leaking_detail() {
+    let error = GraphError::CorruptValue {
+        key: "cell/edge/42".to_string(),
+        reason: "checksum mismatch".to_string(),
+    };
+    match graph_error_to_bolt(error) {
+        BoltError::Backend(message) => {
+            assert!(
+                message.contains("corruption"),
+                "expected the class name in the message, got {message:?}"
+            );
+            assert!(
+                !message.contains("checksum mismatch"),
+                "the withheld detail must not leak onto the wire, got {message:?}"
+            );
+        }
+        other => panic!("expected a backend error, got {other:?}"),
+    }
+}
+
 /// The other half of the split: a routing *misconfiguration* stays a client
 /// error, because no other router will answer differently. Reached by giving the
 /// provider an address map that does not cover the fleet the placement view

--- a/src/client/bolt/values.rs
+++ b/src/client/bolt/values.rs
@@ -267,8 +267,9 @@ pub(super) fn graph_error_to_bolt(error: GraphError) -> BoltError {
             message: error.to_string(),
         },
         _ => {
+            let class = error.class();
             tracing::warn!(target: "slatedb_graph_kernel", error = %error, "Bolt suppressed internal graph error");
-            BoltError::Backend("internal query execution error".to_string())
+            BoltError::Backend(format!("internal query execution error ({class})"))
         }
     }
 }

--- a/src/client/http.rs
+++ b/src/client/http.rs
@@ -426,11 +426,12 @@ impl HttpApiError {
                 authenticate: false,
             },
             _ => {
+                let class = error.class();
                 tracing::warn!(target: "slatedb_graph_kernel", error = %error, "HTTP suppressed internal graph error");
                 Self {
                     status: StatusCode::INTERNAL_SERVER_ERROR,
                     code: "internal",
-                    message: "internal query execution error".to_string(),
+                    message: format!("internal query execution error ({class})"),
                     owner: None,
                     authenticate: false,
                 }

--- a/src/client/http/tests.rs
+++ b/src/client/http/tests.rs
@@ -171,6 +171,29 @@ fn a_routing_refusal_is_a_503_and_not_an_internal_error() {
     );
 }
 
+/// The catch-all arm withholds the error detail but must still name the
+/// coarse class (issue #107) so a client can tell a storage failure from a
+/// query bug without an operator pulling server logs.
+#[test]
+fn unclassified_graph_error_names_its_class_without_leaking_detail() {
+    let error = HttpApiError::from_graph(GraphError::CorruptValue {
+        key: "cell/edge/42".to_string(),
+        reason: "checksum mismatch".to_string(),
+    });
+    assert_eq!(error.status, StatusCode::INTERNAL_SERVER_ERROR);
+    assert_eq!(error.code, "internal");
+    assert!(
+        error.message.contains("corruption"),
+        "expected the class name in the message, got {:?}",
+        error.message
+    );
+    assert!(
+        !error.message.contains("checksum mismatch"),
+        "the withheld detail must not leak onto the wire, got {:?}",
+        error.message
+    );
+}
+
 #[tokio::test]
 async fn http_api_enforces_auth_scope_and_returns_typed_json() {
     let backend = Arc::new(HttpTestClient {


### PR DESCRIPTION
Closes #107

Both `graph_error_to_bolt`'s and `HttpApiError::from_graph_ref`'s catch-all arms mapped every unclassified `GraphError` to the same hardcoded `"internal query execution error"` string, so a storage permission failure and a query bug were indistinguishable to a client on either transport.

`GraphError::class()` (`src/core/error.rs`) already exists for exactly this: a 12-way coarse taxonomy (`storage`, `query`, `contention`, `timeout`, ...) built to be safe to hand to a client without leaking the withheld detail. It was only wired into telemetry, not into either client-facing error path.

Folded `error.class()` into both fallback messages instead of inventing a second classification:

- `src/client/bolt/values.rs` — `BoltError::Backend` fallback
- `src/client/http.rs` — `HttpApiError` `"internal"` fallback

No wire framing changes; only the suppressed fallback text gains the class, e.g. `internal query execution error (storage)`.

Added one test on each side (`unclassified_graph_error_names_its_class_without_leaking_detail`, in `bolt/tests.rs` and `http/tests.rs`) asserting the class name is present and the withheld detail (`error.to_string()`) is not.

## Test status

Couldn't run this crate's test suite in my environment — it hard-links SuiteSparse:GraphBLAS unconditionally (`src/sparse_kernel/graphblas.rs`, not feature-gated), so even `cargo test --lib` needs it built, and I didn't want to sink a from-source GraphBLAS build into validating a 4-line diff. I did get `libcypher-parser` built from source to confirm the diff compiles past the `opencypher` feature gate; the only remaining link failure was the unrelated, pre-existing `-lgraphblas` requirement. `cargo fmt --all --check` is clean on all four changed files. Would appreciate a CI run / second pair of eyes on the actual test result before merge.