### PR TITLE
fix: fail loudly at startup when the store directory is not writable

### DIFF
--- a/src/bin/graph-node.rs
+++ b/src/bin/graph-node.rs
@@ -23,8 +23,8 @@ use config::RuntimeConfig;
 use readiness::NodeReadiness;
 use slatedb::object_store::{path::Path, ObjectStore};
 use slatedb_graph_kernel::{
-    object_store_from_env, BoltServerConfig, ClientBoltServer, ClientHttpServer,
-    ClientQueryService, ClientQueryServiceConfig, ClientQueryTarget,
+    object_store_from_env, probe_store_writable, BoltServerConfig, ClientBoltServer,
+    ClientHttpServer, ClientQueryService, ClientQueryServiceConfig, ClientQueryTarget,
     HierarchicalClientDatabaseResolver, HttpQueryServerConfig, ObjectStoreBoltRoutingTableProvider,
     ObjectStoreNodeDirectory, PlacementConfig, PlacementView, QueryTransportAction,
     QueryTransportScopeGrant, ScopedRoutedGraphCluster, StaticQueryTransportScopeAuthorizer,
@@ -133,6 +133,12 @@ async fn run_node(
     validate_node_id(&config.node_id)?;
     std::fs::create_dir_all(&config.data_cache_dir)?;
     let object_store = object_store_from_env(None)?;
+    // A container that cannot write to its store directory otherwise looks
+    // healthy: reads succeed, /readyz is green, and the first symptom is
+    // every write failing deep in the commit path with a generic execution
+    // error. Fail loudly here instead, before anything durable is staged on
+    // top of a store that cannot accept a write.
+    probe_store_writable(object_store.as_ref(), &config.data_path).await?;
     let open_options = config.graph_open_options();
     let memory_config = config.graph_memory_config();
     let directory = ObjectStoreNodeDirectory::new(

--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -138,6 +138,12 @@ pub enum GraphError {
     RoutingUnavailable { reason: String },
     #[error("operation requires writable SlateDB shard storage")]
     ReadOnlyShardStorage,
+    #[error(
+        "object store {store} rejected a startup write test: {reason}. If this is a local \
+         directory, a Docker bind mount or named volume, check that the process's user can \
+         write to it — named volumes in particular are created root-owned by default"
+    )]
+    StoreNotWritable { store: String, reason: String },
     #[error("cell {cell_id} has been dropped; {operation} is rejected")]
     CellDropped {
         operation: &'static str,
@@ -326,7 +332,8 @@ impl GraphError {
             // durability setting, the other a write to a shard opened read-only.
             Self::UnsafeDurabilityConfig { .. }
             | Self::RoutedWriterConfigMismatch { .. }
-            | Self::ReadOnlyShardStorage => Self::CLASS_CONFIG,
+            | Self::ReadOnlyShardStorage
+            | Self::StoreNotWritable { .. } => Self::CLASS_CONFIG,
 
             Self::Slate(error)
                 if matches!(

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -225,8 +225,10 @@ mod index_store;
 mod placement;
 mod scope_directory;
 mod writer_lease;
+mod writability_probe;
 
 pub use placement::{CellOwnership, PlacementConfig, PlacementRefreshHandle, PlacementView};
+pub use writability_probe::probe_store_writable;
 
 pub use scope_directory::ObjectStoreGraphScopeDirectory;
 pub use writer_lease::{

--- a/src/engine/writability_probe.rs
+++ b/src/engine/writability_probe.rs
@@ -1,0 +1,37 @@
+use slatedb::object_store::path::Path;
+use slatedb::object_store::{ObjectStore, ObjectStoreExt, PutPayload};
+
+use crate::{GraphError, Result};
+
+const PROBE_PAYLOAD: &str = "hydradb-writability-probe\n";
+
+/// Check that an object store accepts a write, before anything durable is
+/// staged on top of it.
+///
+/// A container that cannot write to its store directory does not fail at
+/// startup: reads work, `/readyz` is green, and the first symptom is every
+/// write failing with a generic execution error deep inside the commit path —
+/// exactly what happens when a Docker named volume is mounted root-owned
+/// under a non-root image, since Docker creates named volumes root-owned by
+/// default and only bind mounts inherit the host directory's ownership.
+///
+/// This turns that into an explicit, actionable boot-time failure instead.
+/// The probe writes a small object under `_coordination/v1/`, beside the
+/// conditional-put capability probe, and removes it again; cleanup is
+/// best-effort, since a leftover probe object cannot change the answer on the
+/// next start and a failed delete is not worth failing a healthy boot over.
+pub async fn probe_store_writable(object_store: &dyn ObjectStore, base_path: &str) -> Result<()> {
+    let path = Path::from(format!(
+        "{}/_coordination/v1/writability-probe",
+        base_path.trim_end_matches('/')
+    ));
+    object_store
+        .put(&path, PutPayload::from(PROBE_PAYLOAD.to_string()))
+        .await
+        .map_err(|error| GraphError::StoreNotWritable {
+            store: object_store.to_string(),
+            reason: error.to_string(),
+        })?;
+    let _ = object_store.delete(&path).await;
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,9 +96,9 @@ pub(crate) use core::write_batch::{GraphWriteBatch, GraphWriteGuard};
 #[cfg(feature = "query-transport")]
 pub use engine::ScopedRoutedGraphCluster;
 pub use engine::{
-    local_object_store, object_store_from_env, ArtifactGcResult, BenchmarkResult, CellOwnership,
-    GraphCluster, GraphIndexBuildPath, GraphIndexGeneration, GraphShardRuntimeMetrics,
-    MatrixArtifact, MatrixTraversalResult, ObjectStoreGraphScopeDirectory,
+    local_object_store, object_store_from_env, probe_store_writable, ArtifactGcResult,
+    BenchmarkResult, CellOwnership, GraphCluster, GraphIndexBuildPath, GraphIndexGeneration,
+    GraphShardRuntimeMetrics, MatrixArtifact, MatrixTraversalResult, ObjectStoreGraphScopeDirectory,
     ObjectStoreNodeDirectory, ObjectStoreWriterLeaseDirectory, PlacementConfig,
     PlacementRefreshHandle, PlacementView, RoutedGraphCluster, ScopedGraphShardRuntimeMetrics,
     TraversalBackend, WriterLeaseOwner, WriterLeaseRenewalFailure,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use futures::StreamExt;
+use futures::{StreamExt, TryStreamExt};
 use slatedb::object_store::local::LocalFileSystem;
 use slatedb::object_store::memory::InMemory;
 
@@ -3829,6 +3829,144 @@ async fn local_object_store_reopen_reads_from_remote_ground_truth() {
             .await
             .unwrap(),
         vec![600]
+    );
+}
+
+#[tokio::test]
+async fn writability_probe_passes_and_leaves_no_object_behind_on_a_healthy_store() {
+    let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+
+    probe_store_writable(object_store.as_ref(), "graph/data")
+        .await
+        .unwrap();
+
+    let listed = object_store
+        .list(None)
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+    assert!(
+        listed.is_empty(),
+        "the probe object must not outlive the check: {listed:?}"
+    );
+}
+
+/// An `ObjectStore` whose every write fails, so the probe can be tested
+/// without depending on this process's UID or the host filesystem's
+/// permission bits: a chmod-based test would pass trivially when run as
+/// root, which this repo's own local harness and most CI containers do —
+/// root ignores Unix permission bits entirely.
+struct WriteRejectingStore;
+
+impl std::fmt::Display for WriteRejectingStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "WriteRejectingStore(permission denied)")
+    }
+}
+
+impl std::fmt::Debug for WriteRejectingStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "WriteRejectingStore")
+    }
+}
+
+#[async_trait::async_trait]
+impl ObjectStore for WriteRejectingStore {
+    async fn put_opts(
+        &self,
+        _location: &slatedb::object_store::path::Path,
+        _payload: slatedb::object_store::PutPayload,
+        _opts: slatedb::object_store::PutOptions,
+    ) -> slatedb::object_store::Result<slatedb::object_store::PutResult> {
+        Err(slatedb::object_store::Error::Generic {
+            store: "WriteRejectingStore",
+            source: "permission denied (simulated)".into(),
+        })
+    }
+
+    async fn put_multipart_opts(
+        &self,
+        _location: &slatedb::object_store::path::Path,
+        _opts: slatedb::object_store::PutMultipartOptions,
+    ) -> slatedb::object_store::Result<Box<dyn slatedb::object_store::MultipartUpload>> {
+        Err(slatedb::object_store::Error::Generic {
+            store: "WriteRejectingStore",
+            source: "permission denied (simulated)".into(),
+        })
+    }
+
+    async fn get_opts(
+        &self,
+        location: &slatedb::object_store::path::Path,
+        _options: slatedb::object_store::GetOptions,
+    ) -> slatedb::object_store::Result<slatedb::object_store::GetResult> {
+        Err(slatedb::object_store::Error::NotFound {
+            path: location.to_string(),
+            source: "nothing was ever written".into(),
+        })
+    }
+
+    fn delete_stream(
+        &self,
+        locations: futures::stream::BoxStream<
+            'static,
+            slatedb::object_store::Result<slatedb::object_store::path::Path>,
+        >,
+    ) -> futures::stream::BoxStream<
+        'static,
+        slatedb::object_store::Result<slatedb::object_store::path::Path>,
+    > {
+        locations
+    }
+
+    fn list(
+        &self,
+        _prefix: Option<&slatedb::object_store::path::Path>,
+    ) -> futures::stream::BoxStream<'static, slatedb::object_store::Result<slatedb::object_store::ObjectMeta>>
+    {
+        futures::stream::empty().boxed()
+    }
+
+    async fn list_with_delimiter(
+        &self,
+        _prefix: Option<&slatedb::object_store::path::Path>,
+    ) -> slatedb::object_store::Result<slatedb::object_store::ListResult> {
+        Ok(slatedb::object_store::ListResult {
+            common_prefixes: vec![],
+            objects: vec![],
+            extensions: Default::default(),
+        })
+    }
+
+    async fn copy_opts(
+        &self,
+        _from: &slatedb::object_store::path::Path,
+        _to: &slatedb::object_store::path::Path,
+        _options: slatedb::object_store::CopyOptions,
+    ) -> slatedb::object_store::Result<()> {
+        Err(slatedb::object_store::Error::Generic {
+            store: "WriteRejectingStore",
+            source: "permission denied (simulated)".into(),
+        })
+    }
+}
+
+#[tokio::test]
+async fn writability_probe_reports_a_store_that_rejects_writes() {
+    let error = probe_store_writable(&WriteRejectingStore, "graph/data")
+        .await
+        .unwrap_err();
+
+    let GraphError::StoreNotWritable { store, reason } = error else {
+        panic!("expected StoreNotWritable, got {error:?}");
+    };
+    assert!(
+        store.contains("WriteRejectingStore"),
+        "the store names itself in the report: {store}"
+    );
+    assert!(
+        reason.contains("permission denied"),
+        "the underlying reason is preserved: {reason}"
     );
 }
 


### PR DESCRIPTION
Closes #108

A container that cannot write to its store directory looked healthy: reads succeeded, /readyz stayed green, and the first symptom was every write failing deep in the commit path with a generic execution error. Docker creates named volumes root-owned by default, unlike bind mounts which inherit the host directory's ownership, so this hit named volumes specifically even though the README's permission note only covered bind mounts.

graph-node now probes the object store with a real write right after opening it, before anything durable is staged on top of it. A failure aborts startup with a new StoreNotWritable error naming the store and the underlying reason, instead of deferring to the first client write.

Verified end to end, not just with a mock: created a root-owned store directory, a non-root system user, and ran the real graph-node binary as that user against it. It now fails immediately with

    StoreNotWritable { store: "LocalFileSystem(file:///store)",
      reason: "...Permission denied (os error 13)" }

instead of starting up and deferring the failure to the first write.

Added unit tests for both directions: a healthy store passes and leaves no object behind, and a store double whose every write fails is reported with its own description and the underlying reason. Confirmed the failing-store test catches a probe that silently swallows the error.

Verified locally: cargo test --lib and --lib --features opencypher pass (205 and 327 tests), clippy clean on default and server-runtime,indexer-runtime feature sets.