### PR TITLE
fix: let an HTTP client continue its own result cursor

### DIFF
--- a/src/client/http/tests.rs
+++ b/src/client/http/tests.rs
@@ -356,3 +356,72 @@ async fn http_api_serves_authenticated_queries_over_https() {
     drop(client);
     server.stop().await.unwrap();
 }
+
+/// Issue #115: an HTTP client that does not send `query_id` must still be able
+/// to walk its own cursor.
+///
+/// Every other test in this file passes an explicit `query_id`, which is the
+/// one shape that always worked — so the continuation path was covered without
+/// the configuration real clients use. Page two used to fail the cursor owner
+/// check here, because the handler mints `http-query-{n}` per request and the
+/// owner comparison included it.
+#[tokio::test]
+async fn http_continuation_without_a_client_query_id_returns_the_next_page() {
+    let backend = Arc::new(HttpTestClient {
+        observed_epochs: Mutex::new(Vec::new()),
+        refreshes: AtomicU64::new(0),
+    });
+    let server = ClientHttpServer::bind(
+        "127.0.0.1:0".parse().unwrap(),
+        http_service(backend),
+        HttpQueryServerConfig::default()
+            .with_default_page_size(2)
+            .insecure_allow_plaintext(),
+    )
+    .await
+    .unwrap();
+    let url = format!("http://{}/v1/graphs/social/query", server.local_addr());
+    let client = reqwest::Client::new();
+    let page = |cursor: Option<u64>| {
+        let client = client.clone();
+        let url = url.clone();
+        async move {
+            let mut body = serde_json::json!({
+                "cell_id": "cell-a",
+                "query": "MATCH (n {id: 1}) RETURN n.id",
+                "page_size": 2
+            });
+            if let Some(cursor) = cursor {
+                body["cursor"] = serde_json::json!(cursor);
+            }
+            let response = client
+                .post(&url)
+                .bearer_auth("http-secret")
+                .header(GRAPH_NAMESPACE_HEADER, "acme")
+                .json(&body)
+                .send()
+                .await
+                .unwrap();
+            let status = response.status();
+            let body: serde_json::Value = response.json().await.unwrap();
+            (status, body)
+        }
+    };
+
+    let (status, first) = page(None).await;
+    assert_eq!(status, reqwest::StatusCode::OK);
+    assert_eq!(first["rows"].as_array().unwrap().len(), 2);
+    let cursor = first["next_cursor"]
+        .as_u64()
+        .expect("a partial result advertises a cursor");
+
+    let (status, second) = page(Some(cursor)).await;
+    assert_eq!(status, reqwest::StatusCode::OK, "{second}");
+    assert_eq!(second["rows"].as_array().unwrap().len(), 1, "{second}");
+    assert_eq!(second["rows"][0][0]["value"], 3);
+    assert!(second["next_cursor"].is_null(), "{second}");
+
+    // Every row the query produced is now accounted for across the two pages,
+    // which is the property #115 reported as lost.
+    server.stop().await.unwrap();
+}

--- a/src/client/service.rs
+++ b/src/client/service.rs
@@ -1025,8 +1025,32 @@ struct ClientQueryServiceInner {
     cursor_buffer_bytes: AtomicU64,
 }
 
+/// Who a server cursor belongs to.
+///
+/// Deliberately *not* [`ClientQueryKey`], even though the two were the same
+/// type until this split. That key identifies one in-flight statement so it can
+/// be cancelled, and `query_id` is the whole point of it there. A cursor's
+/// owner is a different question — which authenticated identity read which
+/// scope — and `query_id` answers it wrongly, because it is a per-request
+/// correlation id rather than a property of the caller.
+///
+/// The HTTP surface mints one per request when the body omits it
+/// (`http-query-{n}`, `client/http.rs`), so page two never carried the id page
+/// one was stored under and every continuation failed the owner check: the
+/// rows sat in the cursor, complete and unreachable, until the TTL dropped
+/// them. Bolt was unaffected only incidentally — it holds one `query_id`
+/// across a statement's PULLs.
+///
+/// What still has to match is unchanged and is the part that was ever doing
+/// the work: principal, scope, target, query text, and parameters.
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct ServerCursorOwner {
+    principal: QueryTransportPrincipal,
+    scope: GraphScope,
+}
+
 struct ServerQueryCursor {
-    owner: ClientQueryKey,
+    owner: ServerCursorOwner,
     target: ClientQueryTarget,
     query: String,
     parameters: BTreeMap<String, QueryParameterValue>,
@@ -1687,7 +1711,7 @@ impl ClientQueryService {
         let next_bytes = current_bytes.saturating_add(resident_bytes);
         let cursor_id = next_cursor_id(&self.inner.next_cursor_id, &cursors)?;
         let cursor = ServerQueryCursor {
-            owner: client_query_key(session, request),
+            owner: server_cursor_owner(session, request),
             target: request.target.clone(),
             query: request.query.clone(),
             parameters: request.parameters.clone(),
@@ -1719,7 +1743,7 @@ impl ClientQueryService {
     ) -> Result<ClientQueryPage> {
         let mut cursors = self.inner.cursors.lock().await;
         self.purge_expired_cursors(&mut cursors);
-        let expected_owner = client_query_key(session, request);
+        let expected_owner = server_cursor_owner(session, request);
         let Some(cursor) = cursors.get(&token.offset) else {
             return Err(GraphError::UnsupportedQuery {
                 dialect: "ClientProtocol",
@@ -1791,7 +1815,7 @@ impl ClientQueryService {
     ) -> bool {
         let mut cursors = self.inner.cursors.lock().await;
         self.purge_expired_cursors(&mut cursors);
-        let expected_owner = client_query_key(session, request);
+        let expected_owner = server_cursor_owner(session, request);
         let Some(cursor) = cursors.get(&token.offset) else {
             return false;
         };
@@ -2300,6 +2324,16 @@ fn client_query_key(session: &ClientQuerySession, request: &ClientQueryRequest) 
         principal: session.principal.clone(),
         scope: request.target.scope.clone(),
         query_id: request.query_id.clone(),
+    }
+}
+
+fn server_cursor_owner(
+    session: &ClientQuerySession,
+    request: &ClientQueryRequest,
+) -> ServerCursorOwner {
+    ServerCursorOwner {
+        principal: session.principal.clone(),
+        scope: request.target.scope.clone(),
     }
 }
 

--- a/src/client/service/tests.rs
+++ b/src/client/service/tests.rs
@@ -787,6 +787,61 @@ async fn server_cursor_executes_once_and_release_invalidates_it() {
     assert_eq!(executions.load(Ordering::Relaxed), 1);
 }
 
+/// Issue #115, from the other side: the owner check must stop pinning a cursor
+/// to a `query_id` without becoming a check that pins nothing.
+///
+/// A regenerated `query_id` — which is what the HTTP surface produces on every
+/// request — continues the cursor. A different query text still does not.
+#[tokio::test]
+async fn a_server_cursor_ignores_query_id_but_still_pins_the_query() {
+    let executions = Arc::new(AtomicU64::new(0));
+    let service = cursor_service(Arc::clone(&executions), 4, 1 << 20, 1_000);
+    let session = authenticated_session(&service);
+    let query = "MATCH (n {id: 1}) RETURN n.id AS value";
+    let first = service
+        .execute_page(
+            &session,
+            ClientQueryRequest::new(target(), "query-id-one", query),
+            None,
+            1,
+        )
+        .await
+        .unwrap();
+    let cursor = first.page.next_cursor.expect("remaining rows use a cursor");
+
+    let continued = service
+        .execute_page(
+            &session,
+            ClientQueryRequest::new(target(), "query-id-two", query),
+            Some(cursor),
+            1,
+        )
+        .await
+        .unwrap();
+    assert_eq!(continued.page.rows.len(), 1);
+    // Still one execution: the continuation was served from the buffer rather
+    // than re-running the query under its new id.
+    assert_eq!(executions.load(Ordering::Relaxed), 1);
+
+    let error = service
+        .execute_page(
+            &session,
+            ClientQueryRequest::new(
+                target(),
+                "query-id-three",
+                "MATCH (n {id: 2}) RETURN n.id AS value",
+            ),
+            Some(cursor),
+            1,
+        )
+        .await
+        .unwrap_err();
+    assert!(
+        error.to_string().contains("does not belong to this query"),
+        "{error}"
+    );
+}
+
 #[tokio::test]
 async fn server_cursor_enforces_count_and_buffer_admission() {
     let executions = Arc::new(AtomicU64::new(0));


### PR DESCRIPTION
Fixes #115.

## What is actually wrong

The three symptoms in #115 are one bug, and it is not truncation. No rows are
lost or capped — a result larger than the page size is materialized in full and
paged normally. What fails is the continuation, so everything past page one sits
in the server-side cursor buffer, complete and unreachable, until the TTL drops
it.

A cursor's owner was a `ClientQueryKey`:

```rust
struct ClientQueryKey {
    principal: QueryTransportPrincipal,
    scope: GraphScope,
    query_id: String,
}
```

That type exists to identify one in-flight statement so it can be cancelled, and
`query_id` is exactly right for that job. It is wrong for ownership: it is a
per-request correlation id, not a property of the caller. The HTTP handler mints
a fresh one whenever the body omits the field
(`http-query-{n}`, `client/http.rs`), so page two always arrived under an id
page one was never stored under, and `continue_server_cursor` refused it with
`result cursor does not belong to this query request`.

Bolt is unaffected, incidentally rather than by design: it holds one `query_id`
across a statement's PULLs.

Reproduced end to end over the real HTTP surface before the change:

```
no query_id:      page1 200 rows=2 next_cursor=1
                  page2 400 "result cursor does not belong to this query request"

stable query_id:  page1 200 rows=2 next_cursor=2
                  page2 200 rows=[3] next_cursor=null      <- every row retrieved
```

The second flow is the same query against the same data and returns everything.
That is the evidence the rows were always there.

### Why this maps onto all three reported symptoms

- **"Silent cap at 1024."** Page one of N, with `next_cursor` set. The signal
  exists; the rest was just unreachable.
- **"`LIMIT 2000` capped to 1024."** `LIMIT 2000` is honoured. It comes back as
  page one of two, and `next_cursor: 2` is the id of a second cursor, not a page
  count.
- **"`SKIP`/`LIMIT` works."** `SKIP 1024 LIMIT 500` returns 500 rows, which fits
  in one page, so it never needs a continuation.

## The change

Give the cursor its own owner type instead of borrowing the cancellation key:

```rust
struct ServerCursorOwner {
    principal: QueryTransportPrincipal,
    scope: GraphScope,
}
```

`target`, `query` and `parameters` were already compared separately in
`continue_server_cursor` and `release_server_cursor`, and still are. So what a
cursor may be used for does not change — a different query, a different
parameter set, a different scope or a different principal is refused exactly as
before. What changes is that a cursor is no longer pinned to an identifier the
caller never chose.

**Trade-off worth a reviewer's attention.** Because Bolt's `query_id` embeds its
session id, comparing it also gave incidental isolation between two Bolt sessions
of the *same principal* running the *same query text with the same parameters*.
That is now gone: such a client could continue the other session's cursor if it
used that cursor's server-assigned id. This is not a privilege boundary — same
principal, same scope, same authorization, same query — but it is a real
difference, and I would rather name it than bury it. If you would prefer to keep
it, the alternative is to require HTTP clients to echo `query_id` alongside
`cursor` and document it; I did not take that route because the field is
currently undocumented and the server invents it when absent, which makes the
advertised continuation mechanism unusable by default.

## Tests

- `http_continuation_without_a_client_query_id_returns_the_next_page` — the
  regression, over a real bound HTTP server. Verified it fails without the fix,
  with the reporter's exact message.
- `a_server_cursor_ignores_query_id_but_still_pins_the_query` — guards the other
  direction: a regenerated `query_id` continues the cursor, a different query
  text is still refused, and the continuation is served from the buffer rather
  than re-executing.

Worth noting that every pre-existing HTTP test passes an explicit `query_id`,
which is the one shape that always worked — so the continuation path was covered
without the configuration real clients use.

## Verification

Run locally on macOS arm64 (`suite-sparse` 7.14.0, `libcypher-parser` 0.6.2),
since PRs currently have no CI (#90):

```
cargo test --locked --all-targets --features public-client-protocols
  464 passed; 0 failed

cargo test --locked --features server-runtime --bin graph-node
  44 passed; 0 failed

cargo clippy --locked --all-targets --features public-client-protocols -- -D warnings   exit 0
cargo clippy --locked --all-targets --features server-runtime,indexer-runtime -- -D warnings   exit 0
rustfmt --check on the three touched files: clean
```

## Left for separate changes

- #67 (full materialization before paging) is adjacent but distinct: this PR
  makes the existing buffer reachable, it does not change when rows are
  materialized.
- The reporter's suggestion of an explicit `truncated` flag is a response-shape
  decision rather than a bug fix, so it seemed like yours to make. With the
  cursor working, `next_cursor` is a truthful completeness signal again.
