### PR TITLE
docs(cypher-compat): record the two constraints raised at query time

### DIFF
--- a/cypher-compat.md
+++ b/cypher-compat.md
@@ -48,6 +48,17 @@ MATCH ()-[e:FOLLOWS {weight: 7}]->() RETURN count(*)
 Nodes match on `id`, optionally with a label and inline properties. A node
 carrying labels or non-id properties has to be named.
 
+A `MATCH` of a node on its own needs something to select on — an id, a label, or
+a property. There is no bounded set of vertices to scan without one, so the
+otherwise obvious `MATCH (n) RETURN count(*)` is refused:
+
+```
+node-only MATCH requires an id, label, or property predicate
+```
+
+This one is raised when the query runs rather than when it parses, so it is
+reported against real data rather than by a syntax check.
+
 ### Variable-length paths
 
 ```cypher
@@ -61,6 +72,38 @@ exactly three long.
 The maximum is required. `*1..` and `*` are rejected, because an unbounded
 traversal on a large graph has no predictable cost. The minimum defaults to 1
 when omitted, and must not exceed the maximum.
+
+#### The source node needs an id
+
+A variable-length pattern starts from a node whose `id` the pattern supplies,
+and walks the arrow away from it. The id may be a literal or a parameter, but it
+has to sit in that node's inline property map:
+
+```cypher
+MATCH (u {id: 1})-[:CHAIN*1..3]->(v) RETURN v.id
+MATCH (u {id: $start})-[:CHAIN*1..3]->(v) RETURN v.id
+```
+
+Without it the query is refused when it runs:
+
+```
+variable-length MATCH requires a fixed source id
+```
+
+This makes direction load-bearing in a way a fixed-length pattern does not. An
+inbound spelling puts the id on the destination and leaves the *source* unbound,
+so no arrangement of the same pattern satisfies the requirement:
+
+```cypher
+// refused: the source is (x), and (x) is the node being searched for
+MATCH (c {id: 5})<-[:DEPENDS_ON*1..2]-(x) RETURN x.name
+```
+
+So "everything reachable from X" is expressible and "everything that reaches X"
+is not, unless the graph also carries the reverse relationship type. For the
+same reason a transitive closure over a whole relation — every
+`(a)-[:MANAGES*1..6]->(b)` pair, with no bound endpoint — has to be driven from
+the client, one start node at a time.
 
 ### WHERE
 
@@ -268,6 +311,12 @@ Rejected at parse time, with the reason in the error:
 - Nested unions, mixed `UNION` and `UNION ALL`, and unions containing writes
 - Variable-length relationships in `CREATE` and `MERGE`
 - More than one statement per request
+
+Two are refused when the query runs instead, so they parse cleanly and are only
+reported once a statement reaches data:
+
+- A node-only `MATCH` carrying no id, label, or property predicate
+- A variable-length `MATCH` whose source node has no `id`
 
 ## Checking a query without running it
 


### PR DESCRIPTION
Refs #109, #117.

`cypher-compat.md` documents what the parser rejects. Two of the subset's
constraints are enforced during execution instead, so they parse cleanly and
appear only once a statement reaches data:

```
node-only MATCH requires an id, label, or property predicate     (src/shard/query.rs:3572)
variable-length MATCH requires a fixed source id                 (src/shard/query.rs:3976)
```

Both were reported as costing real discovery time — #109 for the second, #117
items 1 and 3 for both — and neither is written down. This adds them, plus the
distinction that they are raised at query time rather than parse time, which is
why they survive a syntax check.

## The part with modelling consequences

A variable-length pattern walks away from a node whose `id` the pattern supplies.
That makes direction load-bearing in a way a fixed-length pattern is not: an
inbound spelling puts the id on the destination and leaves the *source* unbound,
and no rearrangement of the same pattern fixes it.

```cypher
MATCH (c {id: 5})<-[:DEPENDS_ON*1..2]-(x) RETURN x.name   // source is (x), which has no id
```

So "everything reachable from X" is expressible and "everything that reaches X"
is not, unless the graph also carries the reverse relationship type — and a
transitive closure over a whole relation has to be driven from the client one
start node at a time. #109 makes this point well; it is worth having in the
compatibility doc rather than only in an issue.

## One correction to #109

#109 also reports that the id must be a literal, and that `$id` is rejected for
variable-length patterns while working for fixed-length ones. That part does not
reproduce. `row_node_properties` substitutes parameters while lowering the node
pattern, so an id supplied as `$parameter` inside the inline property map lowers
to a fixed source exactly as a literal does. Checked against the parser:

```
literal-outbound   src.id=Some(5)  src.binding=Some("a")  hops=Some((1, 2))   OK
param-outbound     src.id=Some(5)  src.binding=Some("a")  hops=Some((1, 2))   OK
param-fixed-hop    src.id=Some(5)  src.binding=Some("a")  hops=None           OK
literal-inbound    src.id=None     src.binding=Some("x")  hops=Some((1, 2))   -> refused
```

The real requirement is that the id be **in the source node's inline property
map**, whether written as a literal or a parameter. A `WHERE n.id = $id` clause
does not satisfy it, which is the likeliest explanation for what #109 hit. The
doc is written to say that, and both spellings are shown:

```cypher
MATCH (u {id: 1})-[:CHAIN*1..3]->(v) RETURN v.id
MATCH (u {id: $start})-[:CHAIN*1..3]->(v) RETURN v.id
```

## Scope

Documentation only — no behaviour change, one file, +49/−0.

Deliberately not included:

- #117 items 2 and 4 (one relationship type per pattern; labels require a named
  node). Both are already documented under **Reading → Patterns**, so the gap
  there is discoverability rather than coverage.
- #117 item 5 (`PutMode::Update` unimplemented on `LocalFileSystem`) is #81, and
  #94 and #87 are already open against it.
- Whether any of these constraints should be *lifted* rather than documented.
  #109 is filed as a documentation request and I have treated it as one; the
  inbound-traversal limitation in particular looks like a design decision that is
  yours to make.
