### PR TITLE
fix: name the supported batch shape when an UNWIND batch is rejected

### DIFF
--- a/cypher-compat.md
+++ b/cypher-compat.md
@@ -194,6 +194,9 @@ write one:
 - Ids read fields from the row map, so `{id: row.vertex}`, and the alias has to
   be the one the `UNWIND` bound.
 - One relationship pattern per batch, one hop, directed.
+- Node patterns inside a batch match by id alone. A label goes in the `SET` of a
+  vertex upsert, or on the endpoints of the `UNWIND MATCH` that binds a
+  relationship — not on a node pattern written directly into `UNWIND ... CREATE`.
 - `UNWIND ... CREATE` and `UNWIND MATCH ... CREATE` cannot be followed by
   another clause, and an `UNWIND MATCH` must end in `RETURN` or `DELETE`.
 - `UNWIND MATCH` does not take `OPTIONAL`, hints, or `WHERE`.

--- a/src/query/opencypher.rs
+++ b/src/query/opencypher.rs
@@ -967,7 +967,13 @@ impl ParsedCypher {
             }
             let expression = checked_node(sys::cypher_ast_unwind_get_expression(unwind))?;
             if !is_instance(expression, sys::CYPHER_AST_PARAMETER) {
-                return unsupported("UNWIND batch input must be a parameter");
+                // An inline list parses, so the rejection lands on a statement that reads
+                // like a working batch. Naming the input the batch wants keeps the next
+                // attempt from being the same literal list rearranged.
+                return unsupported(
+                    "UNWIND batch input must be a parameter holding a list of maps, \
+                     not an inline list",
+                );
             }
             let parameter = parameter_name(expression)?;
             let alias = identifier_name(checked_node(sys::cypher_ast_unwind_get_alias(unwind))?)?;
@@ -2931,7 +2937,9 @@ fn unwind_edge_template(
         let path = checked_node(sys::cypher_ast_pattern_get_path(pattern, 0))?;
         ensure_instance(path, sys::CYPHER_AST_PATTERN_PATH, "UNWIND edge path")?;
         if sys::cypher_ast_pattern_path_nelements(path) != 3 {
-            return unsupported("UNWIND batch supports one-hop relationships only");
+            return unsupported(
+                "UNWIND batch supports one-hop relationships only; send one batch per hop",
+            );
         }
         let left = checked_node(sys::cypher_ast_pattern_path_get_element(path, 0))?;
         let relationship = checked_node(sys::cypher_ast_pattern_path_get_element(path, 1))?;
@@ -2996,7 +3004,14 @@ fn unwind_node_id_field(
 ) -> Result<Option<String>> {
     unsafe {
         if sys::cypher_ast_node_pattern_nlabels(node) != 0 {
-            return unsupported("UNWIND batch node patterns do not support labels");
+            // Labelled batch writes do exist, just not in this shape. A message that only
+            // says "no labels" reads as "no labelled batch path at all", and the way out
+            // of that reading is one round trip per edge, so name the shapes that work.
+            return unsupported(
+                "UNWIND batch node patterns match by id alone; label a vertex in the SET \
+                 of an UNWIND MERGE upsert, and label relationship endpoints in an \
+                 UNWIND MATCH that binds them for CREATE or MERGE",
+            );
         }
         let properties = sys::cypher_ast_node_pattern_get_properties(node);
         if properties.is_null() {
@@ -3893,6 +3908,47 @@ mod tests {
                 destination_label: "Source".to_string(),
             }
         );
+    }
+
+    #[cfg(feature = "client-api")]
+    #[test]
+    fn labeled_unwind_create_names_the_labeled_batch_forms() {
+        // The labelled forms this points at are the ones covered by
+        // lowers_unwind_vertex_upsert_batch and
+        // lowers_unwind_create_between_matched_labeled_vertices, so a caller who
+        // follows the message lands on a batch that parses.
+        let err = parse_opencypher_unwind_batch(
+            "UNWIND $rows AS row \
+             CREATE (s:Source {id: row.source_vertex})-[:RELATES]->(d:Source {id: row.related_vertex})",
+        )
+        .unwrap_err();
+        let message = err.to_string();
+        assert!(message.contains("match by id alone"), "{message}");
+        assert!(message.contains("SET of an UNWIND MERGE upsert"), "{message}");
+        assert!(message.contains("MATCH that binds them"), "{message}");
+    }
+
+    #[cfg(feature = "client-api")]
+    #[test]
+    fn inline_unwind_list_names_the_batch_input_it_wanted() {
+        let err = parse_opencypher_unwind_batch("UNWIND [1, 2, 3] AS row CREATE (n {id: row})")
+            .unwrap_err();
+        let message = err.to_string();
+        assert!(message.contains("parameter holding a list of maps"), "{message}");
+        assert!(message.contains("not an inline list"), "{message}");
+    }
+
+    #[cfg(feature = "client-api")]
+    #[test]
+    fn multi_hop_unwind_batch_names_the_one_hop_rule() {
+        let err = parse_opencypher_unwind_batch(
+            "UNWIND $rows AS row \
+             CREATE (a {id: row.a})-[:RELATES]->(b {id: row.b})-[:RELATES]->(c {id: row.c})",
+        )
+        .unwrap_err();
+        let message = err.to_string();
+        assert!(message.contains("one-hop relationships only"), "{message}");
+        assert!(message.contains("one batch per hop"), "{message}");
     }
 
     #[cfg(feature = "client-api")]


### PR DESCRIPTION
## What this changes

Three `UNWIND` batch rejections say what is not allowed and stop there:

```
UNWIND [1,2,3] AS x CREATE (n:__probe {i: x})
  -> UNWIND batch input must be a parameter

UNWIND $b AS row CREATE (a:__bp {id: row.aid})-[:LINKS]->(b:__bq {id: row.bid})
  -> UNWIND batch node patterns do not support labels

  -> UNWIND batch supports one-hop relationships only
```

None of them names the batch form the caller was reaching for, so the middle
one in particular reads as *"there is no labelled batch path"* rather than
*"not in this shape"*. The way out of that reading is a request per row.

## Why it matters

That happened, in #116. A caller ingesting 226,357 edges hit these three
messages, concluded labelled nodes cannot be batch written, and fell back to one
HTTP round trip per edge — measured at 281 edges/s, an ingest over an hour long
that did not finish three times.

The path they wanted already exists, and both halves of it are already covered
by tests in this file:

- a vertex upsert carries its label in the `SET` —
  `UNWIND $rows AS row MERGE (n {id: row.vertex}) SET n:Source, n.active = row.active`
  (`lowers_unwind_vertex_upsert_batch`)
- a relationship carries labels on the endpoints of the `UNWIND MATCH` that
  binds it —
  `UNWIND $rows AS row MATCH (s:Source {id: row.a}), (d:Source {id: row.b}) CREATE (s)-[:RELATES]->(d)`
  (`lowers_unwind_create_between_matched_labeled_vertices`)

`cypher-compat.md` documents both. The messages were the only thing standing
between the caller and that section, and they pointed away from it.

## What it does not change

No lowering rule moves. The same statements are accepted and the same statements
are rejected, with the same error variant — only the `feature` text differs. The
three new tests assert that a rejected statement now says where to go next; they
do not assert any new statement parses.

`cypher-compat.md` gains the one rule the list did not spell out: node patterns
inside a batch match by id alone, and a label belongs either in the `SET` of an
upsert or on the endpoints of the binding `MATCH`.

This addresses the discoverability half of #116 only. It does not add a batch
endpoint and does not lift the label restriction, so I have left the issue open
rather than closing it — the throughput and resumability parts of that report
are untouched.

## Testing

Not compiled or run locally: I have no Rust toolchain on this machine, and the
FFI dependencies (`libcypher-parser`, `libgraphblas`) do not build on Windows.

Verified by inspection instead:

- each new test query reaches the exact branch it asserts on — the labelled
  `CREATE` and the multi-hop path both go through `unwind_edge_template`, and
  the inline list is rejected before `parameter_name`;
- none of the three messages was asserted by any existing test, so no existing
  assertion is invalidated (`grep` over `src/` and `crates/`);
- the two shapes the new message recommends are the ones the two existing tests
  named above already prove parse.

Happy to adjust the wording if it is longer than you want in an error string.

Refs #116
