### PR TITLE
fix(justfile): fail fast when harness scripts are not tracked

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -33,15 +33,20 @@ silently drift into different test matrices.
 
 ## Local Harnesses
 
-| Recipe | What it runs | Output or side effect |
+The recipes below are wired in the `justfile` but their shell scripts are not
+yet tracked in this repository ([#88](https://github.com/hydra-db/hydradb/issues/88)).
+Running them prints a clear error naming the missing script. Use
+`just verify-harness-scripts` to list which scripts are present on a checkout.
+
+| Recipe | What it runs | Status |
 |---|---|---|
-| `just smoke` | Isolated local object-store write, traversal, reopen, and verification | Temporary directory removed on exit |
-| `just smoke-graphblas` | The same smoke flow with SuiteSparse selected explicitly | Temporary directory removed on exit |
-| `just query-correctness` | Exact OpenCypher result checks | `bench-results/query_correctness.csv` and `.log` |
-| `just query-bench` | Configurable cold, hot, and concurrent query benchmark | `bench-results/query_bench_full.csv` and `.log` by default |
-| `just query-memory-profile` | Build/query memory matrix with runtime-selectable kernels | Results and logs under the configured benchmark directory |
-| `just stress` | Multiprocess writes, restart recovery, compaction, GC, and verification | Temporary local stores removed on exit |
-| `just fence` | Hard SlateDB writer-takeover proof | Temporary local stores removed on exit |
+| `just smoke` | Isolated local object-store write, traversal, reopen, and verification | Available |
+| `just smoke-graphblas` | The same smoke flow with SuiteSparse selected explicitly | Available |
+| `just query-memory-profile` | Build/query memory matrix with runtime-selectable kernels | Available |
+| `just query-correctness` | Exact OpenCypher result checks | Script not tracked ([#88](https://github.com/hydra-db/hydradb/issues/88)) |
+| `just query-bench` | Configurable cold, hot, and concurrent query benchmark | Script not tracked ([#88](https://github.com/hydra-db/hydradb/issues/88)) |
+| `just stress` | Multiprocess writes, restart recovery, compaction, GC, and verification | Script not tracked ([#88](https://github.com/hydra-db/hydradb/issues/88)) |
+| `just fence` | Hard SlateDB writer-takeover proof | Script not tracked ([#88](https://github.com/hydra-db/hydradb/issues/88)) |
 
 The benchmark recipes intentionally use production-sized defaults and can run
 for a long time. Override their documented `GRAPH_QUERY_*` environment
@@ -49,14 +54,17 @@ variables for a small development sample.
 
 ## Docker And MinIO Harnesses
 
-| Recipe | Purpose |
-|---|---|
-| `just minio-smoke` | Runs the object-store smoke flow against an ephemeral MinIO container |
-| `just minio-query-correctness` | Runs exact query checks against MinIO |
-| `just minio-query-bench` | Runs the query benchmark against MinIO |
-| `just minio-chaos` | Pauses, restarts, and recovers MinIO during graph operations |
-| `just minio-fence` | Runs writer takeover against MinIO |
-| `just minio-mbt` | Replays the formal MBT adapters against MinIO; unavailable in this checkout because the referenced `tests/formal_mbt*.rs` targets are absent |
+These recipes also depend on shell scripts that are not tracked in the public
+tree ([#88](https://github.com/hydra-db/hydradb/issues/88)).
+
+| Recipe | Purpose | Status |
+|---|---|---|
+| `just minio-smoke` | Runs the object-store smoke flow against an ephemeral MinIO container | Script not tracked ([#88](https://github.com/hydra-db/hydradb/issues/88)) |
+| `just minio-query-correctness` | Runs exact query checks against MinIO | Script not tracked ([#88](https://github.com/hydra-db/hydradb/issues/88)) |
+| `just minio-query-bench` | Runs the query benchmark against MinIO | Script not tracked ([#88](https://github.com/hydra-db/hydradb/issues/88)) |
+| `just minio-chaos` | Pauses, restarts, and recovers MinIO during graph operations | Script not tracked ([#88](https://github.com/hydra-db/hydradb/issues/88)) |
+| `just minio-fence` | Runs writer takeover against MinIO | Script not tracked ([#88](https://github.com/hydra-db/hydradb/issues/88)) |
+| `just minio-mbt` | Replays the formal MBT adapters against MinIO | Script not tracked ([#88](https://github.com/hydra-db/hydradb/issues/88)) |
 
 The MinIO recipes create isolated containers, networks, buckets, and temporary
 configuration files. Their cleanup traps remove those resources unless a

--- a/README.md
+++ b/README.md
@@ -230,11 +230,11 @@ traversal, closes the database, reopens it, and verifies the durable result.
 The recipe creates and removes an isolated local object-store directory. Use
 `just smoke-graphblas` to pin the traversal kernel to SuiteSparse GraphBLAS.
 
-To exercise the same flow against an ephemeral MinIO instance:
-
-```bash
-just minio-smoke
-```
+To exercise the same flow against an ephemeral MinIO instance, use
+`just minio-smoke`. That recipe is not available on a clean checkout because the
+shell script it invokes is not tracked in this repository yet; see
+[#88](https://github.com/hydra-db/hydradb/issues/88). Until those harness
+scripts ship, `just smoke` is the supported local verification path.
 
 #### Run a local server
 

--- a/justfile
+++ b/justfile
@@ -267,20 +267,56 @@ smoke-graphblas:
     CLOUD_PROVIDER=local LOCAL_PATH="$store_root" GRAPH_MATRIX_KERNEL=graphblas \
       cargo run --locked --example object_store_smoke
 
+# Fail fast when a harness script is referenced but not shipped in this tree.
+# See https://github.com/hydra-db/hydradb/issues/88
+[private]
+_require-harness-script script:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    script="{{script}}"
+    if [[ ! -f "$script" ]]; then
+      echo "error: $script is not included in this repository checkout." >&2
+      echo "Tracked harness scripts: scripts/runtime_smoke.sh, scripts/query_memory_profile.sh, scripts/ci_local.sh" >&2
+      echo "See https://github.com/hydra-db/hydradb/issues/88 for status." >&2
+      exit 1
+    fi
+
+# List every shell script the justfile invokes and whether it is tracked.
+verify-harness-scripts:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    missing=0
+    while read -r script; do
+      if git ls-files --error-unmatch "$script" >/dev/null 2>&1; then
+        echo "OK      $script"
+      else
+        echo "MISSING $script"
+        missing=$((missing + 1))
+      fi
+    done < <(grep -oE 'scripts/[A-Za-z0-9_.-]+\.sh' justfile | sort -u)
+    if [[ "$missing" -gt 0 ]]; then
+      echo "$missing harness script(s) are not tracked; see https://github.com/hydra-db/hydradb/issues/88" >&2
+      exit 1
+    fi
+
 # Run local multiprocess stress against the local filesystem object store.
 stress:
+    @just _require-harness-script scripts/multiprocess_stress.sh
     bash scripts/multiprocess_stress.sh
 
 # Run hard write-fence takeover proof against the local filesystem object store.
 fence:
+    @just _require-harness-script scripts/fence_takeover.sh
     bash scripts/fence_takeover.sh
 
 # Run MinIO smoke test. Requires Docker.
 minio-smoke:
+    @just _require-harness-script scripts/minio_smoke.sh
     bash scripts/minio_smoke.sh
 
 # Run Query engine Cypher query benchmarks.
 query-bench:
+    @just _require-harness-script scripts/query_bench.sh
     bash scripts/query_bench.sh
 
 # Run low-memory query/build/concurrency profiling.
@@ -289,26 +325,32 @@ query-memory-profile:
 
 # Run Query engine exact query correctness benchmark.
 query-correctness:
+    @just _require-harness-script scripts/query_correctness.sh
     bash scripts/query_correctness.sh
 
 # Run Query engine Cypher query benchmarks against MinIO. Requires Docker.
 minio-query-bench:
+    @just _require-harness-script scripts/minio_query_bench.sh
     bash scripts/minio_query_bench.sh
 
 # Run Query engine exact query correctness benchmark against MinIO. Requires Docker.
 minio-query-correctness:
+    @just _require-harness-script scripts/minio_query_correctness.sh
     bash scripts/minio_query_correctness.sh
 
 # Run MinIO chaos test. Requires Docker.
 minio-chaos:
+    @just _require-harness-script scripts/minio_chaos.sh
     bash scripts/minio_chaos.sh
 
 # Run hard write-fence takeover proof against MinIO. Requires Docker.
 minio-fence:
+    @just _require-harness-script scripts/minio_fence_takeover.sh
     bash scripts/minio_fence_takeover.sh
 
 # Replay all six Quint Connect adapters against isolated MinIO paths. Requires Docker.
 minio-mbt:
+    @just _require-harness-script scripts/minio_mbt.sh
     bash scripts/minio_mbt.sh
 
 # Refresh the pinned SlateDB Git dependency in Cargo.lock.

--- a/justfile
+++ b/justfile
@@ -276,8 +276,8 @@ _require-harness-script script:
     script="{{script}}"
     if [[ ! -f "$script" ]]; then
       echo "error: $script is not included in this repository checkout." >&2
-      echo "Tracked harness scripts: scripts/runtime_smoke.sh, scripts/query_memory_profile.sh, scripts/ci_local.sh" >&2
-      echo "See https://github.com/hydra-db/hydradb/issues/88 for status." >&2
+      echo "Available harnesses on a clean checkout: smoke, smoke-graphblas, query-memory-profile." >&2
+      echo "See DEVELOPMENT.md and https://github.com/hydra-db/hydradb/issues/88 for status." >&2
       exit 1
     fi
 
@@ -293,7 +293,7 @@ verify-harness-scripts:
         echo "MISSING $script"
         missing=$((missing + 1))
       fi
-    done < <(grep -oE 'scripts/[A-Za-z0-9_.-]+\.sh' justfile | sort -u)
+    done < <(grep -E 'bash scripts/|_require-harness-script scripts/' justfile | grep -oE 'scripts/[A-Za-z0-9_.-]+\.sh' | sort -u)
     if [[ "$missing" -gt 0 ]]; then
       echo "$missing harness script(s) are not tracked; see https://github.com/hydra-db/hydradb/issues/88" >&2
       exit 1


### PR DESCRIPTION
## Summary
- Guard the ten justfile recipes that call untracked shell scripts with a clear fail-fast error pointing to #88
- Add `just verify-harness-scripts` to list which harness scripts are present on a checkout
- Update README and DEVELOPMENT.md so contributors know which harnesses are unavailable on a clean clone

## Test plan
- [ ] `just minio-smoke` prints the missing-script error instead of a bash `No such file` failure
- [ ] `just verify-harness-scripts` exits non-zero and lists the ten missing scripts
- [ ] `just smoke` and `just query-memory-profile` still work unchanged

Closes #88 (documentation and fail-fast path; the scripts themselves remain out of tree).