### PR TITLE
feat(opencypher): support ENDS WITH and CONTAINS in WHERE

### DIFF
--- a/cypher-compat.md
+++ b/cypher-compat.md
@@ -66,19 +66,23 @@ when omitted, and must not exceed the maximum.
 
 Boolean combinations of property comparisons, using `AND`, `OR` and `NOT`.
 
-Comparison operators: `=`, `<>`, `<`, `>`, `<=`, `>=`, and `STARTS WITH`.
+Comparison operators: `=`, `<>`, `<`, `>`, `<=`, `>=`, `STARTS WITH`, `ENDS WITH`,
+and `CONTAINS`.
 
 ```cypher
 MATCH (s:Score) WHERE s.score > 3.0 RETURN s.id AS score_id ORDER BY score_id
 MATCH (s:S) WHERE s.a = 1 AND (s.b > 2 OR NOT s.c = 3) RETURN s.id
 MATCH (s:Source) WHERE s.thread_id STARTS WITH $prefix RETURN s.id
+MATCH (s:Source) WHERE s.name ENDS WITH $suffix RETURN s.id
+MATCH (s:Source) WHERE s.name CONTAINS $substring RETURN s.id
 ```
 
-`STARTS WITH` needs a string literal or a parameter on the right.
+`STARTS WITH`, `ENDS WITH`, and `CONTAINS` each need a string literal or a
+parameter on the right. All three are case-sensitive. `STARTS WITH` accelerates
+through a string-property index when the query shape allows it; `ENDS WITH` and
+`CONTAINS` always scan.
 
-`IN`, `ENDS WITH`, `CONTAINS` and `IS NULL` are not supported. All four are
-rejected with the same message, that `WHERE` supports boolean combinations of
-property comparisons.
+`IN` and `IS NULL` are not supported.
 
 ### RETURN
 
@@ -263,7 +267,7 @@ Rejected at parse time, with the reason in the error:
 - `WITH` that aliases, filters, orders, or drops a binding
 - Aggregate arguments marked `DISTINCT`, and `count(DISTINCT *)`
 - Aggregates beyond `count`, `sum`, `avg` and `collect`, so no `min` or `max`
-- `IN`, `ENDS WITH`, `CONTAINS` and `IS NULL` in `WHERE`
+- `IN` and `IS NULL` in `WHERE` (use `STARTS WITH`, `ENDS WITH`, or `CONTAINS` for string filtering)
 - `MATCH` hints
 - Nested unions, mixed `UNION` and `UNION ALL`, and unions containing writes
 - Variable-length relationships in `CREATE` and `MERGE`

--- a/src/query/opencypher.rs
+++ b/src/query/opencypher.rs
@@ -247,6 +247,14 @@ pub enum RowPredicate {
         expression: RowExpression,
         prefix: String,
     },
+    EndsWith {
+        expression: RowExpression,
+        suffix: String,
+    },
+    Contains {
+        expression: RowExpression,
+        substring: String,
+    },
     And(Box<RowPredicate>, Box<RowPredicate>),
     Or(Box<RowPredicate>, Box<RowPredicate>),
     Not(Box<RowPredicate>),
@@ -2775,6 +2783,28 @@ fn lower_row_predicate(
                     prefix,
                 });
             }
+            if op == sys::CYPHER_OP_ENDS_WITH {
+                let RowExpression::Literal(VertexPropertyValue::String(suffix)) =
+                    lower_row_expression(right, parameters)?
+                else {
+                    return unsupported("ENDS WITH requires a string literal or parameter");
+                };
+                return Ok(RowPredicate::EndsWith {
+                    expression: lower_row_expression(left, parameters)?,
+                    suffix,
+                });
+            }
+            if op == sys::CYPHER_OP_CONTAINS {
+                let RowExpression::Literal(VertexPropertyValue::String(substring)) =
+                    lower_row_expression(right, parameters)?
+                else {
+                    return unsupported("CONTAINS requires a string literal or parameter");
+                };
+                return Ok(RowPredicate::Contains {
+                    expression: lower_row_expression(left, parameters)?,
+                    substring,
+                });
+            }
             if let Ok(op) = row_comparison_op(op) {
                 return Ok(RowPredicate::Compare {
                     left: lower_row_expression(left, parameters)?,
@@ -3832,6 +3862,72 @@ mod tests {
                 Some(RowPredicate::StartsWith { ref prefix, .. }) if prefix == expected
             ));
         }
+    }
+
+    #[test]
+    fn lowers_ends_with_string_predicate() {
+        let parameters = BTreeMap::from([(
+            "suffix".to_string(),
+            VertexPropertyValue::String("-hydra".to_string()),
+        )]);
+        let parsed = parse_opencypher_row_query_with_parameters(
+            "MATCH (s:Source) WHERE s.name ENDS WITH $suffix RETURN s.id",
+            &parameters,
+        )
+        .unwrap();
+        assert!(matches!(
+            parsed.predicate,
+            Some(RowPredicate::EndsWith {
+                expression: RowExpression::Property { ref binding, ref property },
+                ref suffix,
+            }) if binding == "s" && property == "name" && suffix == "-hydra"
+        ));
+    }
+
+    #[test]
+    fn lowers_contains_string_predicate() {
+        let parameters = BTreeMap::from([(
+            "substring".to_string(),
+            VertexPropertyValue::String("ydr".to_string()),
+        )]);
+        let parsed = parse_opencypher_row_query_with_parameters(
+            "MATCH (s:Source) WHERE s.name CONTAINS $substring RETURN s.id",
+            &parameters,
+        )
+        .unwrap();
+        assert!(matches!(
+            parsed.predicate,
+            Some(RowPredicate::Contains {
+                expression: RowExpression::Property { ref binding, ref property },
+                ref substring,
+            }) if binding == "s" && property == "name" && substring == "ydr"
+        ));
+    }
+
+    #[test]
+    fn ends_with_accepts_literal_on_right() {
+        let parsed = parse_opencypher_row_query_with_parameters(
+            "MATCH (s:Source) WHERE s.name ENDS WITH \"db\" RETURN s.id",
+            &BTreeMap::new(),
+        )
+        .unwrap();
+        assert!(matches!(
+            parsed.predicate,
+            Some(RowPredicate::EndsWith { ref suffix, .. }) if suffix == "db"
+        ));
+    }
+
+    #[test]
+    fn contains_accepts_literal_on_right() {
+        let parsed = parse_opencypher_row_query_with_parameters(
+            "MATCH (s:Source) WHERE s.name CONTAINS \"ydr\" RETURN s.id",
+            &BTreeMap::new(),
+        )
+        .unwrap();
+        assert!(matches!(
+            parsed.predicate,
+            Some(RowPredicate::Contains { ref substring, .. }) if substring == "ydr"
+        ));
     }
 
     #[cfg(feature = "client-api")]

--- a/src/shard/query.rs
+++ b/src/shard/query.rs
@@ -8061,7 +8061,23 @@ fn row_predicate_matches(row: &BindingRow, predicate: &RowPredicate) -> Result<b
         RowPredicate::StartsWith { expression, prefix } => {
             match eval_row_expression(row, expression)? {
                 RowScalarValue::Value(VertexPropertyValue::String(value)) => {
-                    value.starts_with(prefix)
+                    value.starts_with(prefix.as_str())
+                }
+                RowScalarValue::Value(_) | RowScalarValue::Missing => false,
+            }
+        }
+        RowPredicate::EndsWith { expression, suffix } => {
+            match eval_row_expression(row, expression)? {
+                RowScalarValue::Value(VertexPropertyValue::String(value)) => {
+                    value.ends_with(suffix.as_str())
+                }
+                RowScalarValue::Value(_) | RowScalarValue::Missing => false,
+            }
+        }
+        RowPredicate::Contains { expression, substring } => {
+            match eval_row_expression(row, expression)? {
+                RowScalarValue::Value(VertexPropertyValue::String(value)) => {
+                    value.contains(substring.as_str())
                 }
                 RowScalarValue::Value(_) | RowScalarValue::Missing => false,
             }
@@ -8100,6 +8116,7 @@ fn predicate_guarantees_string_property(
             predicate_guarantees_string_property(left, binding, property)
                 && predicate_guarantees_string_property(right, binding, property)
         }
+        RowPredicate::EndsWith { .. } | RowPredicate::Contains { .. } => false,
         RowPredicate::Compare { .. } | RowPredicate::Not(_) => false,
     }
 }
@@ -8194,9 +8211,11 @@ pub(super) fn row_predicate_relationship_property_constraint(
             }
             Some(left)
         }
-        RowPredicate::Compare { .. } | RowPredicate::StartsWith { .. } | RowPredicate::Not(_) => {
-            None
-        }
+        RowPredicate::Compare { .. }
+        | RowPredicate::StartsWith { .. }
+        | RowPredicate::EndsWith { .. }
+        | RowPredicate::Contains { .. }
+        | RowPredicate::Not(_) => None,
     }
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -11894,6 +11894,106 @@ async fn cypher_starts_with_uses_current_index_and_rejects_graph_epoch_replay() 
 
 #[cfg(feature = "opencypher")]
 #[tokio::test]
+async fn cypher_ends_with_filters_vertices_by_suffix() {
+    let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let shard = open_test_shard("graph/cypher-ends-with", object_store).await;
+
+    for (vertex, value) in [(1, "hydradb"), (2, "slatedb"), (3, "rocksdb")] {
+        shard
+            .set_vertex_metadata(
+                "cell-0",
+                vertex,
+                VertexMetadata::default()
+                    .with_label("Source")
+                    .with_property("name", VertexPropertyValue::String(value.to_string())),
+            )
+            .await
+            .unwrap();
+    }
+
+    let rows = shard
+        .execute_cypher_rows(
+            QueryContext::new("cell-0", "ends-with-db")
+                .with_parameter("suffix", VertexPropertyValue::String("db".to_string())),
+            "MATCH (s:Source) WHERE s.name ENDS WITH $suffix RETURN s.id ORDER BY s.id",
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        rows.rows,
+        vec![
+            QueryRow::new(vec![QueryValue::VertexId(1)]),
+            QueryRow::new(vec![QueryValue::VertexId(2)]),
+            QueryRow::new(vec![QueryValue::VertexId(3)]),
+        ]
+    );
+
+    let rows_literal = shard
+        .execute_cypher_rows(
+            QueryContext::new("cell-0", "ends-with-literal"),
+            "MATCH (s:Source) WHERE s.name ENDS WITH \"slatedb\" RETURN s.id",
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        rows_literal.rows,
+        vec![QueryRow::new(vec![QueryValue::VertexId(2)])]
+    );
+}
+
+#[cfg(feature = "opencypher")]
+#[tokio::test]
+async fn cypher_contains_filters_vertices_by_substring() {
+    let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let shard = open_test_shard("graph/cypher-contains", object_store).await;
+
+    for (vertex, value) in [(1, "hydradb"), (2, "hydra-graph"), (3, "slatedb")] {
+        shard
+            .set_vertex_metadata(
+                "cell-0",
+                vertex,
+                VertexMetadata::default()
+                    .with_label("Source")
+                    .with_property("name", VertexPropertyValue::String(value.to_string())),
+            )
+            .await
+            .unwrap();
+    }
+
+    let rows = shard
+        .execute_cypher_rows(
+            QueryContext::new("cell-0", "contains-hydra")
+                .with_parameter(
+                    "substring",
+                    VertexPropertyValue::String("hydra".to_string()),
+                ),
+            "MATCH (s:Source) WHERE s.name CONTAINS $substring RETURN s.id ORDER BY s.id",
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        rows.rows,
+        vec![
+            QueryRow::new(vec![QueryValue::VertexId(1)]),
+            QueryRow::new(vec![QueryValue::VertexId(2)]),
+        ]
+    );
+
+    let rows_literal = shard
+        .execute_cypher_rows(
+            QueryContext::new("cell-0", "contains-literal"),
+            "MATCH (s:Source) WHERE s.name CONTAINS \"slate\" RETURN s.id",
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        rows_literal.rows,
+        vec![QueryRow::new(vec![QueryValue::VertexId(3)])]
+    );
+}
+
+#[cfg(feature = "opencypher")]
+#[tokio::test]
 async fn cypher_tck_style_row_corpus_covers_supported_clause_semantics() {
     let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
     let shard = open_test_shard("graph/cypher-tck-style-corpus", object_store).await;


### PR DESCRIPTION
Closes #130

Summary

Adds support for ENDS WITH suffix match and CONTAINS substring match string predicates in Hydras OpenCypher WHERE clause alongside the existing STARTS WITH operator

Scope and Implementation Details

Lowering src query opencypher rs

Added RowPredicate EndsWith and Contains enum variants

Lowered sys CYPHER OP ENDS WITH and sys CYPHER OP CONTAINS matching the STARTS WITH shape accepting string literals or parameters

Execution src shard query rs

Implemented evaluation in row predicate matches using str ends with and str contains

Missing and non string values safely evaluate to false

Kept prefix index seeding exclusive to STARTS WITH scan only for suffix and substring

Updated predicate guarantees string property and row predicate relationship property constraint to safely handle the new variants

Tests src query opencypher rs and src tests rs

Parser and lowering unit tests for literals and parameters

Execution regression tests against live shard

Documentation cypher compat md

Updated operator list and documented scan only contract for ENDS WITH and CONTAINS

Non goals

No index pushdown for suffix or substring scan only first version

No regular expressions IN or IS NULL

No modification to existing STARTS WITH index optimization
