### PR TITLE
fix(http): map write and idempotency conflicts to 409 Conflict

### DIFF
--- a/src/client/http.rs
+++ b/src/client/http.rs
@@ -413,6 +413,29 @@ impl HttpApiError {
                 owner: owner.clone(),
                 authenticate: false,
             },
+            GraphError::IdempotencyConflict { .. } => Self {
+                status: StatusCode::CONFLICT,
+                code: "idempotency_conflict",
+                message: error.to_string(),
+                owner: None,
+                authenticate: false,
+            },
+            GraphError::ConditionalWriteConflict { .. } => Self {
+                status: StatusCode::CONFLICT,
+                code: "write_conflict",
+                message: error.to_string(),
+                owner: None,
+                authenticate: false,
+            },
+            GraphError::ReadOnlyShardStorage
+            | GraphError::UnsafeDurabilityConfig { .. }
+            | GraphError::RoutedWriterConfigMismatch { .. } => Self {
+                status: StatusCode::BAD_REQUEST,
+                code: "invalid_configuration",
+                message: error.to_string(),
+                owner: None,
+                authenticate: false,
+            },
             GraphError::InvalidKeyComponent { .. }
             | GraphError::GraphScopeMismatch { .. }
             | GraphError::MissingQueryParameter { .. }

--- a/src/client/http/tests.rs
+++ b/src/client/http/tests.rs
@@ -171,6 +171,45 @@ fn a_routing_refusal_is_a_503_and_not_an_internal_error() {
     );
 }
 
+#[test]
+fn an_idempotency_conflict_is_a_409_conflict_and_names_reason() {
+    let conflict = HttpApiError::from_graph(GraphError::IdempotencyConflict {
+        operation: "write_edge",
+        idempotency_key: "key-123".to_string(),
+        reason: "payload mismatch",
+    });
+    assert_eq!(conflict.status, StatusCode::CONFLICT);
+    assert_eq!(conflict.code, "idempotency_conflict");
+    assert!(
+        conflict.message.contains("key-123"),
+        "idempotency key must survive: {}",
+        conflict.message
+    );
+    assert!(
+        conflict.message.contains("payload mismatch"),
+        "reason must survive: {}",
+        conflict.message
+    );
+}
+
+#[test]
+fn a_conditional_write_conflict_is_a_409_conflict() {
+    let conflict = HttpApiError::from_graph(GraphError::ConditionalWriteConflict {
+        operation: "update_manifest",
+        key: "manifest-1".to_string(),
+    });
+    assert_eq!(conflict.status, StatusCode::CONFLICT);
+    assert_eq!(conflict.code, "write_conflict");
+    assert!(conflict.message.contains("manifest-1"));
+}
+
+#[test]
+fn a_configuration_error_is_a_400_bad_request() {
+    let config_err = HttpApiError::from_graph(GraphError::ReadOnlyShardStorage);
+    assert_eq!(config_err.status, StatusCode::BAD_REQUEST);
+    assert_eq!(config_err.code, "invalid_configuration");
+}
+
 #[tokio::test]
 async fn http_api_enforces_auth_scope_and_returns_typed_json() {
     let backend = Arc::new(HttpTestClient {


### PR DESCRIPTION
When a request encounters an idempotency key conflict or a conditional write conflict Bolt maps it to a client visible ClientError so clients stop retrying and can diagnose colliding keys

On the HTTP adapter these errors as well as configuration errors were not handled in HttpApiError from graph ref causing them to fall through to the catch all and return 500 Internal Server Error with internal query execution error

Changes

HTTP Error Mapping

GraphError IdempotencyConflict mapped to 409 Conflict with error code idempotency conflict

GraphError ConditionalWriteConflict mapped to 409 Conflict with error code write conflict

GraphError ReadOnlyShardStorage GraphError UnsafeDurabilityConfig and GraphError RoutedWriterConfigMismatch mapped to 400 Bad Request with error code invalid configuration

Tests

Added an idempotency conflict test verifying status 409 and that both the key and reason survive in the error message

Added a conditional write conflict test verifying status 409

Added a configuration error test verifying status 400