### PR TITLE
feat(opencypher): support min and max aggregate functions

### DIFF
--- a/cypher-compat.md
+++ b/cypher-compat.md
@@ -85,7 +85,7 @@ property comparisons.
 Projections are `<binding>.<property>` or an aggregate. `RETURN *` is not
 executable, so name what you want.
 
-Aggregates: `count`, `sum`, `avg`, `collect`. `count(*)` is supported.
+Aggregates: `count`, `sum`, `avg`, `min`, `max`, `collect`. `count(*)` is supported.
 `DISTINCT` inside an aggregate argument is not, and neither is `count(DISTINCT *)`.
 
 `ORDER BY` accepts a projected alias, `<binding>.id`, or `count(*)`, ascending
@@ -262,7 +262,7 @@ Rejected at parse time, with the reason in the error:
 - Unbounded variable-length traversal, `*` or `*1..`
 - `WITH` that aliases, filters, orders, or drops a binding
 - Aggregate arguments marked `DISTINCT`, and `count(DISTINCT *)`
-- Aggregates beyond `count`, `sum`, `avg` and `collect`, so no `min` or `max`
+- Aggregates beyond `count`, `sum`, `avg`, `min`, `max`, and `collect`
 - `IN`, `ENDS WITH`, `CONTAINS` and `IS NULL` in `WHERE`
 - `MATCH` hints
 - Nested unions, mixed `UNION` and `UNION ALL`, and unions containing writes

--- a/src/query/opencypher.rs
+++ b/src/query/opencypher.rs
@@ -174,6 +174,8 @@ pub enum RowAggregateFunction {
     Count,
     Sum,
     Avg,
+    Min,
+    Max,
     Collect,
 }
 
@@ -2880,6 +2882,10 @@ fn row_aggregate_function(name: &str) -> Option<RowAggregateFunction> {
         Some(RowAggregateFunction::Sum)
     } else if name.eq_ignore_ascii_case("avg") {
         Some(RowAggregateFunction::Avg)
+    } else if name.eq_ignore_ascii_case("min") {
+        Some(RowAggregateFunction::Min)
+    } else if name.eq_ignore_ascii_case("max") {
+        Some(RowAggregateFunction::Max)
     } else if name.eq_ignore_ascii_case("collect") {
         Some(RowAggregateFunction::Collect)
     } else {
@@ -2892,6 +2898,8 @@ fn aggregate_function_name(function: RowAggregateFunction) -> &'static str {
         RowAggregateFunction::Count => "count",
         RowAggregateFunction::Sum => "sum",
         RowAggregateFunction::Avg => "avg",
+        RowAggregateFunction::Min => "min",
+        RowAggregateFunction::Max => "max",
         RowAggregateFunction::Collect => "collect",
     }
 }
@@ -3832,6 +3840,29 @@ mod tests {
                 Some(RowPredicate::StartsWith { ref prefix, .. }) if prefix == expected
             ));
         }
+    }
+
+    #[test]
+    fn lowers_min_and_max_aggregates() {
+        let min_query = "MATCH (s:Source) RETURN min(s.weight) AS min_val";
+        let parsed_min = parse_opencypher_row_query_with_parameters(min_query, &BTreeMap::new()).unwrap();
+        assert!(matches!(
+            parsed_min.projections.as_slice(),
+            [RowProjection::Aggregate {
+                function: RowAggregateFunction::Min,
+                expression: RowExpression::Property { ref binding, ref property },
+            }] if binding == "s" && property == "weight"
+        ));
+
+        let max_query = "MATCH (s:Source) RETURN max(s.weight) AS max_val";
+        let parsed_max = parse_opencypher_row_query_with_parameters(max_query, &BTreeMap::new()).unwrap();
+        assert!(matches!(
+            parsed_max.projections.as_slice(),
+            [RowProjection::Aggregate {
+                function: RowAggregateFunction::Max,
+                expression: RowExpression::Property { ref binding, ref property },
+            }] if binding == "s" && property == "weight"
+        ));
     }
 
     #[cfg(feature = "client-api")]

--- a/src/shard/query.rs
+++ b/src/shard/query.rs
@@ -7866,6 +7866,8 @@ enum AggregateAccumulator {
     CountExpression(u64),
     Sum(u128),
     Avg { sum: u128, count: u64 },
+    Min(Option<QueryValue>),
+    Max(Option<QueryValue>),
     Collect(Vec<QueryValue>),
 }
 
@@ -8607,6 +8609,8 @@ fn new_aggregate_accumulator(projection: &RowProjection) -> Result<AggregateAccu
             RowAggregateFunction::Count => AggregateAccumulator::CountExpression(0),
             RowAggregateFunction::Sum => AggregateAccumulator::Sum(0),
             RowAggregateFunction::Avg => AggregateAccumulator::Avg { sum: 0, count: 0 },
+            RowAggregateFunction::Min => AggregateAccumulator::Min(None),
+            RowAggregateFunction::Max => AggregateAccumulator::Max(None),
             RowAggregateFunction::Collect => AggregateAccumulator::Collect(Vec::new()),
         },
         _ => {
@@ -8673,6 +8677,46 @@ fn apply_aggregate_projection(
             }
         }
         (
+            AggregateAccumulator::Min(min_val),
+            RowProjection::Aggregate {
+                function: RowAggregateFunction::Min,
+                expression,
+            },
+        ) => {
+            if let Some(value) = expression_query_value(row, expression)? {
+                if !matches!(value, QueryValue::Null) {
+                    match min_val {
+                        None => *min_val = Some(value),
+                        Some(current) => {
+                            if compare_query_values(&value, current) == std::cmp::Ordering::Less {
+                                *min_val = Some(value);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        (
+            AggregateAccumulator::Max(max_val),
+            RowProjection::Aggregate {
+                function: RowAggregateFunction::Max,
+                expression,
+            },
+        ) => {
+            if let Some(value) = expression_query_value(row, expression)? {
+                if !matches!(value, QueryValue::Null) {
+                    match max_val {
+                        None => *max_val = Some(value),
+                        Some(current) => {
+                            if compare_query_values(&value, current) == std::cmp::Ordering::Greater {
+                                *max_val = Some(value);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        (
             AggregateAccumulator::Collect(values),
             RowProjection::Aggregate {
                 function: RowAggregateFunction::Collect,
@@ -8726,6 +8770,9 @@ fn finalize_aggregate(state: &AggregateAccumulator) -> Result<QueryValue> {
         AggregateAccumulator::Avg { sum: _, count: 0 } => QueryValue::Null,
         AggregateAccumulator::Avg { sum, count } => {
             QueryValue::Float(QueryFloat(*sum as f64 / *count as f64))
+        }
+        AggregateAccumulator::Min(value) | AggregateAccumulator::Max(value) => {
+            value.clone().unwrap_or(QueryValue::Null)
         }
         AggregateAccumulator::Collect(values) => QueryValue::List(values.clone()),
     })

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -11894,6 +11894,57 @@ async fn cypher_starts_with_uses_current_index_and_rejects_graph_epoch_replay() 
 
 #[cfg(feature = "opencypher")]
 #[tokio::test]
+async fn cypher_min_max_aggregates_compute_correctly() {
+    let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let shard = open_test_shard("graph/cypher-min-max-aggregates", object_store).await;
+
+    for (vertex, score, name) in [(1, 10, "alice"), (2, 30, "bob"), (3, 20, "carol")] {
+        shard
+            .set_vertex_metadata(
+                "cell-0",
+                vertex,
+                VertexMetadata::default()
+                    .with_label("User")
+                    .with_property("score", VertexPropertyValue::Integer(score))
+                    .with_property("name", VertexPropertyValue::String(name.to_string())),
+            )
+            .await
+            .unwrap();
+    }
+
+    let min_max = shard
+        .execute_cypher_rows(
+            QueryContext::new("cell-0", "min-max-score"),
+            "MATCH (u:User) RETURN min(u.score) AS min_score, max(u.score) AS max_score",
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        min_max.rows,
+        vec![QueryRow::new(vec![
+            QueryValue::Property(VertexPropertyValue::Integer(10)),
+            QueryValue::Property(VertexPropertyValue::Integer(30)),
+        ])]
+    );
+
+    let min_max_str = shard
+        .execute_cypher_rows(
+            QueryContext::new("cell-0", "min-max-name"),
+            "MATCH (u:User) RETURN min(u.name) AS min_name, max(u.name) AS max_name",
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        min_max_str.rows,
+        vec![QueryRow::new(vec![
+            QueryValue::Property(VertexPropertyValue::String("alice".to_string())),
+            QueryValue::Property(VertexPropertyValue::String("carol".to_string())),
+        ])]
+    );
+}
+
+#[cfg(feature = "opencypher")]
+#[tokio::test]
 async fn cypher_tck_style_row_corpus_covers_supported_clause_semantics() {
     let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
     let shard = open_test_shard("graph/cypher-tck-style-corpus", object_store).await;


### PR DESCRIPTION
Summary

Adds support for min and max aggregate functions in Hydras OpenCypher query engine completing the standard scalar aggregation set alongside count sum avg and collect

Changes

AST and Lowering src query opencypher rs

Added Min and Max variants to RowAggregateFunction

Updated row aggregate function and aggregate function name to recognize min and max

Added parser unit test for min and max aggregates

Aggregation Execution src shard query rs

Added Min and Max to AggregateAccumulator

Implemented aggregation evaluation using compare query values to support minimum and maximum computation across integers floats and strings while ignoring nulls per OpenCypher standard

In finalize aggregate return the evaluated property value or QueryValue Null if empty

Execution Tests src tests rs

Added an end to end test verifying min and max aggregation on a test shard

Documentation cypher compat md

Updated the list of supported aggregation functions to include min and max
