### PR TITLE
fix(admin): default admin server to loopback

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,9 +148,15 @@ docker run --rm \
   -e GRAPH_DATA_CACHE_DIR=/data/cache \
   -e GRAPH_AUTH_TOKEN_FILE=/data/auth-token \
   -e GRAPH_ALLOW_PLAINTEXT=true \
+  -e GRAPH_ADMIN_ADDR=0.0.0.0:9090 \
   -e RUST_MIN_STACK=33554432 \
   ghcr.io/hydra-db/hydradb:latest
 ```
+
+`GRAPH_ADMIN_ADDR=0.0.0.0:9090` is required here so `-p 9090:9090` can reach the
+admin server from the host. The binary defaults to `127.0.0.1:9090`, which keeps
+`/metrics` and `/readyz` off the LAN unless you opt in. Do not publish the admin
+port on untrusted networks without a firewall or NetworkPolicy in front of it.
 
 The node runs in the foreground. `LOCAL_PATH` must point at a directory that
 already exists, which is why `hydradb-data/store` is created before the mount.

--- a/src/bin/graph-indexer.rs
+++ b/src/bin/graph-indexer.rs
@@ -860,7 +860,7 @@ async fn main() -> RuntimeResult<()> {
         max_wal_tail_files,
         ..GraphLimits::default()
     };
-    let admin_addr = env_value("GRAPH_INDEXER_ADMIN_ADDR", "0.0.0.0:9091").parse::<SocketAddr>()?;
+    let admin_addr = env_value("GRAPH_INDEXER_ADMIN_ADDR", "127.0.0.1:9091").parse::<SocketAddr>()?;
 
     let metrics = Arc::new(IndexerMetrics::default());
     let admin = IndexerAdminServer::bind(admin_addr, Arc::clone(&metrics)).await?;

--- a/src/bin/graph_node/admin.rs
+++ b/src/bin/graph_node/admin.rs
@@ -596,6 +596,7 @@ impl AdminServer {
 
     fn serve(listener: TcpListener, local_addr: SocketAddr, state: AdminState) -> Result<Self> {
         let router = Router::new()
+            // Bind address is chosen by GRAPH_ADMIN_ADDR; default is loopback-only.
             .route("/livez", get(live))
             .route("/readyz", get(readiness))
             .route("/metrics", get(metrics))

--- a/src/bin/graph_node/config.rs
+++ b/src/bin/graph_node/config.rs
@@ -226,7 +226,7 @@ impl RuntimeConfig {
             writer_lease_duration,
             bolt_addr: parse_socket(&values, "GRAPH_BOLT_ADDR", "0.0.0.0:7687")?,
             http_addr: parse_socket(&values, "GRAPH_HTTP_ADDR", "0.0.0.0:8443")?,
-            admin_addr: parse_socket(&values, "GRAPH_ADMIN_ADDR", "0.0.0.0:9090")?,
+            admin_addr: parse_socket(&values, "GRAPH_ADMIN_ADDR", "127.0.0.1:9090")?,
             bolt_node_addresses,
             auth_token_file: PathBuf::from(value(
                 &values,
@@ -517,6 +517,10 @@ mod tests {
         assert_eq!(config.bolt_authentication_timeout, Duration::from_secs(30));
         assert_eq!(config.bolt_idle_timeout, Duration::from_secs(15 * 60));
         assert_eq!(config.bolt_max_connection_age, Duration::from_secs(60 * 60));
+        assert_eq!(
+            config.admin_addr,
+            "127.0.0.1:9090".parse().expect("admin addr")
+        );
         let memory = config.graph_memory_config();
         assert_eq!(memory.max_graphblas_bytes, 128 * 1024 * 1024);
         assert_eq!(memory.max_matrix_adjacency_bytes, 0);


### PR DESCRIPTION
## Summary

Addresses the OpenHack finding on unauthenticated admin/metrics exposure: graph-node and graph-indexer now default admin listeners to loopback instead of 0.0.0.0.

- GRAPH_ADMIN_ADDR default: 127.0.0.1:9090 (was 0.0.0.0:9090)
- GRAPH_INDEXER_ADMIN_ADDR default: 127.0.0.1:9091 (was 0.0.0.0:9091)
- Helm chart keeps explicit 0.0.0.0 bindings for in-cluster probes (unchanged)
- Docker quickstart sets GRAPH_ADMIN_ADDR=0.0.0.0:9090 when publishing -p 9090:9090

## Test plan

- [x] config unit test asserts loopback default for admin_addr
- [ ] just test (config module)
- [ ] runtime_smoke.sh still passes with explicit GRAPH_ADMIN_ADDR