### PR TITLE
feat(opencypher): support IS NULL and IS NOT NULL predicates in WHERE

### DIFF
--- a/cypher-compat.md
+++ b/cypher-compat.md
@@ -74,11 +74,9 @@ MATCH (s:S) WHERE s.a = 1 AND (s.b > 2 OR NOT s.c = 3) RETURN s.id
 MATCH (s:Source) WHERE s.thread_id STARTS WITH $prefix RETURN s.id
 ```
 
-`STARTS WITH` needs a string literal or a parameter on the right.
+`STARTS WITH` needs a string literal or a parameter on the right. `IS NULL` and `IS NOT NULL` test property absence or presence.
 
-`IN`, `ENDS WITH`, `CONTAINS` and `IS NULL` are not supported. All four are
-rejected with the same message, that `WHERE` supports boolean combinations of
-property comparisons.
+`IN` is not supported. It is rejected with the message that `WHERE` supports boolean combinations of property comparisons.
 
 ### RETURN
 
@@ -263,7 +261,7 @@ Rejected at parse time, with the reason in the error:
 - `WITH` that aliases, filters, orders, or drops a binding
 - Aggregate arguments marked `DISTINCT`, and `count(DISTINCT *)`
 - Aggregates beyond `count`, `sum`, `avg` and `collect`, so no `min` or `max`
-- `IN`, `ENDS WITH`, `CONTAINS` and `IS NULL` in `WHERE`
+- `IN` in `WHERE`
 - `MATCH` hints
 - Nested unions, mixed `UNION` and `UNION ALL`, and unions containing writes
 - Variable-length relationships in `CREATE` and `MERGE`

--- a/src/query/opencypher.rs
+++ b/src/query/opencypher.rs
@@ -247,6 +247,8 @@ pub enum RowPredicate {
         expression: RowExpression,
         prefix: String,
     },
+    IsNull(RowExpression),
+    IsNotNull(RowExpression),
     And(Box<RowPredicate>, Box<RowPredicate>),
     Or(Box<RowPredicate>, Box<RowPredicate>),
     Not(Box<RowPredicate>),
@@ -2792,6 +2794,14 @@ fn lower_row_predicate(
                     arg, parameters,
                 )?)));
             }
+            if op == sys::CYPHER_OP_IS_NULL {
+                let arg = checked_node(sys::cypher_ast_unary_operator_get_argument(predicate))?;
+                return Ok(RowPredicate::IsNull(lower_row_expression(arg, parameters)?));
+            }
+            if op == sys::CYPHER_OP_IS_NOT_NULL {
+                let arg = checked_node(sys::cypher_ast_unary_operator_get_argument(predicate))?;
+                return Ok(RowPredicate::IsNotNull(lower_row_expression(arg, parameters)?));
+            }
         }
     }
     unsupported("WHERE currently supports boolean combinations of property comparisons")
@@ -3832,6 +3842,25 @@ mod tests {
                 Some(RowPredicate::StartsWith { ref prefix, .. }) if prefix == expected
             ));
         }
+    }
+
+    #[test]
+    fn lowers_is_null_and_is_not_null_predicates() {
+        let is_null_query = "MATCH (s:Source) WHERE s.deleted_at IS NULL RETURN s.id";
+        let parsed_null = parse_opencypher_row_query_with_parameters(is_null_query, &BTreeMap::new()).unwrap();
+        assert!(matches!(
+            parsed_null.predicate,
+            Some(RowPredicate::IsNull(RowExpression::Property { ref binding, ref property }))
+                if binding == "s" && property == "deleted_at"
+        ));
+
+        let is_not_null_query = "MATCH (s:Source) WHERE s.email IS NOT NULL RETURN s.id";
+        let parsed_not_null = parse_opencypher_row_query_with_parameters(is_not_null_query, &BTreeMap::new()).unwrap();
+        assert!(matches!(
+            parsed_not_null.predicate,
+            Some(RowPredicate::IsNotNull(RowExpression::Property { ref binding, ref property }))
+                if binding == "s" && property == "email"
+        ));
     }
 
     #[cfg(feature = "client-api")]

--- a/src/shard/query.rs
+++ b/src/shard/query.rs
@@ -8066,6 +8066,18 @@ fn row_predicate_matches(row: &BindingRow, predicate: &RowPredicate) -> Result<b
                 RowScalarValue::Value(_) | RowScalarValue::Missing => false,
             }
         }
+        RowPredicate::IsNull(expression) => {
+            match eval_row_expression(row, expression)? {
+                RowScalarValue::Missing => true,
+                RowScalarValue::Value(_) => false,
+            }
+        }
+        RowPredicate::IsNotNull(expression) => {
+            match eval_row_expression(row, expression)? {
+                RowScalarValue::Missing => false,
+                RowScalarValue::Value(_) => true,
+            }
+        }
         RowPredicate::And(left, right) => {
             row_predicate_matches(row, left)? && row_predicate_matches(row, right)?
         }
@@ -8100,7 +8112,10 @@ fn predicate_guarantees_string_property(
             predicate_guarantees_string_property(left, binding, property)
                 && predicate_guarantees_string_property(right, binding, property)
         }
-        RowPredicate::Compare { .. } | RowPredicate::Not(_) => false,
+        RowPredicate::Compare { .. }
+        | RowPredicate::IsNull(_)
+        | RowPredicate::IsNotNull(_)
+        | RowPredicate::Not(_) => false,
     }
 }
 
@@ -8194,7 +8209,11 @@ pub(super) fn row_predicate_relationship_property_constraint(
             }
             Some(left)
         }
-        RowPredicate::Compare { .. } | RowPredicate::StartsWith { .. } | RowPredicate::Not(_) => {
+        RowPredicate::Compare { .. }
+        | RowPredicate::StartsWith { .. }
+        | RowPredicate::IsNull(_)
+        | RowPredicate::IsNotNull(_)
+        | RowPredicate::Not(_) => {
             None
         }
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -11894,6 +11894,60 @@ async fn cypher_starts_with_uses_current_index_and_rejects_graph_epoch_replay() 
 
 #[cfg(feature = "opencypher")]
 #[tokio::test]
+async fn cypher_is_null_and_is_not_null_predicates_filter_rows_correctly() {
+    let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let shard = open_test_shard("graph/cypher-is-null-predicates", object_store).await;
+
+    shard
+        .set_vertex_metadata(
+            "cell-0",
+            1,
+            VertexMetadata::default()
+                .with_label("User")
+                .with_property("name", VertexPropertyValue::String("alice".to_string()))
+                .with_property("email", VertexPropertyValue::String("alice@example.com".to_string())),
+        )
+        .await
+        .unwrap();
+
+    shard
+        .set_vertex_metadata(
+            "cell-0",
+            2,
+            VertexMetadata::default()
+                .with_label("User")
+                .with_property("name", VertexPropertyValue::String("bob".to_string())),
+        )
+        .await
+        .unwrap();
+
+    let not_null = shard
+        .execute_cypher_rows(
+            QueryContext::new("cell-0", "is-not-null-query"),
+            "MATCH (u:User) WHERE u.email IS NOT NULL RETURN u.id AS id",
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        not_null.rows,
+        vec![QueryRow::new(vec![QueryValue::VertexId(1)])]
+    );
+
+    let is_null = shard
+        .execute_cypher_rows(
+            QueryContext::new("cell-0", "is-null-query"),
+            "MATCH (u:User) WHERE u.email IS NULL RETURN u.id AS id",
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        is_null.rows,
+        vec![QueryRow::new(vec![QueryValue::VertexId(2)])]
+    );
+}
+
+#[cfg(feature = "opencypher")]
+#[tokio::test]
 async fn cypher_tck_style_row_corpus_covers_supported_clause_semantics() {
     let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
     let shard = open_test_shard("graph/cypher-tck-style-corpus", object_store).await;


### PR DESCRIPTION
Adds support for IS NULL and IS NOT NULL property predicates in OpenCypher WHERE clauses enabling filtering based on property absence or presence

**Changes**

AST and Lowering src query opencypher rs

Added IsNull and IsNotNull variants to RowPredicate

Updated lower row predicate to handle unary operator AST nodes for IS NULL and IS NOT NULL

Added unit test for IS NULL and IS NOT NULL predicates

Predicate Evaluation src shard query rs

Implemented evaluation in row predicate matches

IsNull evaluates to true when the expression resolves to Missing

IsNotNull evaluates to true when the expression resolves to a Value

Handled the new variants in predicate guarantees string property and row predicate relationship property constraint

Execution Tests src tests rs

Added an end to end test verifying row filtering for present and missing properties

Documentation cypher compat md

Documented support for IS NULL and IS NOT NULL in WHERE clauses and removed IS NULL from the unsupported list
