### PR TITLE
feat(opencypher): support IN list membership predicate in WHERE

### DIFF
--- a/cypher-compat.md
+++ b/cypher-compat.md
@@ -74,9 +74,9 @@ MATCH (s:S) WHERE s.a = 1 AND (s.b > 2 OR NOT s.c = 3) RETURN s.id
 MATCH (s:Source) WHERE s.thread_id STARTS WITH $prefix RETURN s.id
 ```
 
-`STARTS WITH` needs a string literal or a parameter on the right.
+`STARTS WITH` needs a string literal or a parameter on the right. `IN` tests membership in a list literal of property values.
 
-`IN`, `ENDS WITH`, `CONTAINS` and `IS NULL` are not supported. All four are
+`ENDS WITH`, `CONTAINS` and `IS NULL` are not supported. All three are
 rejected with the same message, that `WHERE` supports boolean combinations of
 property comparisons.
 
@@ -263,7 +263,7 @@ Rejected at parse time, with the reason in the error:
 - `WITH` that aliases, filters, orders, or drops a binding
 - Aggregate arguments marked `DISTINCT`, and `count(DISTINCT *)`
 - Aggregates beyond `count`, `sum`, `avg` and `collect`, so no `min` or `max`
-- `IN`, `ENDS WITH`, `CONTAINS` and `IS NULL` in `WHERE`
+- `ENDS WITH`, `CONTAINS` and `IS NULL` in `WHERE`
 - `MATCH` hints
 - Nested unions, mixed `UNION` and `UNION ALL`, and unions containing writes
 - Variable-length relationships in `CREATE` and `MERGE`

--- a/src/query/opencypher.rs
+++ b/src/query/opencypher.rs
@@ -247,6 +247,10 @@ pub enum RowPredicate {
         expression: RowExpression,
         prefix: String,
     },
+    In {
+        expression: RowExpression,
+        values: Vec<VertexPropertyValue>,
+    },
     And(Box<RowPredicate>, Box<RowPredicate>),
     Or(Box<RowPredicate>, Box<RowPredicate>),
     Not(Box<RowPredicate>),
@@ -2775,6 +2779,12 @@ fn lower_row_predicate(
                     prefix,
                 });
             }
+            if op == sys::CYPHER_OP_IN {
+                return Ok(RowPredicate::In {
+                    expression: lower_row_expression(left, parameters)?,
+                    values: lower_row_list_values(right, parameters)?,
+                });
+            }
             if let Ok(op) = row_comparison_op(op) {
                 return Ok(RowPredicate::Compare {
                     left: lower_row_expression(left, parameters)?,
@@ -2837,6 +2847,24 @@ fn lower_row_expression(
     Ok(RowExpression::Literal(scalar_property_value(
         expression, parameters,
     )?))
+}
+
+fn lower_row_list_values(
+    node: *const AstNode,
+    parameters: &BTreeMap<String, VertexPropertyValue>,
+) -> Result<Vec<VertexPropertyValue>> {
+    unsafe {
+        if is_instance(node, sys::CYPHER_AST_COLLECTION) {
+            let count = sys::cypher_ast_collection_nelements(node);
+            let mut values = Vec::with_capacity(count as usize);
+            for idx in 0..count {
+                let elem = checked_node(sys::cypher_ast_collection_get_element(node, idx))?;
+                values.push(scalar_property_value(elem, parameters)?);
+            }
+            return Ok(values);
+        }
+    }
+    unsupported("IN predicate requires a list literal of property values")
 }
 
 fn lower_row_aggregate_expression(
@@ -3832,6 +3860,24 @@ mod tests {
                 Some(RowPredicate::StartsWith { ref prefix, .. }) if prefix == expected
             ));
         }
+    }
+
+    #[test]
+    fn lowers_in_collection_predicate() {
+        let query = "MATCH (s:Source) WHERE s.role IN ['admin', 'moderator'] RETURN s.id";
+        let parsed = parse_opencypher_row_query_with_parameters(query, &BTreeMap::new()).unwrap();
+        assert!(matches!(
+            parsed.predicate,
+            Some(RowPredicate::In {
+                expression: RowExpression::Property { ref binding, ref property },
+                ref values,
+            }) if binding == "s"
+                && property == "role"
+                && values == &[
+                    VertexPropertyValue::String("admin".to_string()),
+                    VertexPropertyValue::String("moderator".to_string()),
+                ]
+        ));
     }
 
     #[cfg(feature = "client-api")]

--- a/src/shard/query.rs
+++ b/src/shard/query.rs
@@ -8066,6 +8066,14 @@ fn row_predicate_matches(row: &BindingRow, predicate: &RowPredicate) -> Result<b
                 RowScalarValue::Value(_) | RowScalarValue::Missing => false,
             }
         }
+        RowPredicate::In { expression, values } => {
+            match eval_row_expression(row, expression)? {
+                RowScalarValue::Value(val) => {
+                    values.iter().any(|v| vertex_property_values_equal(&val, v))
+                }
+                RowScalarValue::Missing => false,
+            }
+        }
         RowPredicate::And(left, right) => {
             row_predicate_matches(row, left)? && row_predicate_matches(row, right)?
         }
@@ -8100,7 +8108,7 @@ fn predicate_guarantees_string_property(
             predicate_guarantees_string_property(left, binding, property)
                 && predicate_guarantees_string_property(right, binding, property)
         }
-        RowPredicate::Compare { .. } | RowPredicate::Not(_) => false,
+        RowPredicate::Compare { .. } | RowPredicate::In { .. } | RowPredicate::Not(_) => false,
     }
 }
 
@@ -8179,6 +8187,14 @@ pub(super) fn row_predicate_relationship_property_constraint(
             right,
         } => row_property_literal_equality(left, right)
             .or_else(|| row_property_literal_equality(right, left)),
+        RowPredicate::In {
+            expression: RowExpression::Property { binding, property },
+            values,
+        } => Some(RowPredicateRelationshipPropertyConstraint {
+            binding: binding.clone(),
+            property: property.clone(),
+            values: values.clone(),
+        }),
         RowPredicate::And(left, right) => row_predicate_relationship_property_constraint(left)
             .or_else(|| row_predicate_relationship_property_constraint(right)),
         RowPredicate::Or(left, right) => {
@@ -8194,7 +8210,7 @@ pub(super) fn row_predicate_relationship_property_constraint(
             }
             Some(left)
         }
-        RowPredicate::Compare { .. } | RowPredicate::StartsWith { .. } | RowPredicate::Not(_) => {
+        RowPredicate::Compare { .. } | RowPredicate::StartsWith { .. } | RowPredicate::In { .. } | RowPredicate::Not(_) => {
             None
         }
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -11894,6 +11894,59 @@ async fn cypher_starts_with_uses_current_index_and_rejects_graph_epoch_replay() 
 
 #[cfg(feature = "opencypher")]
 #[tokio::test]
+async fn cypher_in_predicate_filters_rows_correctly() {
+    let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let shard = open_test_shard("graph/cypher-in-predicate", object_store).await;
+
+    for (vertex, role, active) in [
+        (1, "admin", true),
+        (2, "moderator", true),
+        (3, "member", false),
+        (4, "guest", true),
+    ] {
+        shard
+            .set_vertex_metadata(
+                "cell-0",
+                vertex,
+                VertexMetadata::default()
+                    .with_label("User")
+                    .with_property("role", VertexPropertyValue::String(role.to_string()))
+                    .with_property("active", VertexPropertyValue::Bool(active)),
+            )
+            .await
+            .unwrap();
+    }
+
+    let roles_in = shard
+        .execute_cypher_rows(
+            QueryContext::new("cell-0", "roles-in-query"),
+            "MATCH (u:User) WHERE u.role IN ['admin', 'moderator'] RETURN u.id AS id",
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        roles_in.rows,
+        vec![
+            QueryRow::new(vec![QueryValue::VertexId(1)]),
+            QueryRow::new(vec![QueryValue::VertexId(2)]),
+        ]
+    );
+
+    let combined_in = shard
+        .execute_cypher_rows(
+            QueryContext::new("cell-0", "combined-in-query"),
+            "MATCH (u:User) WHERE u.role IN ['member', 'guest'] AND u.active = true RETURN u.id AS id",
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        combined_in.rows,
+        vec![QueryRow::new(vec![QueryValue::VertexId(4)])]
+    );
+}
+
+#[cfg(feature = "opencypher")]
+#[tokio::test]
 async fn cypher_tck_style_row_corpus_covers_supported_clause_semantics() {
     let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
     let shard = open_test_shard("graph/cypher-tck-style-corpus", object_store).await;


### PR DESCRIPTION
## Summary

Adds support for the `IN` list membership operator in OpenCypher `WHERE` clauses (e.g. `MATCH (u:User) WHERE u.role IN ['admin', 'moderator'] RETURN u.id`).

## Changes

1. **AST & Lowering (`src/query/opencypher.rs`)**:
   - Added `In { expression: RowExpression, values: Vec<VertexPropertyValue> }` variant to the `RowPredicate` enum.
   - Handled `sys::CYPHER_OP_IN` binary operator in `lower_row_predicate` with `lower_row_list_values` for collection AST nodes.
   - Added parser unit test `lowers_in_collection_predicate`.
2. **Predicate Evaluation (`src/shard/query.rs`)**:
   - Implemented evaluation in `row_predicate_matches` using `vertex_property_values_equal` against each element of the candidate list.
   - Forwarded `RowPredicate::In` in `row_predicate_relationship_property_constraint` directly into `RowPredicateRelationshipPropertyConstraint { values }` to leverage existing property index acceleration.
3. **Execution Tests (`src/tests.rs`)**:
   - Added `cypher_in_predicate_filters_rows_correctly` verifying row filtering on multi-value `IN` expressions and combinations with `AND`.
4. **Documentation (`cypher-compat.md`)**:
   - Updated documentation to reflect support for `IN` list membership in `WHERE` and removed `IN` from the unsupported list.
