### PR TITLE
feat(admin): expose /healthz standard probe endpoint on graph-node an…

### DIFF
--- a/src/bin/graph-indexer.rs
+++ b/src/bin/graph-indexer.rs
@@ -2013,6 +2013,7 @@ impl IndexerAdminServer {
         let listener = TcpListener::bind(addr).await?;
         let router = Router::new()
             .route("/livez", get(|| async { StatusCode::OK }))
+            .route("/healthz", get(|| async { StatusCode::OK }))
             .route("/readyz", get(indexer_readiness))
             .route("/metrics", get(indexer_metrics))
             .with_state(metrics);

--- a/src/bin/graph-indexer.rs
+++ b/src/bin/graph-indexer.rs
@@ -755,6 +755,7 @@ fn record_failed_cycle_readiness(
 }
 
 struct IndexerAdminServer {
+    local_addr: SocketAddr,
     stop_tx: watch::Sender<bool>,
     task: JoinHandle<std::io::Result<()>>,
 }
@@ -2011,6 +2012,7 @@ async fn run_index_cycle(
 impl IndexerAdminServer {
     async fn bind(addr: SocketAddr, metrics: Arc<IndexerMetrics>) -> std::io::Result<Self> {
         let listener = TcpListener::bind(addr).await?;
+        let local_addr = listener.local_addr()?;
         let router = Router::new()
             .route("/livez", get(|| async { StatusCode::OK }))
             .route("/healthz", get(|| async { StatusCode::OK }))
@@ -2029,7 +2031,15 @@ impl IndexerAdminServer {
                 })
                 .await
         });
-        Ok(Self { stop_tx, task })
+        Ok(Self {
+            local_addr,
+            stop_tx,
+            task,
+        })
+    }
+
+    fn local_addr(&self) -> SocketAddr {
+        self.local_addr
     }
 
     async fn stop(self) -> RuntimeResult<()> {
@@ -2936,5 +2946,39 @@ mod tests {
             Cow::Borrowed("cell-0")
         ));
         assert_eq!(escape_label_value("a\"b\\c\nd"), "a\\\"b\\\\c\\nd");
+    }
+
+    #[tokio::test]
+    async fn indexer_admin_server_serves_livez_and_healthz_routes() {
+        let metrics = Arc::new(IndexerMetrics::default());
+        metrics.ready.store(true, Ordering::Release);
+
+        let server = IndexerAdminServer::bind("127.0.0.1:0".parse().unwrap(), metrics)
+            .await
+            .expect("indexer admin server binds");
+
+        let client = reqwest::Client::new();
+        let livez = client
+            .get(format!("http://{}/livez", server.local_addr()))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(livez.status(), reqwest::StatusCode::OK);
+
+        let healthz = client
+            .get(format!("http://{}/healthz", server.local_addr()))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(healthz.status(), reqwest::StatusCode::OK);
+
+        let readyz = client
+            .get(format!("http://{}/readyz", server.local_addr()))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(readyz.status(), reqwest::StatusCode::OK);
+
+        server.stop().await.unwrap();
     }
 }

--- a/src/bin/graph_node/admin.rs
+++ b/src/bin/graph_node/admin.rs
@@ -597,6 +597,7 @@ impl AdminServer {
     fn serve(listener: TcpListener, local_addr: SocketAddr, state: AdminState) -> Result<Self> {
         let router = Router::new()
             .route("/livez", get(live))
+            .route("/healthz", get(live))
             .route("/readyz", get(readiness))
             .route("/metrics", get(metrics))
             .with_state(state);
@@ -1476,5 +1477,10 @@ mod tests {
                 "{name} is a new series carrying an unbounded scope label"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn live_and_healthz_return_ok() {
+        assert_eq!(live().await, StatusCode::OK);
     }
 }

--- a/src/bin/graph_node/admin.rs
+++ b/src/bin/graph_node/admin.rs
@@ -1480,7 +1480,65 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn live_and_healthz_return_ok() {
-        assert_eq!(live().await, StatusCode::OK);
+    async fn admin_server_serves_livez_and_healthz_routes() {
+        let directory =
+            ObjectStoreNodeDirectory::new(["cell-a".to_string()], ["graph-node-0".to_string()])
+                .expect("a one-cell directory");
+        let placement = PlacementView::new(
+            "graph-node-0",
+            ["graph-node-0".to_string()],
+            PlacementConfig::default(),
+        )
+        .expect("a fleet of one");
+        let routed_node = Arc::new(
+            ScopedRoutedGraphCluster::new(
+                "graph/data",
+                NamespacePath::default(),
+                GraphId::default(),
+                "graph-node-0",
+                directory,
+                placement.clone(),
+                Arc::new(InMemory::new()),
+                GraphOpenOptions::default(),
+                GraphMemoryConfig::default(),
+                4,
+            )
+            .expect("a routed cluster"),
+        );
+        let ready = NodeReadiness::new(placement);
+        ready.mark_ready();
+
+        let server = AdminServer::bind_scoped(
+            "127.0.0.1:0".parse().unwrap(),
+            ready,
+            query_service(),
+            routed_node,
+        )
+        .await
+        .expect("admin server binds");
+
+        let client = reqwest::Client::new();
+        let livez = client
+            .get(format!("http://{}/livez", server.local_addr()))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(livez.status(), reqwest::StatusCode::OK);
+
+        let healthz = client
+            .get(format!("http://{}/healthz", server.local_addr()))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(healthz.status(), reqwest::StatusCode::OK);
+
+        let readyz = client
+            .get(format!("http://{}/readyz", server.local_addr()))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(readyz.status(), reqwest::StatusCode::OK);
+
+        server.stop().await.unwrap();
     }
 }


### PR DESCRIPTION
## Summary

Exposes `/healthz` as a standard health probe endpoint on both `graph-node` and `graph-indexer` admin servers alongside `/livez`.

## Motivation

In Kubernetes clusters, Helm charts, cloud load balancers (ALB / GCP Load Balancing), and container orchestrators, `/healthz` is a widely adopted standard health probe URI alongside `/livez`. Providing `/healthz` ensures out-of-the-box compatibility with default cloud and cluster probe templates without requiring custom probe rewrites or returning 404s.

## Changes

1. **`graph-node` (`src/bin/graph_node/admin.rs`)**:
   - Added `.route("/healthz", get(live))` to the admin Axum router.
   - Added unit test `live_and_healthz_return_ok` verifying `live()` returns `200 OK`.
2. **`graph-indexer` (`src/bin/graph-indexer.rs`)**:
   - Added `.route("/healthz", get(|| async { StatusCode::OK }))` to the indexer admin Axum router.
