### PR TITLE
fix(config): name attempted file path on auth token read failure

### DIFF
--- a/src/bin/graph_node/config.rs
+++ b/src/bin/graph_node/config.rs
@@ -736,18 +736,17 @@ mod tests {
 
     #[test]
     fn read_auth_token_names_path_on_missing_file() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let missing_path = temp_dir.path().join("missing-auth-token");
+        let path_str = missing_path.to_string_lossy().to_string();
         let values = BTreeMap::from([
             ("GRAPH_ALLOW_PLAINTEXT".to_string(), "true".to_string()),
-            (
-                "GRAPH_AUTH_TOKEN_FILE".to_string(),
-                "/tmp/nonexistent-auth-token-path".to_string(),
-            ),
+            ("GRAPH_AUTH_TOKEN_FILE".to_string(), path_str.clone()),
         ]);
         let config = RuntimeConfig::from_values(values).unwrap();
         let error = config.read_auth_token().unwrap_err().to_string();
         assert!(
-            error.contains("could not read auth token file")
-                && error.contains("/tmp/nonexistent-auth-token-path"),
+            error.contains("could not read auth token file") && error.contains(&path_str),
             "expected error to contain attempted path, got: {error}"
         );
     }

--- a/src/bin/graph_node/config.rs
+++ b/src/bin/graph_node/config.rs
@@ -317,7 +317,16 @@ impl RuntimeConfig {
     }
 
     pub fn read_auth_token(&self) -> ConfigResult<String> {
-        let token = std::fs::read_to_string(&self.auth_token_file)?
+        let token = std::fs::read_to_string(&self.auth_token_file)
+            .map_err(|error| {
+                Error::new(
+                    error.kind(),
+                    format!(
+                        "could not read auth token file {}: {error}",
+                        self.auth_token_file.display()
+                    ),
+                )
+            })?
             .trim()
             .to_string();
         if token.len() < 32 || token.eq_ignore_ascii_case("change-me") {
@@ -723,5 +732,23 @@ mod tests {
         assert_eq!(memory.max_relationship_rows_bytes, 0);
         assert_eq!(memory.max_source_relationship_rows_bytes, 0);
         assert_eq!(memory.max_relationship_property_rows_bytes, 0);
+    }
+
+    #[test]
+    fn read_auth_token_names_path_on_missing_file() {
+        let values = BTreeMap::from([
+            ("GRAPH_ALLOW_PLAINTEXT".to_string(), "true".to_string()),
+            (
+                "GRAPH_AUTH_TOKEN_FILE".to_string(),
+                "/tmp/nonexistent-auth-token-path".to_string(),
+            ),
+        ]);
+        let config = RuntimeConfig::from_values(values).unwrap();
+        let error = config.read_auth_token().unwrap_err().to_string();
+        assert!(
+            error.contains("could not read auth token file")
+                && error.contains("/tmp/nonexistent-auth-token-path"),
+            "expected error to contain attempted path, got: {error}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

When `RuntimeConfig::read_auth_token` fails to read the configured token file (e.g. file missing, permission denied), `std::fs::read_to_string` produces a generic OS error like `No such file or directory (os error 2)` without naming which path the node was attempting to load.

## Changes

1. **`src/bin/graph_node/config.rs`**:
   - Mapped `std::fs::read_to_string` errors to include `self.auth_token_file.display()` so the error message explicitly names the attempted file path.
2. **Unit Test (`src/bin/graph_node/config.rs`)**:
   - Added `read_auth_token_names_path_on_missing_file` verifying that the error message includes the missing file path.
