### PR TITLE
feat(opencypher): support toLower and toUpper scalar functions in WHERE and aggregate expressions

### DIFF
--- a/cypher-compat.md
+++ b/cypher-compat.md
@@ -72,9 +72,12 @@ Comparison operators: `=`, `<>`, `<`, `>`, `<=`, `>=`, and `STARTS WITH`.
 MATCH (s:Score) WHERE s.score > 3.0 RETURN s.id AS score_id ORDER BY score_id
 MATCH (s:S) WHERE s.a = 1 AND (s.b > 2 OR NOT s.c = 3) RETURN s.id
 MATCH (s:Source) WHERE s.thread_id STARTS WITH $prefix RETURN s.id
+MATCH (u:User) WHERE toLower(u.name) = 'alice' AND toUpper(u.role) = 'ADMIN' RETURN u.id
 ```
 
 `STARTS WITH` needs a string literal or a parameter on the right.
+
+Scalar functions `toLower` and `toUpper` are supported in property expressions and comparisons.
 
 `IN`, `ENDS WITH`, `CONTAINS` and `IS NULL` are not supported. All four are
 rejected with the same message, that `WHERE` supports boolean combinations of

--- a/src/query/opencypher.rs
+++ b/src/query/opencypher.rs
@@ -257,6 +257,8 @@ pub enum RowExpression {
     NodeId { binding: String },
     Property { binding: String, property: String },
     Literal(VertexPropertyValue),
+    ToLower(Box<RowExpression>),
+    ToUpper(Box<RowExpression>),
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -2828,6 +2830,38 @@ fn lower_row_expression(
     expression: *const AstNode,
     parameters: &BTreeMap<String, VertexPropertyValue>,
 ) -> Result<RowExpression> {
+    unsafe {
+        if is_instance(expression, sys::CYPHER_AST_APPLY_OPERATOR) {
+            if sys::cypher_ast_apply_operator_get_distinct(expression) {
+                return unsupported(
+                    "DISTINCT function arguments are not executable in Query engine",
+                );
+            }
+            let function_node =
+                checked_node(sys::cypher_ast_apply_operator_get_func_name(expression))?;
+            let function_name = function_name(function_node)?;
+            if function_name.eq_ignore_ascii_case("toLower") {
+                let argument_count = sys::cypher_ast_apply_operator_narguments(expression);
+                if argument_count != 1 {
+                    return unsupported("toLower function expects exactly one argument");
+                }
+                let argument =
+                    checked_node(sys::cypher_ast_apply_operator_get_argument(expression, 0))?;
+                let inner = lower_row_expression(argument, parameters)?;
+                return Ok(RowExpression::ToLower(Box::new(inner)));
+            }
+            if function_name.eq_ignore_ascii_case("toUpper") {
+                let argument_count = sys::cypher_ast_apply_operator_narguments(expression);
+                if argument_count != 1 {
+                    return unsupported("toUpper function expects exactly one argument");
+                }
+                let argument =
+                    checked_node(sys::cypher_ast_apply_operator_get_argument(expression, 0))?;
+                let inner = lower_row_expression(argument, parameters)?;
+                return Ok(RowExpression::ToUpper(Box::new(inner)));
+            }
+        }
+    }
     if let Some(binding) = node_id_expression_binding(expression)? {
         return Ok(RowExpression::NodeId { binding });
     }
@@ -2905,6 +2939,8 @@ fn row_expression_name(expression: &RowExpression) -> String {
         RowExpression::Literal(VertexPropertyValue::Bool(value)) => value.to_string(),
         RowExpression::Literal(VertexPropertyValue::Float(value)) => value.0.to_string(),
         RowExpression::Literal(VertexPropertyValue::String(value)) => format!("'{value}'"),
+        RowExpression::ToLower(inner) => format!("toLower({})", row_expression_name(inner)),
+        RowExpression::ToUpper(inner) => format!("toUpper({})", row_expression_name(inner)),
     }
 }
 
@@ -4600,6 +4636,36 @@ mod tests {
         assert_eq!(
             opencypher_query_fingerprint("MATCH ((("),
             query_shape_fingerprint("MATCH ((("),
+        );
+    }
+
+    #[test]
+    fn lowers_to_lower_and_to_upper_expressions() {
+        let parsed = parse_opencypher_row_query(
+            "MATCH (n:User) WHERE toLower(n.name) = 'alice' AND toUpper(n.role) = 'ADMIN' RETURN n.id",
+        )
+        .unwrap();
+
+        assert_eq!(
+            parsed.predicate,
+            Some(RowPredicate::And(
+                Box::new(RowPredicate::Compare {
+                    left: RowExpression::ToLower(Box::new(RowExpression::Property {
+                        binding: "n".to_string(),
+                        property: "name".to_string(),
+                    })),
+                    op: RowComparisonOp::Eq,
+                    right: RowExpression::Literal(VertexPropertyValue::String("alice".to_string())),
+                }),
+                Box::new(RowPredicate::Compare {
+                    left: RowExpression::ToUpper(Box::new(RowExpression::Property {
+                        binding: "n".to_string(),
+                        property: "role".to_string(),
+                    })),
+                    op: RowComparisonOp::Eq,
+                    right: RowExpression::Literal(VertexPropertyValue::String("ADMIN".to_string())),
+                })
+            ))
         );
     }
 }

--- a/src/shard/query.rs
+++ b/src/shard/query.rs
@@ -8232,6 +8232,18 @@ fn eval_row_expression(row: &BindingRow, expression: &RowExpression) -> Result<R
             })
         }
         RowExpression::Literal(value) => Ok(RowScalarValue::Value(value.clone())),
+        RowExpression::ToLower(inner) => match eval_row_expression(row, inner)? {
+            RowScalarValue::Value(VertexPropertyValue::String(s)) => {
+                Ok(RowScalarValue::Value(VertexPropertyValue::String(s.to_lowercase())))
+            }
+            RowScalarValue::Value(_) | RowScalarValue::Missing => Ok(RowScalarValue::Missing),
+        },
+        RowExpression::ToUpper(inner) => match eval_row_expression(row, inner)? {
+            RowScalarValue::Value(VertexPropertyValue::String(s)) => {
+                Ok(RowScalarValue::Value(VertexPropertyValue::String(s.to_uppercase())))
+            }
+            RowScalarValue::Value(_) | RowScalarValue::Missing => Ok(RowScalarValue::Missing),
+        },
     }
 }
 
@@ -8767,6 +8779,18 @@ fn expression_query_value(
             binding_property(row, binding, property)?.map(QueryValue::Property)
         }
         RowExpression::Literal(value) => Some(QueryValue::Property(value.clone())),
+        RowExpression::ToLower(inner) => match expression_query_value(row, inner)? {
+            Some(QueryValue::Property(VertexPropertyValue::String(s))) => {
+                Some(QueryValue::Property(VertexPropertyValue::String(s.to_lowercase())))
+            }
+            _ => None,
+        },
+        RowExpression::ToUpper(inner) => match expression_query_value(row, inner)? {
+            Some(QueryValue::Property(VertexPropertyValue::String(s))) => {
+                Some(QueryValue::Property(VertexPropertyValue::String(s.to_uppercase())))
+            }
+            _ => None,
+        },
     })
 }
 

--- a/src/shard/query.rs
+++ b/src/shard/query.rs
@@ -9124,3 +9124,119 @@ fn compare_u64_f64(left: u64, right: f64) -> std::cmp::Ordering {
         ordering => ordering,
     }
 }
+
+#[cfg(all(test, feature = "opencypher"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_eval_row_expression_to_lower_and_to_upper() {
+        let mut row = BindingRow::default();
+        row.bind(Some("u"), 1);
+        let mut metadata = VertexMetadata::default();
+        metadata
+            .properties
+            .insert("name".to_string(), VertexPropertyValue::String("Alice".to_string()));
+        metadata
+            .properties
+            .insert("role".to_string(), VertexPropertyValue::String("Admin".to_string()));
+        metadata
+            .properties
+            .insert("age".to_string(), VertexPropertyValue::Integer(30));
+        row.metadata.insert("u".to_string(), metadata);
+
+        // toLower on string property
+        let expr_lower = RowExpression::ToLower(Box::new(RowExpression::Property {
+            binding: "u".to_string(),
+            property: "name".to_string(),
+        }));
+        assert_eq!(
+            eval_row_expression(&row, &expr_lower).unwrap(),
+            RowScalarValue::Value(VertexPropertyValue::String("alice".to_string()))
+        );
+
+        // toUpper on string property
+        let expr_upper = RowExpression::ToUpper(Box::new(RowExpression::Property {
+            binding: "u".to_string(),
+            property: "role".to_string(),
+        }));
+        assert_eq!(
+            eval_row_expression(&row, &expr_upper).unwrap(),
+            RowScalarValue::Value(VertexPropertyValue::String("ADMIN".to_string()))
+        );
+
+        // toLower on missing property -> Missing
+        let expr_missing = RowExpression::ToLower(Box::new(RowExpression::Property {
+            binding: "u".to_string(),
+            property: "nonexistent".to_string(),
+        }));
+        assert_eq!(
+            eval_row_expression(&row, &expr_missing).unwrap(),
+            RowScalarValue::Missing
+        );
+
+        // toLower on non-string property (integer) -> Missing
+        let expr_non_string = RowExpression::ToLower(Box::new(RowExpression::Property {
+            binding: "u".to_string(),
+            property: "age".to_string(),
+        }));
+        assert_eq!(
+            eval_row_expression(&row, &expr_non_string).unwrap(),
+            RowScalarValue::Missing
+        );
+
+        // toUpper on literal string
+        let expr_literal = RowExpression::ToUpper(Box::new(RowExpression::Literal(
+            VertexPropertyValue::String("hello world".to_string()),
+        )));
+        assert_eq!(
+            eval_row_expression(&row, &expr_literal).unwrap(),
+            RowScalarValue::Value(VertexPropertyValue::String("HELLO WORLD".to_string()))
+        );
+
+        // Nested toUpper(toLower(...))
+        let expr_nested = RowExpression::ToUpper(Box::new(RowExpression::ToLower(Box::new(
+            RowExpression::Property {
+                binding: "u".to_string(),
+                property: "name".to_string(),
+            },
+        ))));
+        assert_eq!(
+            eval_row_expression(&row, &expr_nested).unwrap(),
+            RowScalarValue::Value(VertexPropertyValue::String("ALICE".to_string()))
+        );
+
+        // expression_query_value for aggregates
+        assert_eq!(
+            expression_query_value(&row, &expr_lower).unwrap(),
+            Some(QueryValue::Property(VertexPropertyValue::String("alice".to_string())))
+        );
+        assert_eq!(
+            expression_query_value(&row, &expr_upper).unwrap(),
+            Some(QueryValue::Property(VertexPropertyValue::String("ADMIN".to_string())))
+        );
+        assert_eq!(
+            expression_query_value(&row, &expr_missing).unwrap(),
+            None
+        );
+        assert_eq!(
+            expression_query_value(&row, &expr_non_string).unwrap(),
+            None
+        );
+
+        // row_predicate_matches with toLower comparison
+        let pred = RowPredicate::Compare {
+            left: expr_lower,
+            op: RowComparisonOp::Eq,
+            right: RowExpression::Literal(VertexPropertyValue::String("alice".to_string())),
+        };
+        assert!(row_predicate_matches(&row, &pred).unwrap());
+
+        let pred_mismatch = RowPredicate::Compare {
+            left: expr_upper,
+            op: RowComparisonOp::Eq,
+            right: RowExpression::Literal(VertexPropertyValue::String("USER".to_string())),
+        };
+        assert!(!row_predicate_matches(&row, &pred_mismatch).unwrap());
+    }
+}


### PR DESCRIPTION
## Summary

Adds support for the `toLower()` and `toUpper()` scalar string functions in OpenCypher queries:
- **`WHERE` predicates**: Allows case-insensitive / normalized filtering on string properties (e.g. `MATCH (u:User) WHERE toLower(u.name) = 'alice' AND toUpper(u.role) = 'ADMIN' RETURN u.id`).
- **Aggregate expressions**: Enables string normalization inside aggregates (e.g. `RETURN collect(toLower(u.name))`).

## Changes
- **`src/query/opencypher.rs`**:
  - Extended `RowExpression` with `ToLower(Box<RowExpression>)` and `ToUpper(Box<RowExpression>)`.
  - Lowered AST calls for `toLower` and `toUpper` (with single-argument validation).
  - Formatted expression names for query column fallbacks.
  - Added AST lowering unit tests.
- **`src/shard/query.rs`**:
  - Implemented evaluation in `eval_row_expression` for row predicate comparisons.
  - Implemented evaluation in `expression_query_value` for aggregate projections.
- **`cypher-compat.md`**:
  - Documented `toLower` and `toUpper` scalar function support.

## Test Plan
-  Verified AST lowering in `src/query/opencypher.rs` with `lowers_to_lower_and_to_upper_expressions`.
-  Verified correct row evaluation in `src/shard/query.rs`.
