### PR TITLE
Fix query transport error classes

### DIFF
--- a/src/client/bolt/values.rs
+++ b/src/client/bolt/values.rs
@@ -3,7 +3,8 @@ use boltr::types::{BoltDict, BoltNode, BoltPath, BoltUnboundRelationship, BoltVa
 
 use super::{ClientBookmark, ClientQueryTarget};
 use crate::{
-    GraphError, QueryFloat, QueryParameterValue, QueryPath, QueryValue, VertexPropertyValue,
+    GraphError, QueryFloat, QueryParameterValue, QueryPath, QueryValue, RemoteGraphErrorClass,
+    VertexPropertyValue,
 };
 
 const MAX_QUERY_PARAMETER_DEPTH: usize = 16;
@@ -223,6 +224,42 @@ pub(super) fn explicit_transactions_unsupported() -> BoltError {
 
 pub(super) fn graph_error_to_bolt(error: GraphError) -> BoltError {
     match error {
+        GraphError::Remote {
+            class: RemoteGraphErrorClass::Authorization,
+            message,
+        } => BoltError::Forbidden(message),
+        GraphError::Remote {
+            class: RemoteGraphErrorClass::Admission,
+            message,
+        } => BoltError::ResourceExhausted(message),
+        GraphError::Remote {
+            class: RemoteGraphErrorClass::Freshness,
+            message,
+        } => BoltError::Query {
+            code: "Neo.TransientError.Transaction.BookmarkTimeout".to_string(),
+            message,
+        },
+        GraphError::Remote {
+            class: RemoteGraphErrorClass::Query,
+            message,
+        } => BoltError::Query {
+            code: "Neo.ClientError.Statement.InvalidSyntax".to_string(),
+            message,
+        },
+        GraphError::Remote {
+            class: RemoteGraphErrorClass::Timeout,
+            message,
+        } => BoltError::Query {
+            code: "Neo.TransientError.Transaction.Terminated".to_string(),
+            message,
+        },
+        GraphError::Remote {
+            class: RemoteGraphErrorClass::Routing,
+            message,
+        } => BoltError::Query {
+            code: "Neo.TransientError.General.DatabaseUnavailable".to_string(),
+            message,
+        },
         GraphError::GraphScopeAccessDenied { .. } => BoltError::Forbidden(error.to_string()),
         GraphError::AdmissionRejected { .. } => BoltError::ResourceExhausted(error.to_string()),
         GraphError::SnapshotAhead { .. } => BoltError::Query {

--- a/src/client/http.rs
+++ b/src/client/http.rs
@@ -25,7 +25,8 @@ use super::service::{
 use crate::{
     GraphError, GraphId, GraphScope, NamespaceId, NamespacePath, QueryCursorToken, QueryFloat,
     QueryParameterValue, QueryPath, QueryTransportConnectionIdentity,
-    QueryTransportTlsServerConfigProvider, QueryValue, Result, VertexPropertyValue,
+    QueryTransportTlsServerConfigProvider, QueryValue, RemoteGraphErrorClass, Result,
+    VertexPropertyValue,
 };
 
 const GRAPH_NAMESPACE_HEADER: &str = "x-graph-namespace";
@@ -366,6 +367,56 @@ impl HttpApiError {
 
     fn from_graph_ref(error: &GraphError) -> Self {
         match error {
+            GraphError::Remote {
+                class: RemoteGraphErrorClass::Authorization,
+                message,
+            } => Self {
+                status: StatusCode::FORBIDDEN,
+                code: "permission_denied",
+                message: message.clone(),
+                owner: None,
+                authenticate: false,
+            },
+            GraphError::Remote {
+                class: RemoteGraphErrorClass::Admission,
+                message,
+            } => Self {
+                status: StatusCode::TOO_MANY_REQUESTS,
+                code: "resource_exhausted",
+                message: message.clone(),
+                owner: None,
+                authenticate: false,
+            },
+            GraphError::Remote {
+                class: RemoteGraphErrorClass::Timeout,
+                message,
+            } => Self {
+                status: StatusCode::REQUEST_TIMEOUT,
+                code: "query_timeout",
+                message: message.clone(),
+                owner: None,
+                authenticate: false,
+            },
+            GraphError::Remote {
+                class: RemoteGraphErrorClass::Routing,
+                message,
+            } => Self {
+                status: StatusCode::SERVICE_UNAVAILABLE,
+                code: "routing_unavailable",
+                message: message.clone(),
+                owner: None,
+                authenticate: false,
+            },
+            GraphError::Remote {
+                class: RemoteGraphErrorClass::Freshness | RemoteGraphErrorClass::Query,
+                message,
+            } => Self {
+                status: StatusCode::BAD_REQUEST,
+                code: "invalid_request",
+                message: message.clone(),
+                owner: None,
+                authenticate: false,
+            },
             GraphError::GraphScopeAccessDenied { .. } => Self {
                 status: StatusCode::FORBIDDEN,
                 code: "permission_denied",

--- a/src/client/http/tests.rs
+++ b/src/client/http/tests.rs
@@ -110,6 +110,25 @@ fn http_parameters_preserve_integer_sign_and_precision() {
     );
 }
 
+#[test]
+fn remote_query_error_class_preserves_only_safe_http_semantics() {
+    let admission = HttpApiError::from_graph(GraphError::Remote {
+        class: crate::RemoteGraphErrorClass::Admission,
+        message: "cell is saturated".to_string(),
+    });
+    assert_eq!(admission.status, StatusCode::TOO_MANY_REQUESTS);
+    assert_eq!(admission.code, "resource_exhausted");
+    assert_eq!(admission.message, "cell is saturated");
+
+    let unknown_semantics = HttpApiError::from_graph(GraphError::Remote {
+        class: crate::RemoteGraphErrorClass::Storage,
+        message: "peer implementation detail".to_string(),
+    });
+    assert_eq!(unknown_semantics.status, StatusCode::INTERNAL_SERVER_ERROR);
+    assert_eq!(unknown_semantics.code, "internal");
+    assert_eq!(unknown_semantics.message, "internal query execution error");
+}
+
 /// Touch point (c) for HTTP: 421 Misdirected Request, with the owner in the
 /// body because an HTTP client has no routing table to discard and re-fetch.
 /// The hint is *absent* rather than null when this node has shed its view —

--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -7,6 +7,59 @@ use crate::StorageSequence;
 #[cfg(test)]
 mod tests;
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RemoteGraphErrorClass {
+    Contention,
+    Fencing,
+    Routing,
+    Freshness,
+    Admission,
+    Timeout,
+    Query,
+    Authorization,
+    Corruption,
+    Configuration,
+    Storage,
+    Kernel,
+}
+
+impl RemoteGraphErrorClass {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Contention => "contention",
+            Self::Fencing => "fencing",
+            Self::Routing => "routing",
+            Self::Freshness => "freshness",
+            Self::Admission => "admission",
+            Self::Timeout => "timeout",
+            Self::Query => "query",
+            Self::Authorization => "authz",
+            Self::Corruption => "corruption",
+            Self::Configuration => "config",
+            Self::Storage => "storage",
+            Self::Kernel => "kernel",
+        }
+    }
+
+    pub fn from_wire(value: &str) -> Option<Self> {
+        Some(match value {
+            "contention" => Self::Contention,
+            "fencing" => Self::Fencing,
+            "routing" => Self::Routing,
+            "freshness" => Self::Freshness,
+            "admission" => Self::Admission,
+            "timeout" => Self::Timeout,
+            "query" => Self::Query,
+            "authz" => Self::Authorization,
+            "corruption" => Self::Corruption,
+            "config" => Self::Configuration,
+            "storage" => Self::Storage,
+            "kernel" => Self::Kernel,
+            _ => return None,
+        })
+    }
+}
+
 #[derive(Debug, Error)]
 pub enum GraphError {
     #[error("slatedb error: {0}")]
@@ -200,6 +253,11 @@ pub enum GraphError {
         dialect: &'static str,
         feature: String,
     },
+    #[error("remote {} error: {message}", class.as_str())]
+    Remote {
+        class: RemoteGraphErrorClass,
+        message: String,
+    },
 }
 
 impl GraphError {
@@ -234,6 +292,25 @@ impl GraphError {
     /// to the vocabulary resizes every such array instead of silently leaving
     /// the new one uncounted.
     pub const CLASS_COUNT: usize = Self::CLASSES.len();
+
+    /// The query-transport representation of each error class, indexed by the
+    /// corresponding entry in [`Self::CLASSES`]. Keeping this array sized by
+    /// `CLASS_COUNT` makes a taxonomy addition require an explicit wire-class
+    /// decision.
+    const REMOTE_CLASSES: [RemoteGraphErrorClass; Self::CLASS_COUNT] = [
+        RemoteGraphErrorClass::Contention,
+        RemoteGraphErrorClass::Fencing,
+        RemoteGraphErrorClass::Routing,
+        RemoteGraphErrorClass::Freshness,
+        RemoteGraphErrorClass::Admission,
+        RemoteGraphErrorClass::Timeout,
+        RemoteGraphErrorClass::Query,
+        RemoteGraphErrorClass::Authorization,
+        RemoteGraphErrorClass::Corruption,
+        RemoteGraphErrorClass::Configuration,
+        RemoteGraphErrorClass::Storage,
+        RemoteGraphErrorClass::Kernel,
+    ];
 
     // Positions in `CLASSES`, so the match arms in `class_index` read as the
     // names they are. `class_constants_index_their_own_name` pins each one
@@ -275,6 +352,11 @@ impl GraphError {
         Self::CLASSES[self.class_index()]
     }
 
+    /// The recognized class to send for this error over query transport.
+    pub(crate) fn remote_class(&self) -> RemoteGraphErrorClass {
+        Self::REMOTE_CLASSES[self.class_index()]
+    }
+
     /// The same classification as [`Self::class`], as a position in
     /// [`Self::CLASSES`].
     ///
@@ -287,6 +369,20 @@ impl GraphError {
     /// is the vocabulary's own.
     pub fn class_index(&self) -> usize {
         match self {
+            Self::Remote { class, .. } => match class {
+                RemoteGraphErrorClass::Contention => Self::CLASS_CONTENTION,
+                RemoteGraphErrorClass::Fencing => Self::CLASS_FENCING,
+                RemoteGraphErrorClass::Routing => Self::CLASS_ROUTING,
+                RemoteGraphErrorClass::Freshness => Self::CLASS_FRESHNESS,
+                RemoteGraphErrorClass::Admission => Self::CLASS_ADMISSION,
+                RemoteGraphErrorClass::Timeout => Self::CLASS_TIMEOUT,
+                RemoteGraphErrorClass::Query => Self::CLASS_QUERY,
+                RemoteGraphErrorClass::Authorization => Self::CLASS_AUTHZ,
+                RemoteGraphErrorClass::Corruption => Self::CLASS_CORRUPTION,
+                RemoteGraphErrorClass::Configuration => Self::CLASS_CONFIG,
+                RemoteGraphErrorClass::Storage => Self::CLASS_STORAGE,
+                RemoteGraphErrorClass::Kernel => Self::CLASS_KERNEL,
+            },
             Self::ConditionalWriteConflict { .. }
             | Self::IdempotencyConflict { .. }
             | Self::ControlMetadataConflict { .. }

--- a/src/core/error/tests.rs
+++ b/src/core/error/tests.rs
@@ -154,3 +154,19 @@ fn wrong_node_failures_are_routing_not_fencing() {
     assert_eq!(not_writer.class(), "routing");
     assert_eq!(unavailable.class(), "routing");
 }
+
+#[test]
+fn remote_error_classes_use_the_same_stable_taxonomy() {
+    let error = GraphError::Remote {
+        class: RemoteGraphErrorClass::Admission,
+        message: "cell is saturated".to_string(),
+    };
+
+    assert_eq!(error.class(), "admission");
+    assert_eq!(error.remote_class(), RemoteGraphErrorClass::Admission);
+    assert_eq!(
+        RemoteGraphErrorClass::from_wire("admission"),
+        Some(RemoteGraphErrorClass::Admission)
+    );
+    assert_eq!(RemoteGraphErrorClass::from_wire("future-class"), None);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@ pub use core::config::{
     GraphLimits, GraphMemoryConfig, GraphOpenOptions, GraphStorageMemoryConfig,
     DEFAULT_TRUSTED_APPEND_CHUNK_EDGES,
 };
-pub use core::error::{GraphError, Result};
+pub use core::error::{GraphError, RemoteGraphErrorClass, Result};
 // Widen this as H1 converts the remaining client duration counters. It is no
 // longer feature-gated: `GraphOperationalMetrics::query_rows_latency` is a
 // default-features field, so the type is constructed on every build.

--- a/src/namespace_tests.rs
+++ b/src/namespace_tests.rs
@@ -366,7 +366,13 @@ async fn transport_tokens_are_confined_to_granted_namespace_and_graph_scopes() {
         )
         .await
         .unwrap_err();
-    assert!(matches!(denied, GraphError::UnsupportedQuery { .. }));
+    assert!(matches!(
+        denied,
+        GraphError::Remote {
+            class: RemoteGraphErrorClass::Authorization,
+            ..
+        }
+    ));
     assert!(denied.to_string().contains("not authorized"));
 
     for (index, mutation_query) in [

--- a/src/query/coordination.rs
+++ b/src/query/coordination.rs
@@ -2215,8 +2215,8 @@ impl QueryCellClient for TcpQueryCellClient {
                 "query/transport/rows",
                 "server returned cancel response for rows request",
             )),
-            QueryTransportResponse::Error { message } => {
-                Err(transport_remote_error("query/transport/rows", message))
+            QueryTransportResponse::Error { message, class } => {
+                Err(transport_remote_error("query/transport/rows", message, class))
             }
         }
     }
@@ -2247,8 +2247,8 @@ impl QueryCellClient for TcpQueryCellClient {
                 "query/transport/page",
                 "server returned cancel response for page request",
             )),
-            QueryTransportResponse::Error { message } => {
-                Err(transport_remote_error("query/transport/page", message))
+            QueryTransportResponse::Error { message, class } => {
+                Err(transport_remote_error("query/transport/page", message, class))
             }
         }
     }
@@ -2275,8 +2275,8 @@ impl QueryCellClient for TcpQueryCellClient {
                 "query/transport/batch",
                 "server returned cancel response for batch request",
             )),
-            QueryTransportResponse::Error { message } => {
-                Err(transport_remote_error("query/transport/batch", message))
+            QueryTransportResponse::Error { message, class } => {
+                Err(transport_remote_error("query/transport/batch", message, class))
             }
         }
     }
@@ -2307,9 +2307,10 @@ impl QueryCellClient for TcpQueryCellClient {
                 "query/transport/batch_page",
                 "server returned cancel response for batch page request",
             )),
-            QueryTransportResponse::Error { message } => Err(transport_remote_error(
+            QueryTransportResponse::Error { message, class } => Err(transport_remote_error(
                 "query/transport/batch_page",
                 message,
+                class,
             )),
         }
     }
@@ -2362,8 +2363,8 @@ impl TcpQueryCellClient {
                     "server returned query data for cancel request",
                 ))
             }
-            QueryTransportResponse::Error { message } => {
-                Err(transport_remote_error("query/transport/cancel", message))
+            QueryTransportResponse::Error { message, class } => {
+                Err(transport_remote_error("query/transport/cancel", message, class))
             }
         }
     }
@@ -3924,7 +3925,11 @@ enum QueryTransportResponse {
     Rows { result: QueryResultSet },
     Page { result: QueryResultPage },
     Cancelled,
-    Error { message: String },
+    Error {
+        message: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        class: Option<String>,
+    },
 }
 
 #[cfg(feature = "query-transport")]
@@ -4089,6 +4094,7 @@ where
                 if control_only && !request.is_cancel() {
                     QueryTransportResponse::Error {
                         message: "connection is reserved for query cancellation".to_string(),
+                        class: Some(crate::RemoteGraphErrorClass::Query.as_str().to_string()),
                     }
                 } else {
                     execute_query_transport_request(
@@ -4102,6 +4108,7 @@ where
             }
             Err(err) => QueryTransportResponse::Error {
                 message: format!("invalid query transport request: {err}"),
+                class: Some(crate::RemoteGraphErrorClass::Query.as_str().to_string()),
             },
         };
         let close_connection = control_only
@@ -4395,6 +4402,7 @@ fn transport_version_error(version: u16) -> QueryTransportResponse {
         message: format!(
             "unsupported query transport version {version}; expected {QUERY_TRANSPORT_VERSION}"
         ),
+        class: Some(crate::RemoteGraphErrorClass::Query.as_str().to_string()),
     }
 }
 
@@ -4765,7 +4773,10 @@ fn transport_error_response(
             "internal query execution error".to_string()
         }
     };
-    QueryTransportResponse::Error { message }
+    QueryTransportResponse::Error {
+        message,
+        class: Some(err.remote_class().as_str().to_string()),
+    }
 }
 
 #[cfg(feature = "query-transport")]
@@ -4918,10 +4929,21 @@ fn transport_protocol_error(key: &str, reason: &str) -> GraphError {
 }
 
 #[cfg(feature = "query-transport")]
-fn transport_remote_error(key: &str, message: String) -> GraphError {
-    GraphError::UnsupportedQuery {
-        dialect: "QueryTransport",
-        feature: format!("{key}: {message}"),
+fn transport_remote_error(key: &str, message: String, class: Option<String>) -> GraphError {
+    match class {
+        Some(class) => match crate::RemoteGraphErrorClass::from_wire(&class) {
+            Some(class) => GraphError::Remote { class, message },
+            None => GraphError::CorruptValue {
+                key: key.to_string(),
+                reason: "unrecognized query transport error class".to_string(),
+            },
+        },
+        // Older servers sent only `message`; retain the legacy query-class
+        // fallback until every supported peer understands the optional field.
+        None => GraphError::UnsupportedQuery {
+            dialect: "QueryTransport",
+            feature: format!("{key}: {message}"),
+        },
     }
 }
 
@@ -4929,6 +4951,56 @@ fn transport_remote_error(key: &str, message: String) -> GraphError {
 mod scope_grant_tests {
     use super::*;
     use crate::NamespaceId;
+
+    #[derive(serde::Deserialize)]
+    #[serde(tag = "kind", rename_all = "snake_case")]
+    enum LegacyQueryTransportResponse {
+        Error { message: String },
+    }
+
+    #[test]
+    fn query_transport_error_class_is_additive_and_validated() {
+        let legacy: QueryTransportResponse = serde_json::from_str(
+            r#"{"kind":"error","message":"legacy peer"}"#,
+        )
+        .unwrap();
+        assert!(matches!(
+            legacy,
+            QueryTransportResponse::Error { class: None, .. }
+        ));
+
+        let modern = QueryTransportResponse::Error {
+            message: "cell is saturated".to_string(),
+            class: Some("admission".to_string()),
+        };
+        let encoded = serde_json::to_string(&modern).unwrap();
+        let decoded_by_legacy_peer: LegacyQueryTransportResponse =
+            serde_json::from_str(&encoded).unwrap();
+        assert!(matches!(
+            decoded_by_legacy_peer,
+            LegacyQueryTransportResponse::Error { message } if message == "cell is saturated"
+        ));
+
+        assert!(matches!(
+            transport_remote_error(
+                "query/transport/test",
+                "cell is saturated".to_string(),
+                Some("admission".to_string()),
+            ),
+            GraphError::Remote {
+                class: crate::RemoteGraphErrorClass::Admission,
+                ..
+            }
+        ));
+        assert!(matches!(
+            transport_remote_error(
+                "query/transport/test",
+                "untrusted detail".to_string(),
+                Some("future-class".to_string()),
+            ),
+            GraphError::CorruptValue { .. }
+        ));
+    }
 
     #[test]
     fn graph_namespace_grant_restricts_descendants_to_one_graph_id() {

--- a/src/query/coordination.rs
+++ b/src/query/coordination.rs
@@ -2215,9 +2215,11 @@ impl QueryCellClient for TcpQueryCellClient {
                 "query/transport/rows",
                 "server returned cancel response for rows request",
             )),
-            QueryTransportResponse::Error { message, class } => {
-                Err(transport_remote_error("query/transport/rows", message, class))
-            }
+            QueryTransportResponse::Error { message, class } => Err(transport_remote_error(
+                "query/transport/rows",
+                message,
+                class,
+            )),
         }
     }
 
@@ -2247,9 +2249,11 @@ impl QueryCellClient for TcpQueryCellClient {
                 "query/transport/page",
                 "server returned cancel response for page request",
             )),
-            QueryTransportResponse::Error { message, class } => {
-                Err(transport_remote_error("query/transport/page", message, class))
-            }
+            QueryTransportResponse::Error { message, class } => Err(transport_remote_error(
+                "query/transport/page",
+                message,
+                class,
+            )),
         }
     }
 
@@ -2275,9 +2279,11 @@ impl QueryCellClient for TcpQueryCellClient {
                 "query/transport/batch",
                 "server returned cancel response for batch request",
             )),
-            QueryTransportResponse::Error { message, class } => {
-                Err(transport_remote_error("query/transport/batch", message, class))
-            }
+            QueryTransportResponse::Error { message, class } => Err(transport_remote_error(
+                "query/transport/batch",
+                message,
+                class,
+            )),
         }
     }
 
@@ -2363,9 +2369,11 @@ impl TcpQueryCellClient {
                     "server returned query data for cancel request",
                 ))
             }
-            QueryTransportResponse::Error { message, class } => {
-                Err(transport_remote_error("query/transport/cancel", message, class))
-            }
+            QueryTransportResponse::Error { message, class } => Err(transport_remote_error(
+                "query/transport/cancel",
+                message,
+                class,
+            )),
         }
     }
 
@@ -3922,8 +3930,12 @@ impl QueryTransportRequest {
 #[derive(serde::Deserialize, serde::Serialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 enum QueryTransportResponse {
-    Rows { result: QueryResultSet },
-    Page { result: QueryResultPage },
+    Rows {
+        result: QueryResultSet,
+    },
+    Page {
+        result: QueryResultPage,
+    },
     Cancelled,
     Error {
         message: String,
@@ -4960,10 +4972,8 @@ mod scope_grant_tests {
 
     #[test]
     fn query_transport_error_class_is_additive_and_validated() {
-        let legacy: QueryTransportResponse = serde_json::from_str(
-            r#"{"kind":"error","message":"legacy peer"}"#,
-        )
-        .unwrap();
+        let legacy: QueryTransportResponse =
+            serde_json::from_str(r#"{"kind":"error","message":"legacy peer"}"#).unwrap();
         assert!(matches!(
             legacy,
             QueryTransportResponse::Error { class: None, .. }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -5954,21 +5954,21 @@ async fn tcp_query_transport_preserves_remote_error_classes() {
     impl FailingQueryClient {
         fn error(query: &str) -> GraphError {
             match query {
-                "ADMISSION" => GraphError::AdmissionRejected {
+                "RETURN 1 AS admission" => GraphError::AdmissionRejected {
                     operation: "test_admission",
                     actual: 2,
                     limit: 1,
                 },
-                "TIMEOUT" => GraphError::QueryTimeout {
+                "RETURN 1 AS timeout" => GraphError::QueryTimeout {
                     operation: "test_timeout",
                     elapsed_ms: 10,
                     limit_ms: 5,
                 },
-                "QUERY" => GraphError::QueryParse {
+                "RETURN 1 AS query_error" => GraphError::QueryParse {
                     dialect: "openCypher",
                     reason: "test query error".to_string(),
                 },
-                "INTERNAL" => GraphError::CorruptValue {
+                "RETURN 1 AS internal_error" => GraphError::CorruptValue {
                     key: "internal/test-key".to_string(),
                     reason: "sensitive test detail".to_string(),
                 },
@@ -6012,10 +6012,10 @@ async fn tcp_query_transport_preserves_remote_error_classes() {
         .insecure_allow_plaintext();
 
     for (query, expected_class) in [
-        ("ADMISSION", "admission"),
-        ("TIMEOUT", "timeout"),
-        ("QUERY", "query"),
-        ("INTERNAL", "corruption"),
+        ("RETURN 1 AS admission", "admission"),
+        ("RETURN 1 AS timeout", "timeout"),
+        ("RETURN 1 AS query_error", "query"),
+        ("RETURN 1 AS internal_error", "corruption"),
     ] {
         let error = client
             .execute_cypher_rows(
@@ -6025,7 +6025,7 @@ async fn tcp_query_transport_preserves_remote_error_classes() {
             .await
             .unwrap_err();
         assert_eq!(error.class(), expected_class, "{query} error class");
-        if query == "INTERNAL" {
+        if query == "RETURN 1 AS internal_error" {
             assert!(error.to_string().contains("internal query execution error"));
             assert!(!error.to_string().contains("sensitive test detail"));
         }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -5948,6 +5948,95 @@ async fn tcp_query_transport_default_bind_rejects_unauthenticated_requests() {
 
 #[cfg(feature = "query-transport")]
 #[tokio::test]
+async fn tcp_query_transport_preserves_remote_error_classes() {
+    struct FailingQueryClient;
+
+    impl FailingQueryClient {
+        fn error(query: &str) -> GraphError {
+            match query {
+                "ADMISSION" => GraphError::AdmissionRejected {
+                    operation: "test_admission",
+                    actual: 2,
+                    limit: 1,
+                },
+                "TIMEOUT" => GraphError::QueryTimeout {
+                    operation: "test_timeout",
+                    elapsed_ms: 10,
+                    limit_ms: 5,
+                },
+                "QUERY" => GraphError::QueryParse {
+                    dialect: "openCypher",
+                    reason: "test query error".to_string(),
+                },
+                "INTERNAL" => GraphError::CorruptValue {
+                    key: "internal/test-key".to_string(),
+                    reason: "sensitive test detail".to_string(),
+                },
+                _ => unreachable!("unexpected transport test query"),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl QueryCellClient for FailingQueryClient {
+        async fn execute_cypher_rows(
+            &self,
+            _context: QueryContext,
+            query: &str,
+        ) -> Result<QueryResultSet> {
+            Err(Self::error(query))
+        }
+
+        async fn execute_cypher_rows_page(
+            &self,
+            _context: QueryContext,
+            query: &str,
+            _cursor: Option<QueryCursorToken>,
+            _page_size: usize,
+        ) -> Result<QueryResultPage> {
+            Err(Self::error(query))
+        }
+    }
+
+    let server = TcpQueryServer::bind_with_config(
+        "127.0.0.1:0".parse().unwrap(),
+        Arc::new(FailingQueryClient),
+        QueryTransportServerConfig::default()
+            .with_required_bearer_token("transport-test-token")
+            .insecure_allow_plaintext(),
+    )
+    .await
+    .unwrap();
+    let client = TcpQueryCellClient::new(server.local_addr())
+        .with_bearer_token("transport-test-token")
+        .insecure_allow_plaintext();
+
+    for (query, expected_class) in [
+        ("ADMISSION", "admission"),
+        ("TIMEOUT", "timeout"),
+        ("QUERY", "query"),
+        ("INTERNAL", "corruption"),
+    ] {
+        let error = client
+            .execute_cypher_rows(
+                QueryContext::new("cell-a", format!("transport-{query}")),
+                query,
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(error.class(), expected_class, "{query} error class");
+        if query == "INTERNAL" {
+            assert!(error.to_string().contains("internal query execution error"));
+            assert!(!error.to_string().contains("sensitive test detail"));
+        }
+    }
+
+    assert_eq!(client.metrics().client_retries, 0);
+    server.stop().await.unwrap();
+}
+
+#[cfg(feature = "query-transport")]
+#[tokio::test]
 async fn tcp_query_transport_batches_page_rows_and_enforce_write_grants() {
     struct StaticBatchClient;
 


### PR DESCRIPTION
## Problem

Query transport kept the remote error message but discarded its `GraphError`
class. As a result, remote failures such as admission and timeout errors were
reconstructed as `UnsupportedQuery`.

This also changed downstream HTTP/Bolt classification and error telemetry
compared with equivalent local failures.

## Fix

Carry HydraDB's known coarse error class as an optional transport error field
and reconstruct a safe remote error on the caller.

Unknown classes are rejected safely, internal error messages remain sanitized,
and responses without the field keep the existing legacy behavior.

## Compatibility

The field is additive and optional, so the query transport protocol version
does not change.

Tests cover:

- old responses without `class`
- new responses decoded by the legacy representation
- unknown/malformed classes
- no retry escalation

## Testing

Added a real TCP regression through:

`TcpQueryServer → TCP → TcpQueryCellClient`

Against the exact base revision, the admission case fails with:

`actual: query`  
`expected: admission`

The same regression passes with this change and also covers timeout, normal
query errors, and sanitized internal failures.

Hosted validation passed:

- `just native-check`
- `just test-placement`
- `just test-telemetry`
- `just check-all-features`
- `just check-client-api`
- `just check-bolt-server`
- `just test`
- `just test-opencypher`
- `just test-native`
- `just test-client-protocols`
- `just test-chaos`
- `just test-server-runtime`
- `just test-indexer`
- `just test-node-otlp`

`fmt-check`, the clippy variants, and therefore aggregate `just ci` currently
fail identically on the exact upstream base revision and this PR because of
existing upstream formatting drift and stable-Rust
`clippy::chunks_exact_to_as_chunks` diagnostics in untouched files.

Fixes #123