### PR TITLE
fix(opencypher): guard parser against exponential nesting depth (fixes #153)

### DIFF
--- a/src/query/opencypher.rs
+++ b/src/query/opencypher.rs
@@ -821,12 +821,84 @@ fn push_elided_literal(shape: &mut String) {
     shape.push('?');
 }
 
+const MAX_QUERY_NESTING_DEPTH: usize = 64;
+
+fn ensure_query_nesting_depth(query: &str) -> Result<()> {
+    let mut depth = 0_usize;
+    let mut in_single_quote = false;
+    let mut in_double_quote = false;
+    let mut in_line_comment = false;
+    let mut in_block_comment = false;
+    let mut chars = query.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        if in_line_comment {
+            if ch == '\n' {
+                in_line_comment = false;
+            }
+            continue;
+        }
+        if in_block_comment {
+            if ch == '*' && chars.peek() == Some(&'/') {
+                chars.next();
+                in_block_comment = false;
+            }
+            continue;
+        }
+        if in_single_quote {
+            if ch == '\\' {
+                chars.next();
+            } else if ch == '\'' {
+                in_single_quote = false;
+            }
+            continue;
+        }
+        if in_double_quote {
+            if ch == '\\' {
+                chars.next();
+            } else if ch == '"' {
+                in_double_quote = false;
+            }
+            continue;
+        }
+
+        if ch == '/' {
+            if chars.peek() == Some(&'/') {
+                chars.next();
+                in_line_comment = true;
+                continue;
+            } else if chars.peek() == Some(&'*') {
+                chars.next();
+                in_block_comment = true;
+                continue;
+            }
+        }
+
+        if ch == '\'' {
+            in_single_quote = true;
+        } else if ch == '"' {
+            in_double_quote = true;
+        } else if matches!(ch, '(' | '[' | '{') {
+            depth = depth.saturating_add(1);
+            if depth > MAX_QUERY_NESTING_DEPTH {
+                return Err(parse_error(format!(
+                    "query exceeds maximum expression nesting depth limit of {MAX_QUERY_NESTING_DEPTH}"
+                )));
+            }
+        } else if matches!(ch, ')' | ']' | '}') {
+            depth = depth.saturating_sub(1);
+        }
+    }
+    Ok(())
+}
+
 struct ParsedCypher {
     result: *mut sys::cypher_parse_result_t,
 }
 
 impl ParsedCypher {
     fn parse(query: &str) -> Result<Self> {
+        ensure_query_nesting_depth(query)?;
         let c_query =
             CString::new(query).map_err(|_| parse_error("query contains an embedded NUL byte"))?;
 
@@ -4601,5 +4673,21 @@ mod tests {
             opencypher_query_fingerprint("MATCH ((("),
             query_shape_fingerprint("MATCH ((("),
         );
+    }
+
+    #[test]
+    fn deeply_nested_query_expressions_are_rejected() {
+        // 70 levels of parentheses exceed MAX_QUERY_NESTING_DEPTH (64)
+        let open_parens = "(".repeat(70);
+        let close_parens = ")".repeat(70);
+        let pathological = format!("MATCH (n) WHERE {open_parens}n.id = 1{close_parens} RETURN n");
+        let error = parse_opencypher_row_query(&pathological).expect_err("should reject excessive nesting");
+        assert!(matches!(error, GraphError::QueryParse { .. }));
+        assert!(error.to_string().contains("nesting depth limit"));
+
+        // Parentheses inside string literals and comments do not count towards nesting depth
+        let literal_parens = "(".repeat(100);
+        let safe_query = format!("MATCH (n) WHERE n.name = '{literal_parens}' /* {literal_parens} */ RETURN n");
+        assert!(parse_opencypher_row_query(&safe_query).is_ok());
     }
 }

--- a/src/query/opencypher.rs
+++ b/src/query/opencypher.rs
@@ -827,6 +827,7 @@ fn ensure_query_nesting_depth(query: &str) -> Result<()> {
     let mut depth = 0_usize;
     let mut in_single_quote = false;
     let mut in_double_quote = false;
+    let mut in_backtick = false;
     let mut in_line_comment = false;
     let mut in_block_comment = false;
     let mut chars = query.chars().peekable();
@@ -861,6 +862,18 @@ fn ensure_query_nesting_depth(query: &str) -> Result<()> {
             }
             continue;
         }
+        if in_backtick {
+            if ch == '\\' {
+                chars.next();
+            } else if ch == '`' {
+                if chars.peek() == Some(&'`') {
+                    chars.next();
+                } else {
+                    in_backtick = false;
+                }
+            }
+            continue;
+        }
 
         if ch == '/' {
             if chars.peek() == Some(&'/') {
@@ -878,6 +891,8 @@ fn ensure_query_nesting_depth(query: &str) -> Result<()> {
             in_single_quote = true;
         } else if ch == '"' {
             in_double_quote = true;
+        } else if ch == '`' {
+            in_backtick = true;
         } else if matches!(ch, '(' | '[' | '{') {
             depth = depth.saturating_add(1);
             if depth > MAX_QUERY_NESTING_DEPTH {
@@ -4685,9 +4700,9 @@ mod tests {
         assert!(matches!(error, GraphError::QueryParse { .. }));
         assert!(error.to_string().contains("nesting depth limit"));
 
-        // Parentheses inside string literals and comments do not count towards nesting depth
+        // Parentheses, brackets, and braces inside string literals, comments, and backtick identifiers do not count towards nesting depth
         let literal_parens = "(".repeat(100);
-        let safe_query = format!("MATCH (n) WHERE n.name = '{literal_parens}' /* {literal_parens} */ RETURN n");
+        let safe_query = format!("MATCH (`n({literal_parens})`) WHERE `n({literal_parens})`.name = '{literal_parens}' /* {literal_parens} */ RETURN `n({literal_parens})`");
         assert!(parse_opencypher_row_query(&safe_query).is_ok());
     }
 }


### PR DESCRIPTION
Fixes #153.

## Summary

Adds a fast, zero-allocation pre-parse expression nesting depth guard before passing queries to the synchronous `libcypher-parser` C FFI call (`ParsedCypher::parse`), preventing exponential backtracking and tokio worker thread starvation from deeply nested expressions.

### Root Cause
`libcypher-parser`'s recursive-descent parser exhibits exponential time complexity on deeply nested parenthesized expressions (e.g. `WHERE (((((...)))))`). Because parsing occurs synchronously on tokio worker threads without a depth guard, pathological queries (even those under 100 bytes) can starve worker threads and block the async runtime.

### Changes
- **`src/query/opencypher.rs`**:
  - Implemented `ensure_query_nesting_depth` (`MAX_QUERY_NESTING_DEPTH = 64`) that scans expression nesting levels in $O(N)$ time with zero heap allocations before C FFI parsing.
  - Properly tracks and ignores parentheses, brackets, and braces inside single-quoted strings, double-quoted strings, single-line comments (`//`), and multi-line block comments (`/* ... */`).
  - Rejects queries exceeding 64 levels of nesting with a clean `GraphError::QueryParse`.
- **`src/query/opencypher.rs` (`tests`)**:
  - Added unit test `deeply_nested_query_expressions_are_rejected` asserting that queries exceeding the nesting limit are rejected immediately and that parentheses inside strings/comments are safely permitted.

## Test Plan
-Verified `deeply_nested_query_expressions_are_rejected` unit test.
-Verified that strings and comments containing parentheses are not counted towards expression depth limits.
