### PR TITLE
fix(http): reject unreadable or duplicated x-graph-namespace headers (fixes #75)

### DIFF
--- a/src/client/http.rs
+++ b/src/client/http.rs
@@ -597,18 +597,33 @@ fn http_graph_scope(
     graph_id: String,
     allow_default_namespace: bool,
 ) -> std::result::Result<GraphScope, HttpApiError> {
-    let namespace = match headers
-        .get(GRAPH_NAMESPACE_HEADER)
-        .and_then(|value| value.to_str().ok())
-    {
-        Some(namespace) => NamespacePath::new(
-            namespace
-                .split('/')
-                .map(|segment| NamespaceId::new(segment.to_string()))
-                .collect::<Result<Vec<_>>>()
-                .map_err(HttpApiError::from_graph)?,
-        )
-        .map_err(HttpApiError::from_graph)?,
+    if headers.get_all(GRAPH_NAMESPACE_HEADER).iter().count() > 1 {
+        return Err(HttpApiError {
+            status: StatusCode::BAD_REQUEST,
+            code: "invalid_namespace",
+            message: format!("{GRAPH_NAMESPACE_HEADER} header must not be duplicated"),
+            owner: None,
+            authenticate: false,
+        });
+    }
+    let namespace = match headers.get(GRAPH_NAMESPACE_HEADER) {
+        Some(value) => {
+            let namespace = value.to_str().map_err(|_| HttpApiError {
+                status: StatusCode::BAD_REQUEST,
+                code: "invalid_namespace",
+                message: format!("{GRAPH_NAMESPACE_HEADER} must be visible ASCII"),
+                owner: None,
+                authenticate: false,
+            })?;
+            NamespacePath::new(
+                namespace
+                    .split('/')
+                    .map(|segment| NamespaceId::new(segment.to_string()))
+                    .collect::<Result<Vec<_>>>()
+                    .map_err(HttpApiError::from_graph)?,
+            )
+            .map_err(HttpApiError::from_graph)?
+        }
         None if allow_default_namespace => NamespacePath::default(),
         None => {
             return Err(HttpApiError {

--- a/src/client/http/tests.rs
+++ b/src/client/http/tests.rs
@@ -356,3 +356,35 @@ async fn http_api_serves_authenticated_queries_over_https() {
     drop(client);
     server.stop().await.unwrap();
 }
+
+#[test]
+fn an_unreadable_namespace_header_is_rejected_rather_than_defaulted() {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        HeaderName::from_static(GRAPH_NAMESPACE_HEADER),
+        HeaderValue::from_bytes(&[0xff]).expect("a valid header byte"),
+    );
+
+    let error = http_graph_scope(&headers, "social".to_string(), true)
+        .expect_err("a present but unreadable namespace header must not default");
+    assert_eq!(error.status, StatusCode::BAD_REQUEST);
+    assert_eq!(error.code, "invalid_namespace");
+}
+
+#[test]
+fn a_duplicated_namespace_header_is_rejected() {
+    let mut headers = HeaderMap::new();
+    headers.append(
+        HeaderName::from_static(GRAPH_NAMESPACE_HEADER),
+        HeaderValue::from_static("tenant1"),
+    );
+    headers.append(
+        HeaderName::from_static(GRAPH_NAMESPACE_HEADER),
+        HeaderValue::from_static("tenant2"),
+    );
+
+    let error = http_graph_scope(&headers, "social".to_string(), true)
+        .expect_err("duplicated namespace header must be rejected");
+    assert_eq!(error.status, StatusCode::BAD_REQUEST);
+    assert_eq!(error.code, "invalid_namespace");
+}


### PR DESCRIPTION
## Summary

Fixes a security and tenancy routing defect where an unreadable or non-ASCII `x-graph-namespace` header was collapsed into `None` by `.and_then(|v| v.to_str().ok())`, causing the server to silently treat it as an absent header and route the query to the `default` namespace when `allow_default_namespace` is enabled. Also explicitly rejects requests with duplicate `x-graph-namespace` headers.

### Root Cause
In `http_graph_scope` (`src/client/http.rs:600-622`), `headers.get(GRAPH_NAMESPACE_HEADER).and_then(|value| value.to_str().ok())` caused `HeaderValue::to_str()` errors (e.g. non-ASCII bytes or badly encoded client headers) to be turned into `None`. Under `allow_default_namespace`, this matched the `None if allow_default_namespace` arm and executed against `NamespacePath::default()` instead of failing with `400 BAD_REQUEST`.

### Changes
- **`src/client/http.rs` (`http_graph_scope`)**:
  - Differentiated between absent headers (`None`) and present-but-unreadable headers (`Some(value)` with non-ASCII or invalid UTF-8 bytes), returning a `400 BAD_REQUEST` with code `"invalid_namespace"`.
  - Added a validation check to reject duplicate `x-graph-namespace` headers (`headers.get_all(..).iter().count() > 1`).
- **`src/client/http/tests.rs`**:
  - Added unit test `an_unreadable_namespace_header_is_rejected_rather_than_defaulted` asserting `400 BAD_REQUEST` (`invalid_namespace`) for byte `0xff`.
  - Added unit test `a_duplicated_namespace_header_is_rejected` asserting `400 BAD_REQUEST` when multiple namespace headers are supplied.

## Test Plan
- Verified `an_unreadable_namespace_header_is_rejected_rather_than_defaulted` unit test.
- Verified `a_duplicated_namespace_header_is_rejected` unit test.
- Verified existing HTTP API authentication and query test suites.
