### PR TITLE
fix(query): drop null join keys in merge_distributed_inner_join (fixes #96)

### DIFF
--- a/src/query/coordination.rs
+++ b/src/query/coordination.rs
@@ -4969,6 +4969,7 @@ mod scope_grant_tests {
 
     #[test]
     fn merge_distributed_inner_join_drops_null_join_keys() {
+        // Case 1: right rows <= left rows (exercises right_by_key hash-table branch)
         let left_result = QueryResultSet::new(
             vec![QueryColumn::new("id"), QueryColumn::new("manager_id")],
             vec![
@@ -4993,6 +4994,36 @@ mod scope_grant_tests {
         let merged = merge_distributed_inner_join(&leg_results, &join).unwrap();
         assert_eq!(
             merged.rows,
+            vec![QueryRow::new(vec![
+                QueryValue::VertexId(1),
+                QueryValue::VertexId(10),
+                QueryValue::VertexId(10),
+            ])]
+        );
+
+        // Case 2: left rows < right rows (exercises left_by_key hash-table branch)
+        let left_result_small = QueryResultSet::new(
+            vec![QueryColumn::new("id"), QueryColumn::new("manager_id")],
+            vec![
+                QueryRow::new(vec![QueryValue::VertexId(1), QueryValue::VertexId(10)]),
+                QueryRow::new(vec![QueryValue::VertexId(2), QueryValue::Null]),
+            ],
+        );
+        let right_result_large = QueryResultSet::new(
+            vec![QueryColumn::new("id")],
+            vec![
+                QueryRow::new(vec![QueryValue::VertexId(10)]),
+                QueryRow::new(vec![QueryValue::Null]),
+                QueryRow::new(vec![QueryValue::Null]),
+            ],
+        );
+        let leg_results_rev = BTreeMap::from([
+            ("users".to_string(), left_result_small),
+            ("managers".to_string(), right_result_large),
+        ]);
+        let merged_rev = merge_distributed_inner_join(&leg_results_rev, &join).unwrap();
+        assert_eq!(
+            merged_rev.rows,
             vec![QueryRow::new(vec![
                 QueryValue::VertexId(1),
                 QueryValue::VertexId(10),

--- a/src/query/coordination.rs
+++ b/src/query/coordination.rs
@@ -3018,6 +3018,9 @@ fn merge_distributed_inner_join(
                     reason: "right row is missing join column".to_string(),
                 });
             };
+            if matches!(key, QueryValue::Null) {
+                continue;
+            }
             right_by_key.entry(key).or_default().push(row);
         }
 
@@ -3028,6 +3031,9 @@ fn merge_distributed_inner_join(
                     reason: "left row is missing join column".to_string(),
                 });
             };
+            if matches!(key, QueryValue::Null) {
+                continue;
+            }
             if let Some(right_rows) = right_by_key.get(key) {
                 for right_row in right_rows {
                     let mut values = left_row.values.clone();
@@ -3045,6 +3051,9 @@ fn merge_distributed_inner_join(
                     reason: "left row is missing join column".to_string(),
                 });
             };
+            if matches!(key, QueryValue::Null) {
+                continue;
+            }
             left_by_key.entry(key).or_default().push(row);
         }
 
@@ -3055,6 +3064,9 @@ fn merge_distributed_inner_join(
                     reason: "right row is missing join column".to_string(),
                 });
             };
+            if matches!(key, QueryValue::Null) {
+                continue;
+            }
             if let Some(left_rows) = left_by_key.get(key) {
                 for left_row in left_rows {
                     let mut values = left_row.values.clone();
@@ -4953,5 +4965,39 @@ mod scope_grant_tests {
             &GraphScope::new(tenant, GraphId::new("other").unwrap()),
             QueryTransportAction::Read,
         ));
+    }
+
+    #[test]
+    fn merge_distributed_inner_join_drops_null_join_keys() {
+        let left_result = QueryResultSet::new(
+            vec![QueryColumn::new("id"), QueryColumn::new("manager_id")],
+            vec![
+                QueryRow::new(vec![QueryValue::VertexId(1), QueryValue::VertexId(10)]),
+                QueryRow::new(vec![QueryValue::VertexId(2), QueryValue::Null]),
+                QueryRow::new(vec![QueryValue::VertexId(3), QueryValue::Null]),
+            ],
+        );
+        let right_result = QueryResultSet::new(
+            vec![QueryColumn::new("id")],
+            vec![
+                QueryRow::new(vec![QueryValue::VertexId(10)]),
+                QueryRow::new(vec![QueryValue::Null]),
+            ],
+        );
+        let leg_results = BTreeMap::from([
+            ("users".to_string(), left_result),
+            ("managers".to_string(), right_result),
+        ]);
+        let join = DistributedQueryJoin::inner("users", "manager_id", "managers", "id");
+
+        let merged = merge_distributed_inner_join(&leg_results, &join).unwrap();
+        assert_eq!(
+            merged.rows,
+            vec![QueryRow::new(vec![
+                QueryValue::VertexId(1),
+                QueryValue::VertexId(10),
+                QueryValue::VertexId(10),
+            ])]
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fixes a bug in `merge_distributed_inner_join` where `QueryValue::Null` join keys were treated as equal values across legs, causing cross-joining of all null-keyed rows instead of dropping them per Cypher inner join semantics.

### Root Cause
In `merge_distributed_inner_join` (`src/query/coordination.rs:2986-3068`), both the right-hash and left-hash merge branches inserted raw join-column values directly into a `BTreeMap<QueryValue, Vec<&QueryRow>>` and probed it with the other leg's values without filtering out `QueryValue::Null`. Because `QueryValue::Null` implements `Ord`/`Eq`, all null-keyed rows were bucketed together and matched, producing spurious cross products of null rows.

### Changes
- **`src/query/coordination.rs` (`merge_distributed_inner_join`)**:
  - Filtered out `QueryValue::Null` keys when populating the hash map (`right_by_key` / `left_by_key`) on both branches.
  - Filtered out `QueryValue::Null` probe keys during row lookup, avoiding unnecessary map queries and ensuring null-keyed rows are never joined.
- **`src/query/coordination.rs` (`tests`)**:
  - Added unit test `merge_distributed_inner_join_drops_null_join_keys` verifying that nullable join columns with `null` keys on both legs are dropped and only valid matching keys are emitted.

## Test Plan
- Verified `merge_distributed_inner_join_drops_null_join_keys` unit test.
- Verified that single-leg and cross-cell distributed joins produce identical results for nullable join keys.
