### PR TITLE
fix(query): deduplicate requests_failed metric accounting (fixes #77)

### DIFF
--- a/src/query/coordination.rs
+++ b/src/query/coordination.rs
@@ -4951,10 +4951,10 @@ mod scope_grant_tests {
         ));
     }
 
-    #[test]
-    fn transport_error_response_increments_requests_failed_once() {
+    #[tokio::test]
+    async fn metered_query_failure_reconciles_request_counters() {
         let metrics = Arc::new(QueryTransportMetrics::default());
-        let runtime = QueryTransportServerRuntime {
+        let runtime = Arc::new(QueryTransportServerRuntime {
             config: QueryTransportServerConfig::default(),
             metrics: metrics.clone(),
             lifecycle: Arc::new(Mutex::new(QueryTransportLifecycle::default())),
@@ -4962,15 +4962,35 @@ mod scope_grant_tests {
             namespace_query_gates: BTreeMap::new(),
             connection_gate: Arc::new(Semaphore::new(10)),
             control_connection_gate: Arc::new(Semaphore::new(10)),
+        });
+
+        let scope = GraphScope::new(
+            NamespacePath::root(NamespaceId::new("test").unwrap()),
+            GraphId::new("default").unwrap(),
+        );
+        let lifecycle_key = QueryLifecycleKey::new(
+            QueryTransportPrincipal::Anonymous,
+            scope,
+            "q1",
+        );
+
+        let result = execute_metered_query(&runtime, &lifecycle_key, |_cancellation_token| async {
+            Err::<QueryResultSet, _>(GraphError::AdmissionRejected {
+                operation: "test",
+                actual: 10,
+                limit: 5,
+            })
+        })
+        .await;
+
+        let response = match result {
+            Ok(result) => QueryTransportResponse::Rows { result },
+            Err(err) => transport_error_response(&runtime, err),
         };
 
-        let err = GraphError::AdmissionRejected {
-            operation: "test",
-            actual: 10,
-            limit: 5,
-        };
-        let response = transport_error_response(&runtime, err);
         assert!(matches!(response, QueryTransportResponse::Error { .. }));
+        assert_eq!(metrics.requests_started.load(Ordering::Relaxed), 1);
+        assert_eq!(metrics.requests_completed.load(Ordering::Relaxed), 0);
         assert_eq!(metrics.requests_failed.load(Ordering::Relaxed), 1);
     }
 }

--- a/src/query/coordination.rs
+++ b/src/query/coordination.rs
@@ -4470,16 +4470,12 @@ where
         QueryLifecycleFinish::Cancelled => Err(cancelled_query_error()),
         QueryLifecycleFinish::NotCancelled | QueryLifecycleFinish::NotOwned => result,
     };
-    match &result {
-        Ok(_) => runtime
+    if result.is_ok() {
+        runtime
             .metrics
             .requests_completed
-            .fetch_add(1, Ordering::Relaxed),
-        Err(_) => runtime
-            .metrics
-            .requests_failed
-            .fetch_add(1, Ordering::Relaxed),
-    };
+            .fetch_add(1, Ordering::Relaxed);
+    }
     result
 }
 
@@ -4953,5 +4949,28 @@ mod scope_grant_tests {
             &GraphScope::new(tenant, GraphId::new("other").unwrap()),
             QueryTransportAction::Read,
         ));
+    }
+
+    #[test]
+    fn transport_error_response_increments_requests_failed_once() {
+        let metrics = Arc::new(QueryTransportMetrics::default());
+        let runtime = QueryTransportServerRuntime {
+            config: QueryTransportServerConfig::default(),
+            metrics: metrics.clone(),
+            lifecycle: Arc::new(Mutex::new(QueryTransportLifecycle::default())),
+            request_gate: Arc::new(Semaphore::new(10)),
+            namespace_query_gates: BTreeMap::new(),
+            connection_gate: Arc::new(Semaphore::new(10)),
+            control_connection_gate: Arc::new(Semaphore::new(10)),
+        };
+
+        let err = GraphError::AdmissionRejected {
+            operation: "test",
+            actual: 10,
+            limit: 5,
+        };
+        let response = transport_error_response(&runtime, err);
+        assert!(matches!(response, QueryTransportResponse::Error { .. }));
+        assert_eq!(metrics.requests_failed.load(Ordering::Relaxed), 1);
     }
 }


### PR DESCRIPTION
## Summary

Fixes a bug where `runtime.metrics.requests_failed` was double-counted for every query that failed during execution.

### Root Cause
In `src/query/coordination.rs`:
- `execute_metered_query` incremented `runtime.metrics.requests_failed` in the `Err` match arm upon execution failure.
- Its callers (`Rows`, `Page`, `Batch`, `BatchPage`) then forwarded that `Err` to `transport_error_response`, which incremented `runtime.metrics.requests_failed` a second time.
- Consequently, a single failed query resulted in `requests_started = 1`, `requests_completed = 0`, `requests_failed = 2`, breaking metric reconciliation and producing false 200% failure rates.

### Changes
- **`src/query/coordination.rs` (`execute_metered_query`)**:
  - Removed the duplicate `requests_failed` increment from `execute_metered_query`, leaving `transport_error_response` as the single canonical owner of failure accounting across all query paths (including pre-execution auth/authz failures and lifecycle errors).
- **`src/query/coordination.rs` (`tests`)**:
  - Added unit test `transport_error_response_increments_requests_failed_once` verifying that failed requests increment `requests_failed` exactly once.


- Verified `transport_error_response_increments_requests_failed_once` unit test.
- Verified `requests_started == requests_completed + requests_failed` reconciliation.
