### PR TITLE
fix(config): name attempted file path when auth-token read fails (fixes #101)

### DIFF
--- a/src/bin/graph_node/config.rs
+++ b/src/bin/graph_node/config.rs
@@ -317,11 +317,23 @@ impl RuntimeConfig {
     }
 
     pub fn read_auth_token(&self) -> ConfigResult<String> {
-        let token = std::fs::read_to_string(&self.auth_token_file)?
+        let token = std::fs::read_to_string(&self.auth_token_file)
+            .map_err(|err| {
+                Error::new(
+                    err.kind(),
+                    format!(
+                        "failed to read auth-token file {}: {err}",
+                        self.auth_token_file.display()
+                    ),
+                )
+            })?
             .trim()
             .to_string();
         if token.len() < 32 || token.eq_ignore_ascii_case("change-me") {
-            return invalid("graph auth token must contain at least 32 non-placeholder characters");
+            return invalid(format!(
+                "graph auth token in {} must contain at least 32 non-placeholder characters",
+                self.auth_token_file.display()
+            ));
         }
         Ok(token)
     }
@@ -723,5 +735,22 @@ mod tests {
         assert_eq!(memory.max_relationship_rows_bytes, 0);
         assert_eq!(memory.max_source_relationship_rows_bytes, 0);
         assert_eq!(memory.max_relationship_property_rows_bytes, 0);
+    }
+
+    #[test]
+    fn read_auth_token_names_path_on_error() {
+        let values = BTreeMap::from([
+            ("GRAPH_ALLOW_PLAINTEXT".to_string(), "true".to_string()),
+            (
+                "GRAPH_AUTH_TOKEN_FILE".to_string(),
+                "/nonexistent/path/to/auth-token".to_string(),
+            ),
+        ]);
+        let config = RuntimeConfig::from_values(values).unwrap();
+        let err = config.read_auth_token().unwrap_err();
+        assert!(
+            err.to_string().contains("/nonexistent/path/to/auth-token"),
+            "error should name the attempted path: {err}"
+        );
     }
 }

--- a/src/bin/graph_node/config.rs
+++ b/src/bin/graph_node/config.rs
@@ -739,18 +739,39 @@ mod tests {
 
     #[test]
     fn read_auth_token_names_path_on_error() {
+        let auth_token_file = std::env::temp_dir().join(format!(
+            "hydradb-missing-auth-token-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
         let values = BTreeMap::from([
             ("GRAPH_ALLOW_PLAINTEXT".to_string(), "true".to_string()),
             (
                 "GRAPH_AUTH_TOKEN_FILE".to_string(),
-                "/nonexistent/path/to/auth-token".to_string(),
+                auth_token_file.display().to_string(),
             ),
         ]);
         let config = RuntimeConfig::from_values(values).unwrap();
         let err = config.read_auth_token().unwrap_err();
         assert!(
-            err.to_string().contains("/nonexistent/path/to/auth-token"),
+            err.to_string()
+                .contains(&auth_token_file.display().to_string()),
             "error should name the attempted path: {err}"
+        );
+
+        // Also verify when path is a directory (Issue #101 IsADirectory)
+        let dir = std::env::temp_dir();
+        let values_dir = BTreeMap::from([
+            ("GRAPH_ALLOW_PLAINTEXT".to_string(), "true".to_string()),
+            ("GRAPH_AUTH_TOKEN_FILE".to_string(), dir.display().to_string()),
+        ]);
+        let config_dir = RuntimeConfig::from_values(values_dir).unwrap();
+        let err_dir = config_dir.read_auth_token().unwrap_err();
+        assert!(
+            err_dir.to_string().contains(&dir.display().to_string()),
+            "error should name the directory path: {err_dir}"
         );
     }
 }


### PR DESCRIPTION
## Summary

Enhances error messages when reading the auth token file during node startup so that the attempted path is clearly named instead of producing an opaque `Os { code: 21, kind: IsADirectory }` or `NotFound` error.

### Root Cause
In `src/bin/graph_node/config.rs:319-327`, `read_auth_token` called `std::fs::read_to_string(&self.auth_token_file)?`. When the path was missing or pointed to a directory (such as on container volume mounts), `read_to_string` yielded an anonymous `std::io::Error` without the path, making it difficult for operators to determine which path caused the failure.

### Changes
- **`src/bin/graph_node/config.rs` (`read_auth_token`)**:
  - Mapped filesystem IO errors to include the attempted path (`failed to read auth-token file <path>: <err>`).
  - Included the path in token validation errors if the token is shorter than 32 characters or contains placeholder values.
- **`src/bin/graph_node/config.rs` (`tests`)**:
  - Added unit test `read_auth_token_names_path_on_error` asserting that attempting to read a non-existent or invalid file produces an error containing the attempted path.

## Test Plan
-Verified `read_auth_token_names_path_on_error` unit test in `src/bin/graph_node/config.rs`.
-Verified that existing valid auth token loading continues to work as expected.
