### PR TITLE
Name auth-token path in startup read errors

### DIFF
--- a/src/bin/graph_node/config.rs
+++ b/src/bin/graph_node/config.rs
@@ -317,7 +317,16 @@ impl RuntimeConfig {
     }
 
     pub fn read_auth_token(&self) -> ConfigResult<String> {
-        let token = std::fs::read_to_string(&self.auth_token_file)?
+        let token = std::fs::read_to_string(&self.auth_token_file)
+            .map_err(|error| {
+                std::io::Error::new(
+                    error.kind(),
+                    format!(
+                        "failed to read graph auth token from {}: {error}",
+                        self.auth_token_file.display()
+                    ),
+                )
+            })?
             .trim()
             .to_string();
         if token.len() < 32 || token.eq_ignore_ascii_case("change-me") {
@@ -723,5 +732,41 @@ mod tests {
         assert_eq!(memory.max_relationship_rows_bytes, 0);
         assert_eq!(memory.max_source_relationship_rows_bytes, 0);
         assert_eq!(memory.max_relationship_property_rows_bytes, 0);
+    }
+    #[test]
+    fn read_auth_token_error_names_missing_file() {
+        let path = std::env::temp_dir().join("hydradb-missing-auth-token-test");
+        let _ = std::fs::remove_file(&path);
+
+        let mut values =
+            BTreeMap::from([("GRAPH_ALLOW_PLAINTEXT".to_string(), "true".to_string())]);
+        values.insert(
+            "GRAPH_AUTH_TOKEN_FILE".to_string(),
+            path.display().to_string(),
+        );
+
+        let config = RuntimeConfig::from_values(values).unwrap();
+        let error = config.read_auth_token().unwrap_err();
+
+        assert!(error.to_string().contains(&path.display().to_string()));
+    }
+
+    #[test]
+    fn read_auth_token_error_names_directory() {
+        let directory = tempfile::tempdir().unwrap();
+
+        let mut values =
+            BTreeMap::from([("GRAPH_ALLOW_PLAINTEXT".to_string(), "true".to_string())]);
+        values.insert(
+            "GRAPH_AUTH_TOKEN_FILE".to_string(),
+            directory.path().display().to_string(),
+        );
+
+        let config = RuntimeConfig::from_values(values).unwrap();
+        let error = config.read_auth_token().unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains(&directory.path().display().to_string()));
     }
 }

--- a/src/bin/graph_node/config.rs
+++ b/src/bin/graph_node/config.rs
@@ -735,8 +735,8 @@ mod tests {
     }
     #[test]
     fn read_auth_token_error_names_missing_file() {
-        let path = std::env::temp_dir().join("hydradb-missing-auth-token-test");
-        let _ = std::fs::remove_file(&path);
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("missing-auth-token");
 
         let mut values =
             BTreeMap::from([("GRAPH_ALLOW_PLAINTEXT".to_string(), "true".to_string())]);


### PR DESCRIPTION
## Summary

- Include the attempted auth-token file path when reading the token fails.
- Preserve the original I/O error kind.
- Add regression tests for missing auth-token files and directory paths.

## Testing

- `just test-server-runtime`
- `git diff --check`

Fixes #101