### PR TITLE
feat(query): allow labelled UNWIND edge creates

### DIFF
--- a/src/client/service.rs
+++ b/src/client/service.rs
@@ -2476,6 +2476,18 @@ fn resolve_unwind_batch(
             source_label,
             destination_label,
         }),
+        ParsedUnwindBatchKind::CreateEdgesWithLabeledEndpoints {
+            edge_type,
+            source_field,
+            destination_field,
+            source_label,
+            destination_label,
+        } => Ok(QueryBatchOperation::CreateEdgesWithLabeledEndpoints {
+            edge_type,
+            edges: unwind_batch_edges(rows, &source_field, &destination_field)?,
+            source_label,
+            destination_label,
+        }),
         ParsedUnwindBatchKind::DeleteEdges {
             edge_type,
             source_field,
@@ -2722,6 +2734,7 @@ fn batch_operation_columns(operation: &QueryBatchOperation) -> Vec<QueryColumn> 
         } => vec![source_column.clone(), destination_column.clone()],
         QueryBatchOperation::CreateEdges { .. }
         | QueryBatchOperation::CreateEdgesBetweenLabeledVertices { .. }
+        | QueryBatchOperation::CreateEdgesWithLabeledEndpoints { .. }
         | QueryBatchOperation::DeleteEdges { .. }
         | QueryBatchOperation::DeleteVertices { .. }
         | QueryBatchOperation::DeleteRelationshipsByProperty { .. }

--- a/src/query/algebra.rs
+++ b/src/query/algebra.rs
@@ -169,6 +169,12 @@ pub enum QueryBatchOperation {
         source_label: String,
         destination_label: String,
     },
+    CreateEdgesWithLabeledEndpoints {
+        edge_type: String,
+        edges: Vec<QueryBatchEdge>,
+        source_label: String,
+        destination_label: String,
+    },
     UpsertVertices {
         vertices: Vec<QueryBatchVertex>,
     },
@@ -241,6 +247,7 @@ impl QueryBatchOperation {
             self,
             Self::CreateEdges { .. }
                 | Self::CreateEdgesBetweenLabeledVertices { .. }
+                | Self::CreateEdgesWithLabeledEndpoints { .. }
                 | Self::DeleteEdges { .. }
                 | Self::DeleteVertices { .. }
                 | Self::DeleteRelationshipsByProperty { .. }
@@ -257,6 +264,7 @@ impl QueryBatchOperation {
             Self::OutNeighbors { sources, .. } => sources.len(),
             Self::CreateEdges { edges, .. }
             | Self::CreateEdgesBetweenLabeledVertices { edges, .. }
+            | Self::CreateEdgesWithLabeledEndpoints { edges, .. }
             | Self::DeleteEdges { edges, .. } => edges.len(),
             Self::DeleteVertices { vertices, .. } => vertices.len(),
             Self::DeleteRelationshipsByProperty { values, .. } => values.len(),

--- a/src/query/coordination.rs
+++ b/src/query/coordination.rs
@@ -3272,6 +3272,37 @@ impl QueryCellClient for RoutedGraphCluster {
                     .await?;
                 Ok(QueryResultSet::new(Vec::new(), Vec::new()))
             }
+            crate::QueryBatchOperation::CreateEdgesWithLabeledEndpoints {
+                edge_type,
+                edges,
+                source_label,
+                destination_label,
+            } => {
+                self.ensure_local_writer(&context.cell_id).await?;
+                let mutations =
+                    edges
+                        .into_iter()
+                        .enumerate()
+                        .map(|(index, edge)| crate::EdgeMutation {
+                            cell_id: context.cell_id.clone(),
+                            edge_type: edge_type.clone(),
+                            src: edge.src,
+                            dst: edge.dst,
+                            idempotency_key: format!(
+                                "{}.unwind-create-labelled.{index:020}",
+                                context.idempotency_key
+                            ),
+                        });
+                shard
+                    .write_edge_mutations_batch_creating_labeled_vertices(
+                        &context.cell_id,
+                        mutations,
+                        &source_label,
+                        &destination_label,
+                    )
+                    .await?;
+                Ok(QueryResultSet::new(Vec::new(), Vec::new()))
+            }
             crate::QueryBatchOperation::UpsertVertices { vertices } => {
                 self.ensure_local_writer(&context.cell_id).await?;
                 shard

--- a/src/query/opencypher.rs
+++ b/src/query/opencypher.rs
@@ -73,6 +73,13 @@ pub(crate) enum ParsedUnwindBatchKind {
         source_label: String,
         destination_label: String,
     },
+    CreateEdgesWithLabeledEndpoints {
+        edge_type: String,
+        source_field: String,
+        destination_field: String,
+        source_label: String,
+        destination_label: String,
+    },
     DeleteEdges {
         edge_type: String,
         source_field: String,
@@ -914,6 +921,7 @@ impl ParsedCypher {
                     batch.kind,
                     ParsedUnwindBatchKind::CreateEdges { .. }
                         | ParsedUnwindBatchKind::CreateEdgesBetweenLabeledVertices { .. }
+                        | ParsedUnwindBatchKind::CreateEdgesWithLabeledEndpoints { .. }
                         | ParsedUnwindBatchKind::DeleteEdges { .. }
                         | ParsedUnwindBatchKind::DeleteVertices { .. }
                         | ParsedUnwindBatchKind::DeleteRelationshipsByProperty { .. }
@@ -1003,17 +1011,33 @@ impl ParsedCypher {
                     return unsupported("UNWIND CREATE cannot be followed by another clause");
                 }
                 let pattern = checked_node(sys::cypher_ast_create_get_pattern(second))?;
-                let edge = unwind_edge_template(pattern, &alias, true)?;
-                return Ok(Some(ParsedUnwindBatch {
-                    parameter,
-                    kind: ParsedUnwindBatchKind::CreateEdges {
+                let edge = unwind_edge_template(pattern, &alias, true, true)?;
+                let kind = match (edge.source_label, edge.destination_label) {
+                    (None, None) => ParsedUnwindBatchKind::CreateEdges {
                         edge_type: edge.edge_type,
                         source_field: edge.source_field,
                         destination_field: edge.destination_field.ok_or_else(|| {
                             unsupported_value("UNWIND CREATE requires destination id field")
                         })?,
                     },
-                }));
+                    (Some(source_label), Some(destination_label)) => {
+                        ParsedUnwindBatchKind::CreateEdgesWithLabeledEndpoints {
+                            edge_type: edge.edge_type,
+                            source_field: edge.source_field,
+                            destination_field: edge.destination_field.ok_or_else(|| {
+                                unsupported_value("UNWIND CREATE requires destination id field")
+                            })?,
+                            source_label,
+                            destination_label,
+                        }
+                    }
+                    _ => {
+                        return unsupported(
+                            "UNWIND CREATE labels must be specified on both endpoint nodes",
+                        );
+                    }
+                };
+                return Ok(Some(ParsedUnwindBatch { parameter, kind }));
             }
 
             if !is_instance(second, sys::CYPHER_AST_MATCH) || !(3..=4).contains(&clause_count) {
@@ -1143,7 +1167,7 @@ impl ParsedCypher {
                         },
                     }));
                 }
-                let edge = unwind_edge_template(pattern, &alias, true)?;
+                let edge = unwind_edge_template(pattern, &alias, true, false)?;
                 let relationship_binding = edge.relationship_binding.ok_or_else(|| {
                     unsupported_value("UNWIND DELETE requires a named relationship")
                 })?;
@@ -1173,7 +1197,7 @@ impl ParsedCypher {
             if clause_count != 3 {
                 return unsupported("UNWIND MATCH RETURN cannot be followed by another clause");
             }
-            let edge = unwind_edge_template(pattern, &alias, false)?;
+            let edge = unwind_edge_template(pattern, &alias, false, false)?;
             let destination_binding = edge.destination_binding.ok_or_else(|| {
                 unsupported_value("UNWIND batch read requires a named destination node")
             })?;
@@ -2915,6 +2939,8 @@ struct UnwindEdgeTemplate {
     destination_field: Option<String>,
     destination_binding: Option<String>,
     relationship_binding: Option<String>,
+    source_label: Option<String>,
+    destination_label: Option<String>,
 }
 
 #[cfg(feature = "client-api")]
@@ -2922,6 +2948,7 @@ fn unwind_edge_template(
     pattern: *const AstNode,
     unwind_alias: &str,
     require_destination_field: bool,
+    allow_endpoint_labels: bool,
 ) -> Result<UnwindEdgeTemplate> {
     unsafe {
         ensure_instance(pattern, sys::CYPHER_AST_PATTERN, "UNWIND edge pattern")?;
@@ -2960,10 +2987,17 @@ fn unwind_edge_template(
             0,
         ))?)?;
         let relationship_binding = rel_identifier(relationship)?;
-        let left_field = unwind_node_id_field(left, unwind_alias, true)?;
-        let right_field = unwind_node_id_field(right, unwind_alias, require_destination_field)?;
+        let left_field = unwind_node_id_field(left, unwind_alias, true, allow_endpoint_labels)?;
+        let right_field = unwind_node_id_field(
+            right,
+            unwind_alias,
+            require_destination_field,
+            allow_endpoint_labels,
+        )?;
         let left_binding = node_identifier(left)?;
         let right_binding = node_identifier(right)?;
+        let left_label = unwind_node_label(left)?;
+        let right_label = unwind_node_label(right)?;
         match sys::cypher_ast_rel_pattern_get_direction(relationship) {
             sys::cypher_rel_direction::CYPHER_REL_OUTBOUND => Ok(UnwindEdgeTemplate {
                 edge_type,
@@ -2972,6 +3006,8 @@ fn unwind_edge_template(
                 destination_field: right_field,
                 destination_binding: right_binding,
                 relationship_binding,
+                source_label: left_label,
+                destination_label: right_label,
             }),
             sys::cypher_rel_direction::CYPHER_REL_INBOUND => Ok(UnwindEdgeTemplate {
                 edge_type,
@@ -2980,6 +3016,8 @@ fn unwind_edge_template(
                 destination_field: left_field,
                 destination_binding: left_binding,
                 relationship_binding,
+                source_label: right_label,
+                destination_label: left_label,
             }),
             sys::cypher_rel_direction::CYPHER_REL_BIDIRECTIONAL => {
                 unsupported("UNWIND batch does not support undirected relationships")
@@ -2993,9 +3031,10 @@ fn unwind_node_id_field(
     node: *const AstNode,
     unwind_alias: &str,
     required: bool,
+    allow_label: bool,
 ) -> Result<Option<String>> {
     unsafe {
-        if sys::cypher_ast_node_pattern_nlabels(node) != 0 {
+        if !allow_label && sys::cypher_ast_node_pattern_nlabels(node) != 0 {
             return unsupported("UNWIND batch node patterns do not support labels");
         }
         let properties = sys::cypher_ast_node_pattern_get_properties(node);
@@ -3021,6 +3060,20 @@ fn unwind_node_id_field(
             return unsupported("UNWIND batch node id references the wrong row alias");
         }
         Ok(Some(field))
+    }
+}
+
+#[cfg(feature = "client-api")]
+fn unwind_node_label(node: *const AstNode) -> Result<Option<String>> {
+    unsafe {
+        match sys::cypher_ast_node_pattern_nlabels(node) {
+            0 => Ok(None),
+            1 => label_name(checked_node(sys::cypher_ast_node_pattern_get_label(
+                node, 0,
+            ))?)
+            .map(Some),
+            _ => unsupported("UNWIND CREATE endpoint nodes support exactly one label"),
+        }
     }
 }
 
@@ -3893,6 +3946,45 @@ mod tests {
                 destination_label: "Source".to_string(),
             }
         );
+    }
+
+    #[cfg(feature = "client-api")]
+    #[test]
+    fn lowers_unwind_create_between_labeled_vertices() {
+        let parsed = parse_opencypher_unwind_batch(
+            "UNWIND $rows AS row \
+             CREATE (s:Source {id: row.source_vertex}) \
+                    -[:FORCEFUL_RELATION]-> \
+                    (r:Related {id: row.related_vertex})",
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(parsed.parameter, "rows");
+        assert_eq!(
+            parsed.kind,
+            ParsedUnwindBatchKind::CreateEdgesWithLabeledEndpoints {
+                edge_type: "FORCEFUL_RELATION".to_string(),
+                source_field: "source_vertex".to_string(),
+                destination_field: "related_vertex".to_string(),
+                source_label: "Source".to_string(),
+                destination_label: "Related".to_string(),
+            }
+        );
+    }
+
+    #[cfg(feature = "client-api")]
+    #[test]
+    fn rejects_unwind_create_with_a_label_on_only_one_endpoint() {
+        let error = parse_opencypher_unwind_batch(
+            "UNWIND $rows AS row \
+             CREATE (s:Source {id: row.source_vertex}) \
+                    -[:FORCEFUL_RELATION]-> \
+                    (r {id: row.related_vertex})",
+        )
+        .unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("labels must be specified on both endpoint nodes"));
     }
 
     #[cfg(feature = "client-api")]

--- a/src/shard/write.rs
+++ b/src/shard/write.rs
@@ -4181,6 +4181,7 @@ impl GraphShard {
             cell_id,
             mutations.into_iter().collect(),
             None,
+            false,
             "write_edge_mutations_batch",
         )
         .await
@@ -4200,7 +4201,28 @@ impl GraphShard {
             cell_id,
             mutations.into_iter().collect(),
             Some((source_label, destination_label)),
+            false,
             "write_edge_mutations_batch_between_labeled_vertices",
+        )
+        .await
+    }
+
+    #[cfg(feature = "opencypher")]
+    pub(crate) async fn write_edge_mutations_batch_creating_labeled_vertices(
+        &self,
+        cell_id: &str,
+        mutations: impl IntoIterator<Item = EdgeMutation>,
+        source_label: &str,
+        destination_label: &str,
+    ) -> Result<EdgeMutationBatchResult> {
+        validate_component("source_label", source_label)?;
+        validate_component("destination_label", destination_label)?;
+        self.write_edge_mutations_batch_with_endpoint_labels(
+            cell_id,
+            mutations.into_iter().collect(),
+            Some((source_label, destination_label)),
+            true,
+            "write_edge_mutations_batch_creating_labeled_vertices",
         )
         .await
     }
@@ -4210,6 +4232,7 @@ impl GraphShard {
         cell_id: &str,
         mutations: Vec<EdgeMutation>,
         endpoint_labels: Option<(&str, &str)>,
+        create_endpoint_labels: bool,
         operation: &'static str,
     ) -> Result<EdgeMutationBatchResult> {
         validate_component("cell_id", cell_id)?;
@@ -4259,7 +4282,13 @@ impl GraphShard {
                 .await;
             for attempt in 0..GRAPH_TXN_MAX_RETRIES {
                 match self
-                    .write_edge_mutations_batch_txn(cell_id, &mutations, operation, endpoint_labels)
+                    .write_edge_mutations_batch_txn(
+                        cell_id,
+                        &mutations,
+                        operation,
+                        endpoint_labels,
+                        create_endpoint_labels,
+                    )
                     .await
                 {
                     Err(err)
@@ -4368,10 +4397,17 @@ impl GraphShard {
         mutations: &[EdgeMutation],
         operation: &'static str,
         endpoint_labels: Option<(&str, &str)>,
+        create_endpoint_labels: bool,
     ) -> Result<EdgeMutationBatchResult> {
         let lock = self.acquire_local_write_guard(cell_id, operation).await?;
         let result = self
-            .write_edge_mutations_batch_txn_locked(cell_id, mutations, operation, endpoint_labels)
+            .write_edge_mutations_batch_txn_locked(
+                cell_id,
+                mutations,
+                operation,
+                endpoint_labels,
+                create_endpoint_labels,
+            )
             .await;
         finish_local_write(lock, result).await
     }
@@ -4382,6 +4418,7 @@ impl GraphShard {
         mutations: &[EdgeMutation],
         operation: &'static str,
         endpoint_labels: Option<(&str, &str)>,
+        create_endpoint_labels: bool,
     ) -> Result<EdgeMutationBatchResult> {
         let txn = self
             .db
@@ -4424,6 +4461,97 @@ impl GraphShard {
         let mut inserted = 0_u64;
         let mut already_existed = 0_u64;
 
+        if create_endpoint_labels {
+            let (source_label, destination_label) =
+                endpoint_labels.ok_or_else(|| GraphError::CorruptValue {
+                    key: operation.to_string(),
+                    reason: "creating endpoint labels requires labels".to_string(),
+                })?;
+            let requested_labels = format!("{source_label}\0{destination_label}");
+            let idempotency_values = read_txn_remote_many(
+                &txn,
+                mutations.iter().flat_map(|mutation| {
+                    [
+                        keys::idempotency(cell_id, "create", &mutation.idempotency_key),
+                        keys::idempotency(cell_id, "create-labels", &mutation.idempotency_key),
+                    ]
+                }),
+            )
+            .await?;
+            let mut pending_label_idempotency = BTreeSet::new();
+            for mutation in mutations {
+                let edge_key = keys::idempotency(cell_id, "create", &mutation.idempotency_key);
+                let labels_key =
+                    keys::idempotency(cell_id, "create-labels", &mutation.idempotency_key);
+                match (
+                    idempotency_values.get(&edge_key).and_then(Option::as_ref),
+                    idempotency_values.get(&labels_key).and_then(Option::as_ref),
+                ) {
+                    (Some(_), Some(value)) if value.as_ref() == requested_labels.as_bytes() => {}
+                    (Some(_), _) | (None, Some(_)) => {
+                        return Err(GraphError::IdempotencyConflict {
+                            operation: "create",
+                            idempotency_key: mutation.idempotency_key.clone(),
+                            reason:
+                                "a labelled edge create was retried with different endpoint labels"
+                                    .to_string(),
+                        })
+                    }
+                    (None, None) => {
+                        pending_label_idempotency.insert(mutation.idempotency_key.clone());
+                    }
+                }
+            }
+            let mut labels_by_vertex = BTreeMap::<VertexId, BTreeSet<String>>::new();
+            for mutation in mutations {
+                if !pending_label_idempotency.contains(&mutation.idempotency_key) {
+                    continue;
+                }
+                labels_by_vertex
+                    .entry(mutation.src)
+                    .or_default()
+                    .insert(source_label.to_string());
+                labels_by_vertex
+                    .entry(mutation.dst)
+                    .or_default()
+                    .insert(destination_label.to_string());
+            }
+            let endpoint_keys = labels_by_vertex
+                .keys()
+                .map(|vertex| keys::vertex(cell_id, *vertex));
+            let endpoint_values = read_txn_remote_many(&txn, endpoint_keys).await?;
+            let mut labels_changed = false;
+            for (vertex, labels) in labels_by_vertex {
+                let key = keys::vertex(cell_id, vertex);
+                let previous = match endpoint_values.get(&key).and_then(Option::as_ref) {
+                    Some(value) => decode_vertex_metadata(&key, &value)?,
+                    None => VertexMetadata::default(),
+                };
+                let mut next = previous.clone();
+                next.labels.extend(labels);
+                if next != previous {
+                    labels_changed = true;
+                    apply_vertex_metadata_update_txn(
+                        &txn,
+                        cell_id,
+                        vertex,
+                        &previous,
+                        &next,
+                        commit_epoch,
+                    )?;
+                }
+            }
+            if labels_changed {
+                next_epoch = commit_epoch;
+            }
+            for idempotency_key in pending_label_idempotency {
+                txn.put(
+                    keys::idempotency(cell_id, "create-labels", &idempotency_key).as_bytes(),
+                    requested_labels.as_bytes(),
+                )?;
+            }
+        }
+
         for mutation in mutations {
             let idem_key = keys::idempotency(cell_id, "create", &mutation.idempotency_key);
             if let Some(value) = read_txn_remote(&txn, &idem_key).await? {
@@ -4437,31 +4565,33 @@ impl GraphShard {
                 continue;
             }
 
-            if let Some((source_label, destination_label)) = endpoint_labels {
-                for (vertex, label) in [
-                    (mutation.src, source_label),
-                    (mutation.dst, destination_label),
-                ] {
-                    if !validated_endpoints.insert((vertex, label.to_string())) {
-                        continue;
-                    }
-                    let key = keys::vertex(cell_id, vertex);
-                    let Some(value) = read_txn_remote(&txn, &key).await? else {
-                        return Err(GraphError::UnsupportedQuery {
-                            dialect: "OpenCypher",
-                            feature: format!(
+            if !create_endpoint_labels {
+                if let Some((source_label, destination_label)) = endpoint_labels {
+                    for (vertex, label) in [
+                        (mutation.src, source_label),
+                        (mutation.dst, destination_label),
+                    ] {
+                        if !validated_endpoints.insert((vertex, label.to_string())) {
+                            continue;
+                        }
+                        let key = keys::vertex(cell_id, vertex);
+                        let Some(value) = read_txn_remote(&txn, &key).await? else {
+                            return Err(GraphError::UnsupportedQuery {
+                                dialect: "OpenCypher",
+                                feature: format!(
                                 "MATCH endpoint vertex {vertex} with label {label} does not exist"
                             ),
-                        });
-                    };
-                    let metadata = decode_vertex_metadata(&key, &value)?;
-                    if !metadata.labels.contains(label) {
-                        return Err(GraphError::UnsupportedQuery {
-                            dialect: "OpenCypher",
-                            feature: format!(
-                                "MATCH endpoint vertex {vertex} does not have label {label}"
-                            ),
-                        });
+                            });
+                        };
+                        let metadata = decode_vertex_metadata(&key, &value)?;
+                        if !metadata.labels.contains(label) {
+                            return Err(GraphError::UnsupportedQuery {
+                                dialect: "OpenCypher",
+                                feature: format!(
+                                    "MATCH endpoint vertex {vertex} does not have label {label}"
+                                ),
+                            });
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Fixes #116.

Adds support for labelled endpoint nodes in direct `UNWIND … CREATE` edge batches:

UNWIND $rows AS row
CREATE (s:Source {id: row.source})-[:LINKS]->(d:Destination {id: row.destination})


Behaviour
- Creates or merges the Source and Destination labels on endpoint vertices.
- Writes batch edges in the same transaction as endpoint metadata updates.
- Supports one label per endpoint; labels on only one endpoint are rejected explicitly.
- Keeps existing UNWIND MATCH … CREATE semantics unchanged: that form still requires matching labelled vertices to exist.
Invariant
A successful labelled batch CREATE never commits edges without the requested endpoint labels. A failed write commits neither.



Tests
- Added parser coverage for direct labelled UNWIND CREATE.
- Added rejection coverage for a label on only one endpoint.
- Local Rust test execution was blocked because this Windows environment lacks the MSVC linker (link.exe); GitHub CI should run the full suite.