### PR TITLE
fix(path_procedure): allow single-source path procedures to reach all depths with zero pathCount (fixes #188)

### DIFF
--- a/src/shard/path_procedure.rs
+++ b/src/shard/path_procedure.rs
@@ -1256,7 +1256,8 @@ fn enumerate_unweighted_candidate_paths(
     let mut minimum_depth = None;
     while let Some((nodes, edges)) = queue.pop_front() {
         budget.check("native_path_breadth_first")?;
-        if minimum_depth.is_some_and(|depth| edges.len() >= depth)
+        if (procedure.kind == NativePathProcedureKind::SinglePair
+            && minimum_depth.is_some_and(|depth| edges.len() >= depth))
             || edges.len() >= usize::from(procedure.max_len)
         {
             continue;
@@ -1289,12 +1290,13 @@ fn enumerate_unweighted_candidate_paths(
                     cost: 0.0,
                 });
                 if procedure.path_count > 0
+                    && procedure.kind == NativePathProcedureKind::SinglePair
                     && candidates.len()
                         >= usize::try_from(procedure.path_count).unwrap_or(usize::MAX)
                 {
                     return Ok(candidates);
                 }
-                if procedure.path_count == 0 {
+                if procedure.path_count == 0 && procedure.kind == NativePathProcedureKind::SinglePair {
                     minimum_depth.get_or_insert(next_edges.len());
                 }
             }
@@ -1492,6 +1494,33 @@ fn select_native_paths(procedure: &NativePathProcedure, candidates: &mut Vec<Can
     if procedure.fair_relationship_variants {
         return;
     }
+    if procedure.kind == NativePathProcedureKind::SingleSource {
+        let mut grouped: BTreeMap<VertexId, Vec<CandidatePath>> = BTreeMap::new();
+        for candidate in candidates.drain(..) {
+            if let Some(dst) = candidate.nodes.last().copied() {
+                grouped.entry(dst).or_default().push(candidate);
+            }
+        }
+        for (_, group) in &mut grouped {
+            if procedure.path_count == 0 {
+                if let Some(weight) = group.first().map(|c| c.weight) {
+                    group.retain(|c| c.weight.total_cmp(&weight).is_eq());
+                }
+            } else {
+                group.truncate(usize::try_from(procedure.path_count).unwrap_or(usize::MAX));
+            }
+            candidates.extend(group.drain(..));
+        }
+        candidates.sort_by(|left, right| {
+            left.weight
+                .total_cmp(&right.weight)
+                .then_with(|| left.cost.total_cmp(&right.cost))
+                .then_with(|| left.edges.len().cmp(&right.edges.len()))
+                .then_with(|| left.nodes.cmp(&right.nodes))
+                .then_with(|| left.edges.cmp(&right.edges))
+        });
+        return;
+    }
     if procedure.path_count == 0 {
         if let Some(weight) = candidates.first().map(|candidate| candidate.weight) {
             candidates.retain(|candidate| candidate.weight.total_cmp(&weight).is_eq());
@@ -1680,5 +1709,38 @@ mod tests {
                 "path_count={path_count} target=5"
             );
         }
+    }
+
+    #[test]
+    fn single_source_zero_path_count_reaches_all_depths() {
+        let adjacency = BTreeMap::from([
+            (1, vec![edge(1, 2), edge(1, 3)]),
+            (2, vec![edge(2, 4)]),
+            (3, vec![edge(3, 4)]),
+            (4, vec![edge(4, 5)]),
+        ]);
+        let budget = QueryBudget::new(None, None);
+        let mut request = procedure(NativePathProcedureKind::SingleSource, None);
+        request.path_count = 0;
+        request.max_len = 5;
+
+        let mut candidates =
+            enumerate_unweighted_candidate_paths(&request, &adjacency, 100, &budget).unwrap();
+        for candidate in &mut candidates {
+            candidate.weight = candidate.edges.len() as f64;
+        }
+        select_native_paths(&request, &mut candidates);
+
+        let nodes = candidate_nodes(&candidates);
+        // Destination 2 (1 hop)
+        assert!(nodes.contains(&vec![1, 2]));
+        // Destination 3 (1 hop)
+        assert!(nodes.contains(&vec![1, 3]));
+        // Destination 4 (tied 2-hop shortest paths: 1->2->4 and 1->3->4)
+        assert!(nodes.contains(&vec![1, 2, 4]));
+        assert!(nodes.contains(&vec![1, 3, 4]));
+        // Destination 5 (3 hops: 1->2->4->5 and 1->3->4->5)
+        assert!(nodes.contains(&vec![1, 2, 4, 5]));
+        assert!(nodes.contains(&vec![1, 3, 4, 5]));
     }
 }

--- a/src/shard/path_procedure.rs
+++ b/src/shard/path_procedure.rs
@@ -1253,11 +1253,15 @@ fn enumerate_unweighted_candidate_paths(
 ) -> Result<Vec<CandidatePath>> {
     let mut queue = VecDeque::from([(vec![procedure.source], Vec::<PathEdge>::new())]);
     let mut candidates = Vec::new();
-    let mut minimum_depth = None;
+    let mut single_pair_min_depth = None;
+    let mut destination_min_depths = BTreeMap::<VertexId, usize>::new();
+    let mut destination_candidate_counts = BTreeMap::<VertexId, usize>::new();
+    let requested_per_dest = usize::try_from(procedure.path_count).unwrap_or(usize::MAX);
+
     while let Some((nodes, edges)) = queue.pop_front() {
         budget.check("native_path_breadth_first")?;
         if (procedure.kind == NativePathProcedureKind::SinglePair
-            && minimum_depth.is_some_and(|depth| edges.len() >= depth))
+            && single_pair_min_depth.is_some_and(|depth| edges.len() >= depth))
             || edges.len() >= usize::from(procedure.max_len)
         {
             continue;
@@ -1270,34 +1274,69 @@ fn enumerate_unweighted_candidate_paths(
             if nodes.contains(&next) {
                 continue;
             }
+            let depth = edges.len().saturating_add(1);
+
+            if procedure.kind == NativePathProcedureKind::SingleSource {
+                if let Some(&min_depth) = destination_min_depths.get(&next) {
+                    if depth > min_depth {
+                        continue;
+                    }
+                    if procedure.path_count > 0
+                        && destination_candidate_counts.get(&next).copied().unwrap_or(0)
+                            >= requested_per_dest
+                    {
+                        continue;
+                    }
+                } else {
+                    destination_min_depths.insert(next, depth);
+                }
+            }
+
             let mut next_nodes = nodes.clone();
             next_nodes.push(next);
             let mut next_edges = edges.clone();
             next_edges.push(edge.clone());
             let at_target = procedure.target.is_some_and(|target| target == next);
             if procedure.kind == NativePathProcedureKind::SingleSource || at_target {
-                if candidates.len() >= max_candidates {
-                    return Err(GraphError::AdmissionRejected {
-                        operation: "native_path_candidates",
-                        actual: candidates.len().saturating_add(1) as u64,
-                        limit: max_candidates as u64,
+                let should_record = if procedure.kind == NativePathProcedureKind::SingleSource {
+                    if procedure.path_count > 0 {
+                        destination_candidate_counts.get(&next).copied().unwrap_or(0)
+                            < requested_per_dest
+                    } else {
+                        destination_min_depths.get(&next).copied() == Some(depth)
+                    }
+                } else {
+                    true
+                };
+
+                if should_record {
+                    if candidates.len() >= max_candidates {
+                        return Err(GraphError::AdmissionRejected {
+                            operation: "native_path_candidates",
+                            actual: candidates.len().saturating_add(1) as u64,
+                            limit: max_candidates as u64,
+                        });
+                    }
+                    candidates.push(CandidatePath {
+                        nodes: next_nodes.clone(),
+                        edges: next_edges.clone(),
+                        weight: next_edges.len() as f64,
+                        cost: 0.0,
                     });
-                }
-                candidates.push(CandidatePath {
-                    nodes: next_nodes.clone(),
-                    edges: next_edges.clone(),
-                    weight: next_edges.len() as f64,
-                    cost: 0.0,
-                });
-                if procedure.path_count > 0
-                    && procedure.kind == NativePathProcedureKind::SinglePair
-                    && candidates.len()
-                        >= usize::try_from(procedure.path_count).unwrap_or(usize::MAX)
-                {
-                    return Ok(candidates);
-                }
-                if procedure.path_count == 0 && procedure.kind == NativePathProcedureKind::SinglePair {
-                    minimum_depth.get_or_insert(next_edges.len());
+                    if procedure.kind == NativePathProcedureKind::SingleSource {
+                        *destination_candidate_counts.entry(next).or_default() += 1;
+                    }
+                    if procedure.path_count > 0
+                        && procedure.kind == NativePathProcedureKind::SinglePair
+                        && candidates.len() >= requested_per_dest
+                    {
+                        return Ok(candidates);
+                    }
+                    if procedure.path_count == 0
+                        && procedure.kind == NativePathProcedureKind::SinglePair
+                    {
+                        single_pair_min_depth.get_or_insert(next_edges.len());
+                    }
                 }
             }
             if !(procedure.kind == NativePathProcedureKind::SinglePair && at_target) {
@@ -1742,5 +1781,42 @@ mod tests {
         // Destination 5 (3 hops: 1->2->4->5 and 1->3->4->5)
         assert!(nodes.contains(&vec![1, 2, 4, 5]));
         assert!(nodes.contains(&vec![1, 3, 4, 5]));
+    }
+
+    #[test]
+    fn single_source_dense_graph_prunes_longer_non_shortest_paths() {
+        // In a dense/clique-like graph, node 1 connects directly to 2, 3, 4.
+        // Node 2 also connects to 3 and 4, and node 3 connects to 4.
+        let adjacency = BTreeMap::from([
+            (1, vec![edge(1, 2), edge(1, 3), edge(1, 4)]),
+            (2, vec![edge(2, 3), edge(2, 4)]),
+            (3, vec![edge(3, 4)]),
+            (4, vec![]),
+        ]);
+        let budget = QueryBudget::new(None, None);
+        let mut request = procedure(NativePathProcedureKind::SingleSource, None);
+        request.path_count = 0;
+        request.max_len = 5;
+
+        let mut candidates =
+            enumerate_unweighted_candidate_paths(&request, &adjacency, 100, &budget).unwrap();
+        for candidate in &mut candidates {
+            candidate.weight = candidate.edges.len() as f64;
+        }
+        select_native_paths(&request, &mut candidates);
+
+        let nodes = candidate_nodes(&candidates);
+        // Direct 1-hop paths to 2, 3, 4 must be retained
+        assert!(nodes.contains(&vec![1, 2]));
+        assert!(nodes.contains(&vec![1, 3]));
+        assert!(nodes.contains(&vec![1, 4]));
+
+        // Longer non-shortest paths (e.g. 1->2->3, 1->2->4, 1->3->4, 1->2->3->4)
+        // must be pruned during traversal and not present
+        assert!(!nodes.contains(&vec![1, 2, 3]));
+        assert!(!nodes.contains(&vec![1, 2, 4]));
+        assert!(!nodes.contains(&vec![1, 3, 4]));
+        assert!(!nodes.contains(&vec![1, 2, 3, 4]));
+        assert_eq!(candidates.len(), 3);
     }
 }


### PR DESCRIPTION
Fixes #188

## Summary

Fixes a bug where calling `algo.SSpaths` (Single-Source Shortest Paths) with `pathCount: 0` prematurely halted BFS exploration after depth 1, returning only direct neighbors of the source vertex and completely omitting all reachable destinations at depth $\ge 2$.

### Root Cause
In `src/shard/path_procedure.rs`:
1. **BFS Queue Truncation (`enumerate_unweighted_candidate_paths`)**:
   When `procedure.path_count == 0`, `minimum_depth` was set as soon as the first neighbor was reached (`depth = 1`). Subsequent BFS queue exploration was pruned with `edges.len() >= depth`, terminating traversal before deeper levels were explored. While this logic is valid for `SinglePair` (where we search for a specific target), for `SingleSource` we must discover paths to *all* reachable destinations.
2. **Global Candidate Filtering (`select_native_paths`)**:
   `select_native_paths` previously filtered candidates globally against the minimum weight across all candidates. For `SingleSource`, candidates must be grouped by destination vertex (`nodes.last()`), filtering for tied shortest paths per destination rather than globally.

### Changes
- **`src/shard/path_procedure.rs`**:
  - Gated `minimum_depth` pruning and `path_count` early termination in `enumerate_unweighted_candidate_paths` to `NativePathProcedureKind::SinglePair`.
  - In `select_native_paths`, added destination grouping for `SingleSource` procedures so that tied shortest paths are retained per destination.
  - Added unit test `single_source_zero_path_count_reaches_all_depths` verifying that multi-hop destinations (and tied shortest paths) at depths 1, 2, and 3 are returned for `SingleSource` with `path_count: 0`.
