### PR TITLE
fix(query): implement three-valued logic for missing property predicates (fixes #186)

### DIFF
--- a/src/shard/query.rs
+++ b/src/shard/query.rs
@@ -8106,7 +8106,8 @@ fn eval_row_predicate(row: &BindingRow, predicate: &RowPredicate) -> Result<TriB
                         TriBool::False
                     }
                 }
-                RowScalarValue::Value(_) | RowScalarValue::Missing => TriBool::Null,
+                RowScalarValue::Value(_) => TriBool::False,
+                RowScalarValue::Missing => TriBool::Null,
             }
         }
         RowPredicate::And(left, right) => {
@@ -9255,6 +9256,30 @@ mod tests {
         // NOT (n.name STARTS WITH 'A') -> NOT Null = Null -> not true
         let not_starts_with = RowPredicate::Not(Box::new(starts_with_pred));
         assert!(!row_predicate_matches(&row, &not_starts_with).unwrap());
+
+        // StartsWith on present non-string property -> False
+        let non_string_starts_with = RowPredicate::StartsWith {
+            expression: RowExpression::Property {
+                binding: "n".to_string(),
+                property: "age".to_string(),
+            },
+            prefix: "A".to_string(),
+        };
+        let mut row_with_age = BindingRow::from_node(&node, 1).unwrap();
+        let mut props = BTreeMap::new();
+        props.insert("age".to_string(), VertexPropertyValue::Integer(30));
+        row_with_age.metadata.insert(
+            "n".to_string(),
+            VertexMetadata {
+                labels: vec!["User".to_string()],
+                properties: props,
+            },
+        );
+        // Present integer property does not start with string -> False -> excluded
+        assert!(!row_predicate_matches(&row_with_age, &non_string_starts_with).unwrap());
+        // NOT (present integer STARTS WITH 'A') -> NOT False = True -> included
+        let not_non_string_starts_with = RowPredicate::Not(Box::new(non_string_starts_with));
+        assert!(row_predicate_matches(&row_with_age, &not_non_string_starts_with).unwrap());
 
         // Missing property in OR: (n.age = 30 OR n.id = 1) -> Null OR True = True
         let id_pred = RowPredicate::Compare {

--- a/src/shard/query.rs
+++ b/src/shard/query.rs
@@ -8051,7 +8051,46 @@ fn vertex_metadata_matches(metadata: &VertexMetadata, node: &RowNodePattern) -> 
 }
 
 #[cfg(feature = "opencypher")]
-fn row_predicate_matches(row: &BindingRow, predicate: &RowPredicate) -> Result<bool> {
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum TriBool {
+    True,
+    False,
+    Null,
+}
+
+#[cfg(feature = "opencypher")]
+impl TriBool {
+    fn not(self) -> Self {
+        match self {
+            Self::True => Self::False,
+            Self::False => Self::True,
+            Self::Null => Self::Null,
+        }
+    }
+
+    fn and(self, other: Self) -> Self {
+        match (self, other) {
+            (Self::False, _) | (_, Self::False) => Self::False,
+            (Self::True, Self::True) => Self::True,
+            _ => Self::Null,
+        }
+    }
+
+    fn or(self, other: Self) -> Self {
+        match (self, other) {
+            (Self::True, _) | (_, Self::True) => Self::True,
+            (Self::False, Self::False) => Self::False,
+            _ => Self::Null,
+        }
+    }
+
+    fn is_true(self) -> bool {
+        matches!(self, Self::True)
+    }
+}
+
+#[cfg(feature = "opencypher")]
+fn eval_row_predicate(row: &BindingRow, predicate: &RowPredicate) -> Result<TriBool> {
     Ok(match predicate {
         RowPredicate::Compare { left, op, right } => compare_row_values(
             eval_row_expression(row, left)?,
@@ -8061,19 +8100,38 @@ fn row_predicate_matches(row: &BindingRow, predicate: &RowPredicate) -> Result<b
         RowPredicate::StartsWith { expression, prefix } => {
             match eval_row_expression(row, expression)? {
                 RowScalarValue::Value(VertexPropertyValue::String(value)) => {
-                    value.starts_with(prefix)
+                    if value.starts_with(prefix) {
+                        TriBool::True
+                    } else {
+                        TriBool::False
+                    }
                 }
-                RowScalarValue::Value(_) | RowScalarValue::Missing => false,
+                RowScalarValue::Value(_) | RowScalarValue::Missing => TriBool::Null,
             }
         }
         RowPredicate::And(left, right) => {
-            row_predicate_matches(row, left)? && row_predicate_matches(row, right)?
+            let left_val = eval_row_predicate(row, left)?;
+            if left_val == TriBool::False {
+                TriBool::False
+            } else {
+                left_val.and(eval_row_predicate(row, right)?)
+            }
         }
         RowPredicate::Or(left, right) => {
-            row_predicate_matches(row, left)? || row_predicate_matches(row, right)?
+            let left_val = eval_row_predicate(row, left)?;
+            if left_val == TriBool::True {
+                TriBool::True
+            } else {
+                left_val.or(eval_row_predicate(row, right)?)
+            }
         }
-        RowPredicate::Not(inner) => !row_predicate_matches(row, inner)?,
+        RowPredicate::Not(inner) => eval_row_predicate(row, inner)?.not(),
     })
+}
+
+#[cfg(feature = "opencypher")]
+fn row_predicate_matches(row: &BindingRow, predicate: &RowPredicate) -> Result<bool> {
+    Ok(eval_row_predicate(row, predicate)?.is_true())
 }
 
 #[cfg(feature = "opencypher")]
@@ -8240,11 +8298,15 @@ fn compare_row_values(
     left: RowScalarValue,
     op: RowComparisonOp,
     right: RowScalarValue,
-) -> Result<bool> {
+) -> Result<TriBool> {
     let (RowScalarValue::Value(left), RowScalarValue::Value(right)) = (left, right) else {
-        return Ok(false);
+        return Ok(TriBool::Null);
     };
-    compare_vertex_property_values(&left, op, &right)
+    Ok(if compare_vertex_property_values(&left, op, &right)? {
+        TriBool::True
+    } else {
+        TriBool::False
+    })
 }
 
 #[cfg(feature = "opencypher")]
@@ -9098,5 +9160,115 @@ fn compare_u64_f64(left: u64, right: f64) -> std::cmp::Ordering {
         std::cmp::Ordering::Equal if floor == right => std::cmp::Ordering::Equal,
         std::cmp::Ordering::Equal => std::cmp::Ordering::Less,
         ordering => ordering,
+    }
+}
+
+#[cfg(all(test, feature = "opencypher"))]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+    use crate::core::VertexMetadata;
+
+    #[test]
+    fn test_tribool_logic() {
+        assert_eq!(TriBool::True.not(), TriBool::False);
+        assert_eq!(TriBool::False.not(), TriBool::True);
+        assert_eq!(TriBool::Null.not(), TriBool::Null);
+
+        assert_eq!(TriBool::True.and(TriBool::True), TriBool::True);
+        assert_eq!(TriBool::True.and(TriBool::False), TriBool::False);
+        assert_eq!(TriBool::True.and(TriBool::Null), TriBool::Null);
+        assert_eq!(TriBool::False.and(TriBool::True), TriBool::False);
+        assert_eq!(TriBool::False.and(TriBool::False), TriBool::False);
+        assert_eq!(TriBool::False.and(TriBool::Null), TriBool::False);
+        assert_eq!(TriBool::Null.and(TriBool::True), TriBool::Null);
+        assert_eq!(TriBool::Null.and(TriBool::False), TriBool::False);
+        assert_eq!(TriBool::Null.and(TriBool::Null), TriBool::Null);
+
+        assert_eq!(TriBool::True.or(TriBool::True), TriBool::True);
+        assert_eq!(TriBool::True.or(TriBool::False), TriBool::True);
+        assert_eq!(TriBool::True.or(TriBool::Null), TriBool::True);
+        assert_eq!(TriBool::False.or(TriBool::True), TriBool::True);
+        assert_eq!(TriBool::False.or(TriBool::False), TriBool::False);
+        assert_eq!(TriBool::False.or(TriBool::Null), TriBool::Null);
+        assert_eq!(TriBool::Null.or(TriBool::True), TriBool::True);
+        assert_eq!(TriBool::Null.or(TriBool::False), TriBool::Null);
+        assert_eq!(TriBool::Null.or(TriBool::Null), TriBool::Null);
+
+        assert!(TriBool::True.is_true());
+        assert!(!TriBool::False.is_true());
+        assert!(!TriBool::Null.is_true());
+    }
+
+    #[test]
+    fn test_row_predicate_missing_property_evaluates_to_null() {
+        let mut node = RowNodePattern::default();
+        node.binding = Some("n".to_string());
+        let mut row = BindingRow::from_node(&node, 1).unwrap();
+        let metadata = VertexMetadata {
+            labels: vec!["User".to_string()],
+            properties: BTreeMap::new(),
+        };
+        row.metadata.insert("n".to_string(), metadata);
+
+        let compare_pred = RowPredicate::Compare {
+            left: RowExpression::Property {
+                binding: "n".to_string(),
+                property: "age".to_string(),
+            },
+            op: RowComparisonOp::Eq,
+            right: RowExpression::Literal(VertexPropertyValue::Integer(30)),
+        };
+
+        // n.age = 30 -> Null -> not true
+        assert!(!row_predicate_matches(&row, &compare_pred).unwrap());
+
+        // NOT (n.age = 30) -> NOT Null = Null -> not true (fixes #186)
+        let not_pred = RowPredicate::Not(Box::new(compare_pred.clone()));
+        assert!(!row_predicate_matches(&row, &not_pred).unwrap());
+
+        // n.age <> 30 -> Null -> not true
+        let ne_pred = RowPredicate::Compare {
+            left: RowExpression::Property {
+                binding: "n".to_string(),
+                property: "age".to_string(),
+            },
+            op: RowComparisonOp::Ne,
+            right: RowExpression::Literal(VertexPropertyValue::Integer(30)),
+        };
+        assert!(!row_predicate_matches(&row, &ne_pred).unwrap());
+
+        // NOT (n.age <> 30) -> NOT Null = Null -> not true
+        let not_ne_pred = RowPredicate::Not(Box::new(ne_pred));
+        assert!(!row_predicate_matches(&row, &not_ne_pred).unwrap());
+
+        // StartsWith on missing property -> Null -> not true
+        let starts_with_pred = RowPredicate::StartsWith {
+            expression: RowExpression::Property {
+                binding: "n".to_string(),
+                property: "name".to_string(),
+            },
+            prefix: "A".to_string(),
+        };
+        assert!(!row_predicate_matches(&row, &starts_with_pred).unwrap());
+
+        // NOT (n.name STARTS WITH 'A') -> NOT Null = Null -> not true
+        let not_starts_with = RowPredicate::Not(Box::new(starts_with_pred));
+        assert!(!row_predicate_matches(&row, &not_starts_with).unwrap());
+
+        // Missing property in OR: (n.age = 30 OR n.id = 1) -> Null OR True = True
+        let id_pred = RowPredicate::Compare {
+            left: RowExpression::NodeId {
+                binding: "n".to_string(),
+            },
+            op: RowComparisonOp::Eq,
+            right: RowExpression::Literal(VertexPropertyValue::Integer(1)),
+        };
+        let or_pred = RowPredicate::Or(Box::new(compare_pred.clone()), Box::new(id_pred.clone()));
+        assert!(row_predicate_matches(&row, &or_pred).unwrap());
+
+        // Missing property in AND: (n.age = 30 AND n.id = 1) -> Null AND True = Null -> false
+        let and_pred = RowPredicate::And(Box::new(compare_pred), Box::new(id_pred));
+        assert!(!row_predicate_matches(&row, &and_pred).unwrap());
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -13214,6 +13214,142 @@ async fn cypher_rows_filter_project_and_sort_vertex_metadata() {
 
 #[cfg(feature = "opencypher")]
 #[tokio::test]
+async fn missing_property_predicate_three_valued_logic() {
+    let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let shard = open_test_shard("graph/missing-property-3vl", object_store).await;
+
+    // User 1 has age 30
+    shard
+        .set_vertex_metadata(
+            "reddit-home",
+            1,
+            VertexMetadata::default()
+                .with_label("User")
+                .with_property("id", VertexPropertyValue::Integer(1))
+                .with_property("age", VertexPropertyValue::Integer(30)),
+        )
+        .await
+        .unwrap();
+
+    // User 2 has NO age property
+    shard
+        .set_vertex_metadata(
+            "reddit-home",
+            2,
+            VertexMetadata::default()
+                .with_label("User")
+                .with_property("id", VertexPropertyValue::Integer(2)),
+        )
+        .await
+        .unwrap();
+
+    // 1. Positive match on age = 30 returns user 1 only
+    let rows = shard
+        .execute_cypher_rows(
+            QueryContext::new("reddit-home", "cypher-missing-prop-1"),
+            "MATCH (n:User) WHERE n.age = 30 RETURN n.id AS id",
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        rows,
+        QueryResultSet::new(
+            vec![QueryColumn::new("id")],
+            vec![QueryRow::new(vec![QueryValue::Property(
+                VertexPropertyValue::Integer(1)
+            )])],
+        )
+    );
+
+    // 2. Negated match NOT (n.age = 30):
+    // User 1: age = 30 is true, NOT true is false -> excluded
+    // User 2: age is missing, so age = 30 is null, NOT null is null -> excluded (Issue #186 fix)
+    let rows = shard
+        .execute_cypher_rows(
+            QueryContext::new("reddit-home", "cypher-missing-prop-2"),
+            "MATCH (n:User) WHERE NOT (n.age = 30) RETURN n.id AS id",
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        rows,
+        QueryResultSet::new(vec![QueryColumn::new("id")], vec![])
+    );
+
+    // 3. Inequality n.age <> 30:
+    // User 1: 30 <> 30 is false -> excluded
+    // User 2: missing <> 30 is null -> excluded
+    let rows = shard
+        .execute_cypher_rows(
+            QueryContext::new("reddit-home", "cypher-missing-prop-3"),
+            "MATCH (n:User) WHERE n.age <> 30 RETURN n.id AS id",
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        rows,
+        QueryResultSet::new(vec![QueryColumn::new("id")], vec![])
+    );
+
+    // 4. Negated inequality NOT (n.age <> 30):
+    // User 1: 30 <> 30 is false, NOT false is true -> included!
+    // User 2: missing <> 30 is null, NOT null is null -> excluded!
+    let rows = shard
+        .execute_cypher_rows(
+            QueryContext::new("reddit-home", "cypher-missing-prop-4"),
+            "MATCH (n:User) WHERE NOT (n.age <> 30) RETURN n.id AS id",
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        rows,
+        QueryResultSet::new(
+            vec![QueryColumn::new("id")],
+            vec![QueryRow::new(vec![QueryValue::Property(
+                VertexPropertyValue::Integer(1)
+            )])],
+        )
+    );
+
+    // 5. OR predicate: n.age = 30 OR n.id = 2
+    // User 1: age = 30 is true -> true
+    // User 2: age = 30 is null, id = 2 is true -> null OR true = true
+    let rows = shard
+        .execute_cypher_rows(
+            QueryContext::new("reddit-home", "cypher-missing-prop-5"),
+            "MATCH (n:User) WHERE n.age = 30 OR n.id = 2 RETURN n.id AS id ORDER BY id",
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        rows,
+        QueryResultSet::new(
+            vec![QueryColumn::new("id")],
+            vec![
+                QueryRow::new(vec![QueryValue::Property(VertexPropertyValue::Integer(1))]),
+                QueryRow::new(vec![QueryValue::Property(VertexPropertyValue::Integer(2))]),
+            ],
+        )
+    );
+
+    // 6. AND predicate: n.age = 30 AND n.id = 2
+    // User 1: true AND false = false
+    // User 2: null AND true = null -> excluded
+    let rows = shard
+        .execute_cypher_rows(
+            QueryContext::new("reddit-home", "cypher-missing-prop-6"),
+            "MATCH (n:User) WHERE n.age = 30 AND n.id = 2 RETURN n.id AS id",
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        rows,
+        QueryResultSet::new(vec![QueryColumn::new("id")], vec![])
+    );
+}
+
+#[cfg(feature = "opencypher")]
+#[tokio::test]
 async fn vertex_metadata_indexes_are_replaced_on_update() {
     let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
     let shard = open_test_shard("graph/vertex-metadata-index-update", object_store).await;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -13346,6 +13346,26 @@ async fn missing_property_predicate_three_valued_logic() {
         rows,
         QueryResultSet::new(vec![QueryColumn::new("id")], vec![])
     );
+
+    // 7. STARTS WITH on present non-string property:
+    // User 1: age is integer 30 -> n.age STARTS WITH '3' is false -> NOT (false) is true -> included!
+    // User 2: age is missing -> null -> NOT (null) is null -> excluded!
+    let rows = shard
+        .execute_cypher_rows(
+            QueryContext::new("reddit-home", "cypher-missing-prop-7"),
+            "MATCH (n:User) WHERE NOT (n.age STARTS WITH '3') RETURN n.id AS id",
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        rows,
+        QueryResultSet::new(
+            vec![QueryColumn::new("id")],
+            vec![QueryRow::new(vec![QueryValue::Property(
+                VertexPropertyValue::Integer(1)
+            )])],
+        )
+    );
 }
 
 #[cfg(feature = "opencypher")]


### PR DESCRIPTION
# Problem

During OpenCypher `WHERE` predicate evaluation, comparisons involving missing properties (`RowScalarValue::Missing`) previously evaluated to boolean `false`.

When wrapped in a negation, `NOT false` evaluated to `true`, causing nodes that lacked the property to be incorrectly returned.

## Reproduction Case

```cypher
CREATE (:User {id: 1, age: 30});
CREATE (:User {id: 2});

MATCH (n:User) WHERE NOT (n.age = 30) RETURN n.id;
```

### Previous Behavior

For `User 2`, the `age` property is missing:

```text
n.age = 30  → false
NOT false   → true
```

As a result, `User 2` was incorrectly returned.

### Expected OpenCypher Behavior

According to OpenCypher semantics, comparisons involving missing properties should evaluate to `null` (unknown):

```text
n.age = 30  → null
NOT null    → null
```

A row should only be retained in a `WHERE` clause when the condition evaluates to `true`. Both `false` and `null` should be excluded.

---

# Solution

Implemented OpenCypher-compliant **Three-Valued Logic (3VL / Kleene Logic)** for row predicate evaluation.

## TriBool Logic Type

In `src/shard/query.rs`, added:

```rust
enum TriBool {
    True,
    False,
    Null,
}
```

Implemented standard Kleene truth tables for:

* `.not()`
* `.and()`
* `.or()`

Also added `.is_true()` so that only `TriBool::True` satisfies a filter condition.

## 3VL Predicate Evaluation

Updated `eval_row_predicate` to use `TriBool`.

### Comparisons

`compare_row_values` now returns `TriBool::Null` when either operand evaluates to `RowScalarValue::Missing`.

### STARTS WITH

`STARTS WITH` now returns `TriBool::Null` when the property is missing.

### AND / OR

`AND` and `OR` now preserve proper three-valued logic semantics with short-circuit evaluation.

Examples:

```text
Null OR True  = True
Null OR False = Null

Null AND True  = Null
Null AND False = False
```

### NOT

Negation now follows:

```text
NOT True  = False
NOT False = True
NOT Null  = Null
```

---

# Filtering

Updated `row_predicate_matches` to delegate to:

```rust
eval_row_predicate(row, predicate)?.is_true()
```

This ensures that only `True` predicates are retained.

Therefore:

```text
True  → row retained
False → row excluded
Null  → row excluded
```

---

# Verification & Testing

## Unit Tests

Added and validated tests in:

```text
src/shard/query.rs
```

The tests cover:

* Complete `NOT` truth table
* Complete `AND` truth table
* Complete `OR` truth table
* Missing-property comparisons using `=`
* Missing-property comparisons using `<>`
* Missing-property comparisons using `<`
* Missing-property `STARTS WITH`
* `NOT (=)` with missing properties
* `NOT (<>)` with missing properties
* `NOT (STARTS WITH)` with missing properties
* Compound `OR` predicates
* Compound `AND` predicates

## End-to-End Tests

Added:

```text
missing_property_predicate_three_valued_logic
```

in:

```text
src/tests.rs
```

The test validates the exact reproduction case from **#186**, along with:

* Positive matches
* Inequality predicates
* Compound `AND` filters
* Compound `OR` filters
* Missing properties against actual storage

---

# Result

The query:

```cypher
MATCH (n:User)
WHERE NOT (n.age = 30)
RETURN n.id;
```

now correctly excludes the user whose `age` property is missing:

```text
n.age = 30 → null
NOT null   → null
WHERE null → excluded
```

This brings OpenCypher `WHERE` predicate evaluation in line with **Three-Valued Logic semantics**.
