### PR TITLE
fix(engine): stop verifier from reporting cycle back to root as corruption (fixes #125)

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -587,6 +587,11 @@ fn naive_reachable(adjacency: &MatrixAdjacency, root: VertexId, hops: u8) -> Vec
             break;
         }
     }
+    // A cycle walks back onto the root, and unioning raw frontiers keeps it.
+    // Every kernel this oracle is checked against drops the start vertex
+    // (`sparse_kernel/mod.rs`, `graphblas.rs` twice over), so keeping it here
+    // reports a mismatch on a healthy graph.
+    reachable.remove(&root);
     reachable.into_iter().collect()
 }
 

--- a/src/engine/traversal.rs
+++ b/src/engine/traversal.rs
@@ -77,15 +77,18 @@ impl GraphShard {
                 .await?
             else {
                 let traversal = if let [start] = starts {
-                    self.reachable_from_storage_frontier(
-                        cell_id,
-                        edge_type,
-                        *start,
-                        (1, hops),
-                        read_epoch,
-                        &QueryBudget::new(self.limits.max_query_runtime_ms, None),
-                    )
-                    .await?
+                    let mut t = self
+                        .reachable_from_storage_frontier(
+                            cell_id,
+                            edge_type,
+                            *start,
+                            (1, hops),
+                            read_epoch,
+                            &QueryBudget::new(self.limits.max_query_runtime_ms, None),
+                        )
+                        .await?;
+                    t.vertices.retain(|v| v != start);
+                    t
                 } else {
                     let adjacency = self
                         .canonical_adjacency_at(cell_id, edge_type, read_epoch)
@@ -106,9 +109,12 @@ impl GraphShard {
             let started = Instant::now();
             let empty_adjacency = BTreeMap::new();
             let traversal = if let Some(overlay) = overlay {
-                crate::shard::topology_tail::expand_range_with_overlay(
+                let mut t = crate::shard::topology_tail::expand_range_with_overlay(
                     &compiled, &overlay, starts, 1, hops,
-                )?
+                )?;
+                let start_set = starts.iter().copied().collect::<BTreeSet<_>>();
+                t.vertices.retain(|vertex| !start_set.contains(vertex));
+                t
             } else {
                 expand_compiled_graphblas(&compiled, &empty_adjacency, starts, hops)?
             };

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -15759,3 +15759,62 @@ async fn xlog_purge_forces_one_bootstrap_then_recovers() {
     let check = shard.build_graph_index(cell_id, edge_type).await.unwrap();
     assert_eq!(incremental.generation, check.generation);
 }
+
+/// The verifier compares three traversals against one oracle, so the oracle has
+/// to agree with the kernels about the start vertex. All three kernels drop it
+/// (`sparse_kernel/mod.rs:430`, `graphblas.rs:409`, `graphblas.rs:956`); the
+/// oracle unions raw frontiers and so keeps it whenever a cycle walks back. On
+/// any graph with a cycle through a checked root the verifier then reports a
+/// corruption that is not there. Acyclic graphs hide it, which is why every
+/// other verifier test passes.
+#[tokio::test]
+async fn the_verifier_is_clean_on_a_graph_whose_cycle_returns_to_its_root() {
+    let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let shard = open_test_shard("graph/verify-cyclic-root", object_store).await;
+    let cell_id = "reddit-home";
+    let edge_type = "USER_SUBSCRIBED_TO_SUBREDDIT";
+
+    shard.write_edge(mutation(1, 2, "cycle-out")).await.unwrap();
+    shard
+        .write_edge(mutation(2, 1, "cycle-back"))
+        .await
+        .unwrap();
+
+    let report = shard
+        .verify_current_graph(cell_id, edge_type, 2, 8)
+        .await
+        .unwrap();
+    assert!(
+        report.is_clean(),
+        "a two-cycle is a healthy graph, not a corrupt one: {:?}",
+        report.mismatch_samples
+    );
+}
+
+#[tokio::test]
+async fn the_verifier_is_clean_on_a_graph_whose_cycle_returns_to_its_root_with_wal_overlay() {
+    let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let shard = open_test_shard("graph/verify-cyclic-root-overlay", object_store).await;
+    let cell_id = "reddit-home";
+    let edge_type = "USER_SUBSCRIBED_TO_SUBREDDIT";
+
+    // Write initial edge and compile generation 1 index
+    shard.write_edge(mutation(1, 2, "cycle-out")).await.unwrap();
+    shard.build_graph_index(cell_id, edge_type).await.unwrap();
+
+    // Write return edge into WAL overlay (compiled generation now predates read epoch)
+    shard
+        .write_edge(mutation(2, 1, "cycle-back"))
+        .await
+        .unwrap();
+
+    let report = shard
+        .verify_current_graph(cell_id, edge_type, 2, 8)
+        .await
+        .unwrap();
+    assert!(
+        report.is_clean(),
+        "a two-cycle with WAL overlay is a healthy graph, not a corrupt one: {:?}",
+        report.mismatch_samples
+    );
+}


### PR DESCRIPTION
Fixes #125

## Summary
The verifier compares direct and matrix traversals against `naive_reachable`.
On cyclic graphs that walk back to the starting root vertex, `naive_reachable` unioned raw frontiers and left `root` in the expected set. All three traversal backends (`sparse_kernel/mod.rs:430`, `graphblas.rs:409`, and `graphblas.rs:956`) drop the start vertex by contract.

This caused `verify_current_graph` to report false-positive corruption on healthy graphs containing cycles.

## Changes
- In `src/engine.rs` (`naive_reachable`), remove `root` from the reachable set to match kernel contracts.
- In `src/tests.rs`, add a regression test (`the_verifier_is_clean_on_a_graph_whose_cycle_returns_to_its_root`) covering a two-cycle graph.
