### PR TITLE
fix(http): classify all freshness errors as transient 503 (fixes #122)

### DIFF
--- a/src/client/http.rs
+++ b/src/client/http.rs
@@ -413,11 +413,27 @@ impl HttpApiError {
                 owner: owner.clone(),
                 authenticate: false,
             },
+            // Every CLASS_FRESHNESS variant (`GraphError::class_index`) is a
+            // wait, not a defect: the epoch the caller asked for has not landed
+            // here yet, or moved while they read. Same reasoning as
+            // `RoutingUnavailable` above, and the same 503 the Bolt mapping
+            // reaches for when answering `SnapshotAhead` with `Neo.TransientError`.
+            // A 4xx would tell every client and proxy never to retry.
+            GraphError::SnapshotAhead { .. }
+            | GraphError::SnapshotExpired { .. }
+            | GraphError::SnapshotChanged { .. }
+            | GraphError::QueryStatsSnapshotChanged { .. }
+            | GraphError::ControlWatermarkRegression { .. } => Self {
+                status: StatusCode::SERVICE_UNAVAILABLE,
+                code: "freshness",
+                message: error.to_string(),
+                owner: None,
+                authenticate: false,
+            },
             GraphError::InvalidKeyComponent { .. }
             | GraphError::GraphScopeMismatch { .. }
             | GraphError::MissingQueryParameter { .. }
             | GraphError::QueryParse { .. }
-            | GraphError::SnapshotAhead { .. }
             | GraphError::UnsupportedQuery { .. } => Self {
                 status: StatusCode::BAD_REQUEST,
                 code: "invalid_request",

--- a/src/client/http/tests.rs
+++ b/src/client/http/tests.rs
@@ -356,3 +356,72 @@ async fn http_api_serves_authenticated_queries_over_https() {
     drop(client);
     server.stop().await.unwrap();
 }
+
+/// A freshness error is a wait, not a bad request: the epoch the caller asked
+/// for has not landed on this node yet, or moved while they were reading. The
+/// same request succeeds on retry, so it has to arrive as a 503 — a 4xx tells
+/// every client library and proxy in front of it never to try again. Bolt
+/// answers `SnapshotAhead` with `Neo.TransientError`; this provides the HTTP
+/// analogue for the freshness family, and the guard below keeps the arm from
+/// swallowing real client errors on its way past.
+#[test]
+fn a_stale_snapshot_is_a_503_and_not_a_bad_request() {
+    let freshness = [
+        GraphError::SnapshotAhead {
+            cell_id: "cell-a".to_string(),
+            read_epoch: 9,
+            current_epoch: 4,
+        },
+        GraphError::SnapshotExpired {
+            cell_id: "cell-a".to_string(),
+            edge_type: "KNOWS".to_string(),
+            read_epoch: 9,
+            min_epoch: 12,
+        },
+        GraphError::SnapshotChanged {
+            operation: "scan",
+            cell_id: "cell-a".to_string(),
+            edge_type: "KNOWS".to_string(),
+            read_epoch: 9,
+            current_epoch: 11,
+        },
+        GraphError::QueryStatsSnapshotChanged {
+            operation: "stats",
+            cell_id: "cell-a".to_string(),
+            read_epoch: 9,
+            current_epoch: 11,
+        },
+        GraphError::ControlWatermarkRegression {
+            cell_id: "cell-a".to_string(),
+            field: "applied_epoch",
+            requested_epoch: 9,
+            current_epoch: 4,
+        },
+    ];
+
+    for error in freshness {
+        let class = error.class();
+        let rendered = error.to_string();
+        let mapped = HttpApiError::from_graph(error);
+        assert_eq!(class, "freshness", "{rendered} must stay CLASS_FRESHNESS");
+        assert_eq!(
+            mapped.status,
+            StatusCode::SERVICE_UNAVAILABLE,
+            "{rendered} must be retryable, not terminal"
+        );
+        assert_eq!(mapped.code, "freshness");
+        assert_eq!(
+            mapped.message, rendered,
+            "the epochs are the whole diagnostic; they must reach the client"
+        );
+    }
+
+    // The arm sits above the bad-request group, so a genuine client error must
+    // still fall through to it.
+    let malformed = HttpApiError::from_graph(GraphError::QueryParse {
+        dialect: "OpenCypher",
+        reason: "unexpected token".to_string(),
+    });
+    assert_eq!(malformed.status, StatusCode::BAD_REQUEST);
+    assert_eq!(malformed.code, "invalid_request");
+}


### PR DESCRIPTION
## Summary
All five `CLASS_FRESHNESS` `GraphError` variants represent a transient wait rather than a malformed request: the requested epoch has not landed on this node yet or moved during read.

Previously, `SnapshotAhead` was incorrectly mapped to `400 Bad Request`, and the remaining four variants fell through to `500 Internal Server Error`, preventing HTTP clients and proxies from retrying.

## Changes
- In `src/client/http.rs`, map all five `CLASS_FRESHNESS` variants (`SnapshotAhead`, `SnapshotExpired`, `SnapshotChanged`, `QueryStatsSnapshotChanged`, `ControlWatermarkRegression`) to `503 Service Unavailable` with code `"freshness"`.
- Remove `SnapshotAhead` from the `BAD_REQUEST` match arm.
- In `src/client/http/tests.rs`, add unit tests covering all five variants and verifying that genuine client errors continue to return `400`.
